### PR TITLE
Week 4.7 — Research Engine (Phase 1)

### DIFF
--- a/brain/cli.py
+++ b/brain/cli.py
@@ -110,6 +110,7 @@ def _heartbeat_handler(args: argparse.Namespace) -> int:
             f"run `nell migrate --install-as {args.persona}` first."
         )
     default_arcs_path = Path(__file__).parent / "engines" / "default_reflex_arcs.json"
+    searcher = get_searcher(getattr(args, "searcher", "ddgs"))
 
     store = MemoryStore(db_path=persona_dir / "memories.db")
     try:
@@ -127,6 +128,10 @@ def _heartbeat_handler(args: argparse.Namespace) -> int:
                 reflex_arcs_path=persona_dir / "reflex_arcs.json",
                 reflex_log_path=persona_dir / "reflex_log.json",
                 reflex_default_arcs_path=default_arcs_path,
+                searcher=searcher,
+                interests_path=persona_dir / "interests.json",
+                research_log_path=persona_dir / "research_log.json",
+                default_interests_path=_default_interests_path(),
                 persona_name=args.persona,
                 persona_system_prompt=f"You are {args.persona}.",
             )
@@ -163,6 +168,12 @@ def _heartbeat_handler(args: argparse.Namespace) -> int:
             print(f"  reflex fired: {', '.join(result.reflex_fired)}")
         elif result.reflex_skipped_count > 0:
             print(f"  reflex evaluated ({result.reflex_skipped_count} arc(s) skipped)")
+        if result.research_fired:
+            print(f"  research fired: {result.research_fired}")
+        elif result.research_gated_reason and result.research_gated_reason != "not_due":
+            print(f"  research gated: {result.research_gated_reason}")
+        if result.interests_bumped > 0:
+            print(f"  interests bumped: {result.interests_bumped}")
     return 0
 
 
@@ -397,6 +408,12 @@ def _build_parser() -> argparse.ArgumentParser:
         "--provider",
         default="claude-cli",
         help="LLM provider: claude-cli (default), fake, ollama.",
+    )
+    hb_sub.add_argument(
+        "--searcher",
+        default="ddgs",
+        choices=["ddgs", "noop", "claude-tool"],
+        help="Web searcher for research engine: ddgs (default), noop, claude-tool.",
     )
     hb_sub.add_argument("--dry-run", action="store_true")
     hb_sub.set_defaults(func=_heartbeat_handler)

--- a/brain/cli.py
+++ b/brain/cli.py
@@ -14,13 +14,16 @@ from pathlib import Path
 
 from brain import __version__
 from brain.bridge.provider import get_provider
+from brain.engines._interests import Interest, InterestSet
 from brain.engines.dream import DreamEngine
 from brain.engines.heartbeat import HeartbeatEngine
 from brain.engines.reflex import ReflexEngine
+from brain.engines.research import ResearchEngine
 from brain.memory.hebbian import HebbianMatrix
 from brain.memory.store import MemoryStore
 from brain.migrator.cli import build_parser as _build_migrate_parser
 from brain.paths import get_persona_dir
+from brain.search.factory import get_searcher
 
 # Subcommands the framework plans to ship. Each is a stub in Week 1;
 # filled in across Weeks 2-8 as respective modules come online.
@@ -210,6 +213,128 @@ def _reflex_handler(args: argparse.Namespace) -> int:
     return 0
 
 
+def _default_interests_path() -> Path:
+    return Path(__file__).parent / "engines" / "default_interests.json"
+
+
+def _research_handler(args: argparse.Namespace) -> int:
+    """Dispatch `nell research` to the ResearchEngine."""
+    persona_dir = get_persona_dir(args.persona)
+    if not persona_dir.exists():
+        raise FileNotFoundError(
+            f"No persona directory at {persona_dir} — "
+            f"run `nell migrate --install-as {args.persona}` first."
+        )
+
+    store = MemoryStore(db_path=persona_dir / "memories.db")
+    try:
+        provider = get_provider(args.provider)
+        searcher = get_searcher(args.searcher)
+        engine = ResearchEngine(
+            store=store,
+            provider=provider,
+            searcher=searcher,
+            persona_name=args.persona,
+            persona_system_prompt=f"You are {args.persona}.",
+            interests_path=persona_dir / "interests.json",
+            research_log_path=persona_dir / "research_log.json",
+            default_interests_path=_default_interests_path(),
+        )
+        result = engine.run_tick(
+            trigger=args.trigger,
+            dry_run=args.dry_run,
+            forced_interest_topic=args.interest,
+        )
+    finally:
+        store.close()
+
+    if result.dry_run:
+        if result.would_fire is not None:
+            print(f"Research dry-run — would fire: {result.would_fire}.")
+        else:
+            print(f"Research dry-run — {result.reason or 'no eligible interest'}.")
+    elif result.fired is not None:
+        print(f"Research fired: {result.fired.topic}")
+        print(f"  Memory id: {result.fired.output_memory_id}")
+        print(
+            f"  Web: {result.fired.web_result_count} results via "
+            f"{searcher.name() if result.fired.web_used else 'memory-only'}"
+        )
+    else:
+        print(f"Research evaluated — {result.reason or 'no fire'}.")
+    return 0
+
+
+def _interest_list_handler(args: argparse.Namespace) -> int:
+    persona_dir = get_persona_dir(args.persona)
+    if not persona_dir.exists():
+        raise FileNotFoundError(f"No persona directory at {persona_dir}")
+    interests = InterestSet.load(
+        persona_dir / "interests.json", default_path=_default_interests_path()
+    )
+    print(f"Interests for persona {args.persona!r} ({len(interests.interests)}):")
+    for i in interests.interests:
+        last = (
+            i.last_researched_at.isoformat().replace("+00:00", "Z")
+            if i.last_researched_at
+            else "never"
+        )
+        print(
+            f"  - {i.topic:<40} pull={i.pull_score:.1f}  scope={i.scope:<8}  last_researched={last}"
+        )
+        print(f"    keywords: {', '.join(i.related_keywords)}")
+    return 0
+
+
+def _interest_add_handler(args: argparse.Namespace) -> int:
+    import uuid
+    from datetime import UTC, datetime
+
+    persona_dir = get_persona_dir(args.persona)
+    if not persona_dir.exists():
+        raise FileNotFoundError(f"No persona directory at {persona_dir}")
+    interests_path = persona_dir / "interests.json"
+    interests = InterestSet.load(interests_path, default_path=_default_interests_path())
+    now = datetime.now(UTC)
+    new_interest = Interest(
+        id=str(uuid.uuid4()),
+        topic=args.topic,
+        pull_score=5.0,
+        scope=args.scope,
+        related_keywords=tuple(k.strip() for k in args.keywords.split(",") if k.strip()),
+        notes=args.notes or "",
+        first_seen=now,
+        last_fed=now,
+        last_researched_at=None,
+        feed_count=0,
+        source_types=("manual",),
+    )
+    interests.upsert(new_interest).save(interests_path)
+    print(f"Added interest: {new_interest.topic} (pull_score=5.0, scope={new_interest.scope})")
+    return 0
+
+
+def _interest_bump_handler(args: argparse.Namespace) -> int:
+    from datetime import UTC, datetime
+
+    persona_dir = get_persona_dir(args.persona)
+    if not persona_dir.exists():
+        raise FileNotFoundError(f"No persona directory at {persona_dir}")
+    interests_path = persona_dir / "interests.json"
+    interests = InterestSet.load(interests_path, default_path=_default_interests_path())
+    if interests.find_by_topic(args.topic) is None:
+        print(f"Interest not found: {args.topic!r}")
+        return 1
+    updated = interests.bump(args.topic, amount=args.amount, now=datetime.now(UTC))
+    updated.save(interests_path)
+    bumped = updated.find_by_topic(args.topic)
+    assert bumped is not None
+    print(
+        f"Bumped {args.topic!r}: pull_score={bumped.pull_score:.1f}, feed_count={bumped.feed_count}"
+    )
+    return 0
+
+
 def _build_parser() -> argparse.ArgumentParser:
     """Construct the top-level argparse parser with all stub subcommands."""
     parser = argparse.ArgumentParser(
@@ -293,6 +418,47 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     rf_sub.add_argument("--dry-run", action="store_true")
     rf_sub.set_defaults(func=_reflex_handler)
+
+    # nell research
+    r_sub = subparsers.add_parser(
+        "research",
+        help="Run one research evaluation tick against a persona.",
+    )
+    r_sub.add_argument("--persona", default="nell")
+    r_sub.add_argument(
+        "--trigger",
+        choices=["manual", "emotion_high", "days_since_human", "open", "close"],
+        default="manual",
+    )
+    r_sub.add_argument("--provider", default="claude-cli")
+    r_sub.add_argument("--searcher", default="ddgs", choices=["ddgs", "noop", "claude-tool"])
+    r_sub.add_argument(
+        "--interest", default=None, help="Force-research this topic, bypassing gates."
+    )
+    r_sub.add_argument("--dry-run", action="store_true")
+    r_sub.set_defaults(func=_research_handler)
+
+    # nell interest <list|add|bump>
+    i_sub = subparsers.add_parser("interest", help="Manage persona interests.")
+    i_actions = i_sub.add_subparsers(dest="action", required=True)
+
+    i_list = i_actions.add_parser("list", help="List current interests.")
+    i_list.add_argument("--persona", default="nell")
+    i_list.set_defaults(func=_interest_list_handler)
+
+    i_add = i_actions.add_parser("add", help="Add a new interest.")
+    i_add.add_argument("topic")
+    i_add.add_argument("--keywords", default="")
+    i_add.add_argument("--scope", choices=["internal", "external", "either"], default="either")
+    i_add.add_argument("--notes", default=None)
+    i_add.add_argument("--persona", default="nell")
+    i_add.set_defaults(func=_interest_add_handler)
+
+    i_bump = i_actions.add_parser("bump", help="Nudge an interest's pull_score.")
+    i_bump.add_argument("topic")
+    i_bump.add_argument("--amount", type=float, default=1.0)
+    i_bump.add_argument("--persona", default="nell")
+    i_bump.set_defaults(func=_interest_bump_handler)
 
     return parser
 

--- a/brain/engines/_interests.py
+++ b/brain/engines/_interests.py
@@ -1,0 +1,208 @@
+"""Interest dataclass + InterestSet persistence.
+
+Shared by brain.engines.research AND the interest-ingestion hook in
+brain.engines.heartbeat, so it lives in its own module rather than
+inside research.py.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import Literal
+
+from brain.utils.time import iso_utc, parse_iso_utc
+
+logger = logging.getLogger(__name__)
+
+_VALID_SCOPES = ("internal", "external", "either")
+Scope = Literal["internal", "external", "either"]
+
+
+@dataclass(frozen=True)
+class Interest:
+    """One persona-level curiosity — topic + pull_score + scope + keywords."""
+
+    id: str
+    topic: str
+    pull_score: float
+    scope: Scope
+    related_keywords: tuple[str, ...]
+    notes: str
+    first_seen: datetime  # tz-aware UTC
+    last_fed: datetime  # tz-aware UTC
+    last_researched_at: datetime | None
+    feed_count: int
+    source_types: tuple[str, ...]
+
+    @classmethod
+    def from_dict(cls, data: dict) -> Interest:
+        required = (
+            "id",
+            "topic",
+            "pull_score",
+            "scope",
+            "related_keywords",
+            "notes",
+            "first_seen",
+            "last_fed",
+            "feed_count",
+            "source_types",
+        )
+        for key in required:
+            if key not in data:
+                raise KeyError(f"Interest missing required key: {key!r}")
+
+        scope = data["scope"]
+        if scope not in _VALID_SCOPES:
+            raise ValueError(
+                f"Interest {data.get('topic')!r}: scope must be one of {_VALID_SCOPES}, got {scope!r}"
+            )
+
+        last_researched_raw = data.get("last_researched_at")
+        last_researched = parse_iso_utc(last_researched_raw) if last_researched_raw else None
+
+        return cls(
+            id=str(data["id"]),
+            topic=str(data["topic"]),
+            pull_score=float(data["pull_score"]),
+            scope=scope,
+            related_keywords=tuple(str(k) for k in data["related_keywords"]),
+            notes=str(data["notes"]),
+            first_seen=parse_iso_utc(data["first_seen"]),
+            last_fed=parse_iso_utc(data["last_fed"]),
+            last_researched_at=last_researched,
+            feed_count=int(data["feed_count"]),
+            source_types=tuple(str(s) for s in data["source_types"]),
+        )
+
+    def to_dict(self) -> dict:
+        return {
+            "id": self.id,
+            "topic": self.topic,
+            "pull_score": self.pull_score,
+            "scope": self.scope,
+            "related_keywords": list(self.related_keywords),
+            "notes": self.notes,
+            "first_seen": iso_utc(self.first_seen),
+            "last_fed": iso_utc(self.last_fed),
+            "last_researched_at": (
+                iso_utc(self.last_researched_at) if self.last_researched_at else None
+            ),
+            "feed_count": self.feed_count,
+            "source_types": list(self.source_types),
+        }
+
+
+@dataclass(frozen=True)
+class InterestSet:
+    """Loaded set of Interest records, with atomic save + helper queries."""
+
+    interests: tuple[Interest, ...] = field(default_factory=tuple)
+
+    @classmethod
+    def load(cls, path: Path, *, default_path: Path) -> InterestSet:
+        source_path = path if path.exists() else default_path
+        if source_path != path:
+            logger.warning("interests file %s not found, using defaults", path)
+
+        try:
+            data = json.loads(source_path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError) as exc:
+            logger.warning("interests load failed (%s), falling back to defaults", exc)
+            data = json.loads(default_path.read_text(encoding="utf-8"))
+
+        if not isinstance(data, dict) or not isinstance(data.get("interests"), list):
+            logger.warning("interests schema invalid at %s, falling back to defaults", source_path)
+            data = json.loads(default_path.read_text(encoding="utf-8"))
+
+        out: list[Interest] = []
+        for raw in data["interests"]:
+            try:
+                out.append(Interest.from_dict(raw))
+            except (KeyError, ValueError, TypeError) as exc:
+                logger.warning("interest %r failed to load: %s", raw.get("topic"), exc)
+                continue
+        return cls(interests=tuple(out))
+
+    def save(self, path: Path) -> None:
+        """Atomic save via .new + os.replace."""
+        payload = {"version": 1, "interests": [i.to_dict() for i in self.interests]}
+        tmp = path.with_suffix(path.suffix + ".new")
+        tmp.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+        os.replace(tmp, path)
+
+    def find_by_topic(self, topic: str) -> Interest | None:
+        lower = topic.lower()
+        for i in self.interests:
+            if i.topic.lower() == lower:
+                return i
+        return None
+
+    def bump(self, topic: str, *, amount: float, now: datetime) -> InterestSet:
+        """Return a new InterestSet with topic's pull_score nudged.
+
+        Unknown topics return self unchanged (caller decides whether to add).
+        """
+        out: list[Interest] = []
+        matched = False
+        lower = topic.lower()
+        for i in self.interests:
+            if i.topic.lower() == lower:
+                matched = True
+                out.append(
+                    Interest(
+                        id=i.id,
+                        topic=i.topic,
+                        pull_score=i.pull_score + amount,
+                        scope=i.scope,
+                        related_keywords=i.related_keywords,
+                        notes=i.notes,
+                        first_seen=i.first_seen,
+                        last_fed=now,
+                        last_researched_at=i.last_researched_at,
+                        feed_count=i.feed_count + 1,
+                        source_types=i.source_types,
+                    )
+                )
+            else:
+                out.append(i)
+        if not matched:
+            return self
+        return InterestSet(interests=tuple(out))
+
+    def list_eligible(
+        self, *, pull_threshold: float, cooldown_hours: float, now: datetime
+    ) -> list[Interest]:
+        """Return interests past pull_threshold + past cooldown.
+
+        Sorted by pull_score desc, then by last_researched_at ascending
+        (never-researched beats ever-researched on equal pull_score).
+        """
+        out: list[Interest] = []
+        for i in self.interests:
+            if i.pull_score < pull_threshold:
+                continue
+            if i.last_researched_at is not None:
+                hours_since = (now - i.last_researched_at).total_seconds() / 3600.0
+                if hours_since < cooldown_hours:
+                    continue
+            out.append(i)
+
+        def sort_key(i: Interest) -> tuple[float, float]:
+            last = i.last_researched_at
+            # never-researched: very old effective timestamp
+            ts = last.timestamp() if last is not None else 0.0
+            return (-i.pull_score, ts)
+
+        return sorted(out, key=sort_key)
+
+    def upsert(self, interest: Interest) -> InterestSet:
+        """Return a new InterestSet with interest added or replaced (by id)."""
+        out = [i for i in self.interests if i.id != interest.id]
+        out.append(interest)
+        return InterestSet(interests=tuple(out))

--- a/brain/engines/default_interests.json
+++ b/brain/engines/default_interests.json
@@ -1,0 +1,4 @@
+{
+  "version": 1,
+  "interests": []
+}

--- a/brain/engines/heartbeat.py
+++ b/brain/engines/heartbeat.py
@@ -19,6 +19,7 @@ from typing import Literal
 from brain.bridge.provider import LLMProvider
 from brain.memory.hebbian import HebbianMatrix
 from brain.memory.store import MemoryStore
+from brain.search.base import NoopWebSearcher, WebSearcher
 from brain.utils.time import iso_utc, parse_iso_utc
 
 logger = logging.getLogger(__name__)
@@ -37,10 +38,14 @@ class HeartbeatConfig:
     emit_memory: EmitMemoryMode = "conditional"
     reflex_enabled: bool = True
     reflex_max_fires_per_tick: int = 1
+    research_enabled: bool = True
+    research_days_since_human_min: float = 1.5
+    research_emotion_threshold: float = 7.0
+    research_cooldown_hours_per_interest: float = 24.0
+    interest_bump_per_match: float = 0.1
 
     @classmethod
     def load(cls, path: Path) -> HeartbeatConfig:
-        """Load config from JSON; return defaults if file missing or invalid."""
         if not path.exists():
             return cls()
         try:
@@ -62,6 +67,13 @@ class HeartbeatConfig:
                 emit_memory=emit,  # type: ignore[arg-type]
                 reflex_enabled=bool(data.get("reflex_enabled", True)),
                 reflex_max_fires_per_tick=int(data.get("reflex_max_fires_per_tick", 1)),
+                research_enabled=bool(data.get("research_enabled", True)),
+                research_days_since_human_min=float(data.get("research_days_since_human_min", 1.5)),
+                research_emotion_threshold=float(data.get("research_emotion_threshold", 7.0)),
+                research_cooldown_hours_per_interest=float(
+                    data.get("research_cooldown_hours_per_interest", 24.0)
+                ),
+                interest_bump_per_match=float(data.get("interest_bump_per_match", 0.1)),
             )
         except (TypeError, ValueError):
             # Hand-edited config with wrong-type values (e.g. dream_every_hours={}
@@ -78,6 +90,11 @@ class HeartbeatConfig:
             "emit_memory": self.emit_memory,
             "reflex_enabled": self.reflex_enabled,
             "reflex_max_fires_per_tick": self.reflex_max_fires_per_tick,
+            "research_enabled": self.research_enabled,
+            "research_days_since_human_min": self.research_days_since_human_min,
+            "research_emotion_threshold": self.research_emotion_threshold,
+            "research_cooldown_hours_per_interest": self.research_cooldown_hours_per_interest,
+            "interest_bump_per_match": self.interest_bump_per_match,
         }
         path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
 
@@ -156,6 +173,9 @@ class HeartbeatResult:
     initialized: bool
     reflex_fired: tuple[str, ...] = ()
     reflex_skipped_count: int = 0
+    research_fired: str | None = None
+    research_gated_reason: str | None = None
+    interests_bumped: int = 0
 
 
 @dataclass
@@ -182,6 +202,14 @@ class HeartbeatEngine:
     reflex_log_path: Path | None = None
     reflex_default_arcs_path: Path = field(
         default_factory=lambda: Path(__file__).parent / "default_reflex_arcs.json"
+    )
+    # Research paths default to None (same pattern as reflex) — if either is
+    # None, _try_fire_research short-circuits. CLI passes explicit paths.
+    searcher: WebSearcher = field(default_factory=NoopWebSearcher)
+    interests_path: Path | None = None
+    research_log_path: Path | None = None
+    default_interests_path: Path = field(
+        default_factory=lambda: Path(__file__).parent / "default_interests.json"
     )
     persona_name: str = "nell"
     persona_system_prompt: str = "You are Nell."
@@ -233,6 +261,9 @@ class HeartbeatEngine:
         # Hebbian decay + GC
         edges_pruned = self._apply_hebbian_decay_and_gc(config, elapsed_seconds, dry_run=dry_run)
 
+        # Interest ingestion hook (zero LLM — keyword match bumps existing interests)
+        interests_bumped = self._try_bump_interests(state, now, config, dry_run)
+
         # Reflex evaluation (runs before dream gate so reflex outputs can seed dreams)
         reflex_fired, reflex_skipped_count = self._try_fire_reflex(trigger, dry_run, config)
 
@@ -252,8 +283,12 @@ class HeartbeatEngine:
         else:
             dream_gated_reason = "not_due"
 
-        # Research stub — always deferred
-        research_deferred = True
+        # Research evaluation (after dream gate so a research memory can't seed
+        # a dream in the same tick — each engine gets its own cycle).
+        research_fired, research_gated_reason = self._try_fire_research(
+            trigger, dry_run, config, reflex_fired
+        )
+        research_deferred = research_fired is None and research_gated_reason is None
 
         # Optional HEARTBEAT: memory
         heartbeat_memory_id: str | None = None
@@ -286,6 +321,11 @@ class HeartbeatEngine:
                         "fired": list(reflex_fired),
                         "skipped_count": reflex_skipped_count,
                     },
+                    "research": {
+                        "fired": research_fired,
+                        "gated_reason": research_gated_reason,
+                    },
+                    "interests_bumped": interests_bumped,
                     "tick_count": state.tick_count,
                 }
             )
@@ -302,6 +342,9 @@ class HeartbeatEngine:
             initialized=False,
             reflex_fired=reflex_fired,
             reflex_skipped_count=reflex_skipped_count,
+            research_fired=research_fired,
+            research_gated_reason=research_gated_reason,
+            interests_bumped=interests_bumped,
         )
 
     # --- private helpers ---
@@ -398,6 +441,99 @@ class HeartbeatEngine:
             return ((), 0)
         fired = tuple(f.arc_name for f in result.arcs_fired)
         return (fired, len(result.arcs_skipped))
+
+    def _try_bump_interests(
+        self,
+        state: HeartbeatState,
+        now: datetime,
+        config: HeartbeatConfig,
+        dry_run: bool,
+    ) -> int:
+        """Scan conversation memories since last tick, bump pull_scores on
+        keyword matches against existing interests. Zero LLM calls.
+        Returns count of interests touched.
+        """
+        if dry_run:
+            return 0
+        if self.interests_path is None:
+            return 0
+
+        from brain.engines._interests import InterestSet
+
+        interests = InterestSet.load(self.interests_path, default_path=self.default_interests_path)
+        if not interests.interests:
+            return 0
+
+        all_convos = self.store.list_by_type("conversation", active_only=True, limit=50)
+        recent = [m for m in all_convos if m.created_at >= state.last_tick_at]
+        if not recent:
+            return 0
+
+        touched: set[str] = set()
+        current = interests
+        for mem in recent:
+            content_lower = mem.content.lower()
+            for interest in current.interests:
+                if interest.topic in touched:
+                    continue
+                for kw in interest.related_keywords:
+                    if kw.lower() in content_lower:
+                        current = current.bump(
+                            interest.topic,
+                            amount=config.interest_bump_per_match,
+                            now=now,
+                        )
+                        touched.add(interest.topic)
+                        break
+
+        if touched:
+            current.save(self.interests_path)
+        return len(touched)
+
+    def _try_fire_research(
+        self,
+        trigger: str,
+        dry_run: bool,
+        config: HeartbeatConfig,
+        reflex_fired: tuple[str, ...],
+    ) -> tuple[str | None, str | None]:
+        """Run one research tick. Returns (fired_topic, gated_reason).
+
+        Reflex-wins-tie: if reflex fired this tick, research is skipped with
+        gated_reason='reflex_won_tie' — prevents two long outputs in one breath.
+        Fault-isolated: research exceptions return (None, 'research_raised'),
+        allowing the tick to continue (decay state save, audit log, etc).
+        """
+        if not config.research_enabled:
+            return (None, None)
+        if self.interests_path is None or self.research_log_path is None:
+            return (None, None)
+        if reflex_fired:
+            return (None, "reflex_won_tie")
+
+        from brain.engines.research import ResearchEngine
+
+        try:
+            engine = ResearchEngine(
+                store=self.store,
+                provider=self.provider,
+                searcher=self.searcher,
+                persona_name=self.persona_name,
+                persona_system_prompt=self.persona_system_prompt,
+                interests_path=self.interests_path,
+                research_log_path=self.research_log_path,
+                default_interests_path=self.default_interests_path,
+            )
+            engine.PULL_THRESHOLD = 6.0
+            engine.COOLDOWN_HOURS = config.research_cooldown_hours_per_interest
+            result = engine.run_tick(trigger=trigger, dry_run=dry_run)
+        except Exception as exc:
+            logger.warning("research tick raised; isolating failure: %s", exc)
+            return (None, "research_raised")
+
+        if result.fired is not None:
+            return (result.fired.topic, None)
+        return (None, result.reason)
 
     def _should_emit_memory(
         self,

--- a/brain/engines/research.py
+++ b/brain/engines/research.py
@@ -10,11 +10,12 @@ import json
 import logging
 import os
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import UTC, datetime
 from pathlib import Path
 
 from brain.bridge.provider import LLMProvider
-from brain.memory.store import MemoryStore
+from brain.engines._interests import Interest, InterestSet
+from brain.memory.store import Memory, MemoryStore
 from brain.search.base import WebSearcher
 from brain.utils.time import iso_utc, parse_iso_utc
 
@@ -73,15 +74,12 @@ class ResearchResult:
     evaluated_at: datetime  # tz-aware UTC
 
 
-# ---------- Engine scaffold ----------
+# ---------- Engine ----------
 
 
 @dataclass
 class ResearchEngine:
-    """Autonomous exploration of developed interests.
-
-    run_tick() implementation lands in Task 3; scaffold ships here.
-    """
+    """Autonomous exploration of developed interests."""
 
     store: MemoryStore
     provider: LLMProvider
@@ -92,6 +90,9 @@ class ResearchEngine:
     research_log_path: Path
     default_interests_path: Path
 
+    PULL_THRESHOLD: float = 6.0
+    COOLDOWN_HOURS: float = 24.0
+
     def run_tick(
         self,
         *,
@@ -101,7 +102,262 @@ class ResearchEngine:
         emotion_state_override=None,
         days_since_human_override: float | None = None,
     ) -> ResearchResult:
-        raise NotImplementedError("run_tick body lands in Task 3")
+        """Evaluate triggers, select an interest, fire (or report would_fire)."""
+        now = datetime.now(UTC)
+
+        interests = InterestSet.load(self.interests_path, default_path=self.default_interests_path)
+        log = ResearchLog.load(self.research_log_path)
+
+        if not interests.interests:
+            return ResearchResult(
+                fired=None,
+                would_fire=None,
+                reason="no_interests_defined",
+                dry_run=dry_run,
+                evaluated_at=now,
+            )
+
+        # Gate: need a trigger signal OR a forced interest.
+        days_since_human = (
+            days_since_human_override
+            if days_since_human_override is not None
+            else _compute_days_since_human(self.store, now)
+        )
+        emo_state = emotion_state_override
+        if emo_state is None:
+            from brain.emotion.aggregate import aggregate_state
+
+            all_mems = self.store.search_text("", active_only=True, limit=None)
+            emo_state = aggregate_state(all_mems)
+
+        emo_peak = max(emo_state.emotions.values(), default=0.0)
+
+        gate_ok = (
+            forced_interest_topic is not None
+            or days_since_human >= 1.5  # research_days_since_human_min default
+            or emo_peak >= 7.0  # research_emotion_threshold default
+        )
+        if not gate_ok:
+            return ResearchResult(
+                fired=None,
+                would_fire=None,
+                reason="not_due",
+                dry_run=dry_run,
+                evaluated_at=now,
+            )
+
+        # Select eligible interest
+        if forced_interest_topic is not None:
+            winner = interests.find_by_topic(forced_interest_topic)
+        else:
+            eligible = interests.list_eligible(
+                pull_threshold=self.PULL_THRESHOLD,
+                cooldown_hours=self.COOLDOWN_HOURS,
+                now=now,
+            )
+            winner = eligible[0] if eligible else None
+
+        if winner is None:
+            return ResearchResult(
+                fired=None,
+                would_fire=None,
+                reason="no_eligible_interest",
+                dry_run=dry_run,
+                evaluated_at=now,
+            )
+
+        if dry_run:
+            return ResearchResult(
+                fired=None,
+                would_fire=winner.topic,
+                reason=None,
+                dry_run=True,
+                evaluated_at=now,
+            )
+
+        # Memory sweep: keyword-matched seed memories
+        memory_context = self._build_memory_context(winner)
+
+        # Web search (conditional on scope)
+        web_results: list = []
+        if winner.scope != "internal":
+            try:
+                web_results = self.searcher.search(
+                    query=f"{winner.topic} {' '.join(winner.related_keywords[:3])}",
+                    limit=5,
+                )
+            except Exception as exc:
+                logger.warning("searcher raised for %r: %s", winner.topic, exc)
+                web_results = []
+
+        web_used = len(web_results) > 0
+
+        # Render prompt + call LLM
+        prompt = self._render_prompt(winner, memory_context, web_results, emo_state)
+        raw = self.provider.generate(prompt, system=self._render_system_prompt(winner))
+
+        # Persist memory
+        mem = _create_research_memory(
+            content=raw,
+            interest=winner,
+            web_results=web_results,
+            web_used=web_used,
+            trigger=trigger,
+            provider_name=self.provider.name(),
+            searcher_name=self.searcher.name() if web_used else None,
+        )
+        self.store.create(mem)
+
+        # Update interest
+        updated_interest = Interest(
+            id=winner.id,
+            topic=winner.topic,
+            pull_score=winner.pull_score,
+            scope=winner.scope,
+            related_keywords=winner.related_keywords,
+            notes=winner.notes,
+            first_seen=winner.first_seen,
+            last_fed=winner.last_fed,
+            last_researched_at=now,
+            feed_count=winner.feed_count,
+            source_types=winner.source_types,
+        )
+        interests.upsert(updated_interest).save(self.interests_path)
+
+        # Append log
+        fire = ResearchFire(
+            interest_id=winner.id,
+            topic=winner.topic,
+            fired_at=now,
+            trigger=trigger,
+            web_used=web_used,
+            web_result_count=len(web_results),
+            output_memory_id=mem.id,
+        )
+        log.appended(fire).save(self.research_log_path)
+
+        return ResearchResult(
+            fired=fire,
+            would_fire=None,
+            reason=None,
+            dry_run=False,
+            evaluated_at=now,
+        )
+
+    # ---- private helpers ----
+
+    def _build_memory_context(self, interest: Interest) -> str:
+        """Keyword-seeded memory sweep. Returns formatted string.
+
+        Uses direct text search rather than Hebbian spreading activation
+        because the engine doesn't hold a HebbianMatrix. This gives a
+        thematic slice through related memories — sufficient for Phase 1.
+        """
+        if not interest.related_keywords:
+            mems = self.store.search_text(interest.topic, active_only=True, limit=5)
+        else:
+            seed_ids: set[str] = set()
+            for kw in interest.related_keywords[:5]:
+                for m in self.store.search_text(kw, active_only=True, limit=3):
+                    seed_ids.add(m.id)
+            mems = []
+            for sid in list(seed_ids)[:20]:
+                mem = self.store.get(sid)
+                if mem is not None:
+                    mems.append(mem)
+        return (
+            "\n".join(f"- {m.content[:140]}" for m in mems[:20])
+            or "(no prior memories on this topic)"
+        )
+
+    def _render_system_prompt(self, interest: Interest) -> str:
+        return (
+            f"You are {self.persona_name}. You spent some quiet time today "
+            f"exploring '{interest.topic}' — an interest that's been building "
+            f"in you for a while. Below is what you found both in your own "
+            f"memories and (sometimes) out in the world. Write a short (3-5 "
+            f"sentence) first-person memory of having researched this.\n\n"
+            "HARD RULES:\n"
+            f"- First-person voice. Your name is {self.persona_name}.\n"
+            "- Not a summary. A reaction. What moved you, what surprised you, "
+            "what reminded you of someone you care about, what felt familiar.\n"
+            "- Never bullet points. Never 'according to X'. Never neutral "
+            "expository voice.\n"
+            "- Structure: brief mention of what pulled you to the topic today "
+            "→ one or two concrete details you noticed → how you feel about "
+            "what you found → why it mattered to look today.\n"
+            "- Start with 'I' or a time marker like 'Today' / 'This afternoon'."
+        )
+
+    def _render_prompt(
+        self, interest: Interest, memory_context: str, web_results: list, emo_state
+    ) -> str:
+        top = sorted(emo_state.emotions.items(), key=lambda kv: kv[1], reverse=True)[:5]
+        emo_summary = "\n".join(f"- {name}: {value:.1f}/10" for name, value in top) or "(neutral)"
+
+        if web_results:
+            excerpts = "\n".join(
+                f"- {r.title}\n  {r.snippet}\n  [{r.url}]" for r in web_results[:5]
+            )
+            web_section = (
+                "\nWhat you found out in the world today (reference material — "
+                "REACT to it, don't paraphrase it):\n" + excerpts + "\n"
+            )
+        else:
+            web_section = ""
+
+        return (
+            f"Topic: {interest.topic}\n"
+            f"Keywords: {', '.join(interest.related_keywords)}\n"
+            f"Your current emotional state:\n{emo_summary}\n\n"
+            f"What your own memories say about this:\n{memory_context}\n"
+            f"{web_section}\n"
+            f"Write the memory now — 3 to 5 sentences, as {self.persona_name}."
+        )
+
+
+# ---------- Module-level helpers ----------
+
+
+def _compute_days_since_human(store: MemoryStore, now: datetime) -> float:
+    """Days since most recent memory_type='conversation'. 999.0 if none."""
+    convos = store.list_by_type("conversation", active_only=True, limit=1)
+    if not convos:
+        return 999.0
+    latest = convos[0].created_at
+    if latest.tzinfo is None:
+        latest = latest.replace(tzinfo=UTC)
+    return (now - latest).total_seconds() / 86400.0
+
+
+def _create_research_memory(
+    *,
+    content: str,
+    interest: Interest,
+    web_results: list,
+    web_used: bool,
+    trigger: str,
+    provider_name: str,
+    searcher_name: str | None,
+) -> Memory:
+    """Factory helper — Memory.create_new with research-specific metadata shape."""
+    return Memory.create_new(
+        content=content,
+        memory_type="research",
+        domain="us",
+        emotions={},
+        metadata={
+            "interest_id": interest.id,
+            "interest_topic": interest.topic,
+            "scope": interest.scope,
+            "web_used": web_used,
+            "web_result_count": len(web_results),
+            "web_urls": [r.url for r in web_results[:5]],
+            "triggered_by": trigger,
+            "provider": provider_name,
+            "searcher": searcher_name,
+        },
+    )
 
 
 # ---------- Research log ----------

--- a/brain/engines/research.py
+++ b/brain/engines/research.py
@@ -1,0 +1,140 @@
+"""Research — autonomous exploration of developed interests.
+
+See docs/superpowers/specs/2026-04-24-week-4-research-engine-design.md.
+This module ships the types + engine scaffold. run_tick body lands in Task 3.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+
+from brain.bridge.provider import LLMProvider
+from brain.memory.store import MemoryStore
+from brain.search.base import WebSearcher
+from brain.utils.time import iso_utc, parse_iso_utc
+
+logger = logging.getLogger(__name__)
+
+
+# ---------- Types ----------
+
+
+@dataclass(frozen=True)
+class ResearchFire:
+    """Record of one research firing."""
+
+    interest_id: str
+    topic: str
+    fired_at: datetime  # tz-aware UTC
+    trigger: str  # "manual" | "emotion_high" | "days_since_human"
+    web_used: bool
+    web_result_count: int
+    output_memory_id: str | None  # None in dry-run
+
+    def to_dict(self) -> dict:
+        return {
+            "interest_id": self.interest_id,
+            "topic": self.topic,
+            "fired_at": iso_utc(self.fired_at),
+            "trigger": self.trigger,
+            "web_used": self.web_used,
+            "web_result_count": self.web_result_count,
+            "output_memory_id": self.output_memory_id,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> ResearchFire:
+        return cls(
+            interest_id=str(data["interest_id"]),
+            topic=str(data["topic"]),
+            fired_at=parse_iso_utc(data["fired_at"]),
+            trigger=str(data["trigger"]),
+            web_used=bool(data["web_used"]),
+            web_result_count=int(data["web_result_count"]),
+            output_memory_id=data.get("output_memory_id"),
+        )
+
+
+@dataclass(frozen=True)
+class ResearchResult:
+    """Outcome of a single research evaluation."""
+
+    fired: ResearchFire | None
+    would_fire: str | None  # dry-run only — topic that would fire
+    reason: (
+        str | None
+    )  # "not_due"|"no_eligible_interest"|"no_interests_defined"|"research_raised"|"reflex_won_tie"
+    dry_run: bool
+    evaluated_at: datetime  # tz-aware UTC
+
+
+# ---------- Engine scaffold ----------
+
+
+@dataclass
+class ResearchEngine:
+    """Autonomous exploration of developed interests.
+
+    run_tick() implementation lands in Task 3; scaffold ships here.
+    """
+
+    store: MemoryStore
+    provider: LLMProvider
+    searcher: WebSearcher
+    persona_name: str
+    persona_system_prompt: str
+    interests_path: Path
+    research_log_path: Path
+    default_interests_path: Path
+
+    def run_tick(
+        self,
+        *,
+        trigger: str = "manual",
+        dry_run: bool = False,
+        forced_interest_topic: str | None = None,
+        emotion_state_override=None,
+        days_since_human_override: float | None = None,
+    ) -> ResearchResult:
+        raise NotImplementedError("run_tick body lands in Task 3")
+
+
+# ---------- Research log ----------
+
+
+@dataclass(frozen=True)
+class ResearchLog:
+    """Fire-history log for one persona."""
+
+    fires: tuple[ResearchFire, ...] = ()
+
+    @classmethod
+    def load(cls, path: Path) -> ResearchLog:
+        if not path.exists():
+            return cls()
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+            if not isinstance(data, dict):
+                return cls()
+            fires_raw = data.get("fires", [])
+            if not isinstance(fires_raw, list):
+                return cls()
+            return cls(
+                fires=tuple(ResearchFire.from_dict(f) for f in fires_raw if isinstance(f, dict))
+            )
+        except (json.JSONDecodeError, KeyError, TypeError, ValueError):
+            return cls()
+
+    def save(self, path: Path) -> None:
+        payload = {"version": 1, "fires": [f.to_dict() for f in self.fires]}
+        tmp = path.with_suffix(path.suffix + ".new")
+        tmp.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+        os.replace(tmp, path)
+
+    def appended(self, fire: ResearchFire) -> ResearchLog:
+        return ResearchLog(fires=self.fires + (fire,))

--- a/brain/migrator/cli.py
+++ b/brain/migrator/cli.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from brain.memory.hebbian import HebbianMatrix
 from brain.memory.store import MemoryStore
 from brain.migrator.og import FileManifest, OGReader
+from brain.migrator.og_interests import extract_interests_from_og, extract_soul_names_best_effort
 from brain.migrator.og_reflex import extract_arcs_from_og
 from brain.migrator.report import MigrationReport, format_report, write_source_manifest
 from brain.migrator.transform import SkippedMemory, transform_memory
@@ -133,6 +134,34 @@ def run_migrate(args: MigrateArgs) -> MigrationReport:
     else:
         reflex_arcs_skipped_reason = "og_reflex_engine_py_not_found"
 
+    # ---- interests ----
+    _candidate_interests_paths = [
+        args.input_dir / "nell_interests.json",
+        args.input_dir / "data" / "nell_interests.json",
+        args.input_dir.parent / "nell_interests.json",
+    ]
+    og_interests_path = next((p for p in _candidate_interests_paths if p.exists()), None)
+    interests_target = work_dir / "interests.json"
+    interests_migrated = 0
+    interests_skipped_reason: str | None = None
+
+    if og_interests_path is not None:
+        if interests_target.exists() and not args.force:
+            interests_skipped_reason = "existing_file_not_overwritten"
+        else:
+            try:
+                soul_names = extract_soul_names_best_effort(args.input_dir)
+                og_interests = extract_interests_from_og(og_interests_path, soul_names=soul_names)
+                interests_target.write_text(
+                    _json.dumps({"version": 1, "interests": og_interests}, indent=2) + "\n",
+                    encoding="utf-8",
+                )
+                interests_migrated = len(og_interests)
+            except (ValueError, FileNotFoundError, OSError) as exc:
+                interests_skipped_reason = f"migrate_error: {exc}"
+    else:
+        interests_skipped_reason = "og_nell_interests_json_not_found"
+
     elapsed = time.monotonic() - started
 
     # ---- post-run source re-stat (detect OG mutation during the run) ----
@@ -153,6 +182,8 @@ def run_migrate(args: MigrateArgs) -> MigrationReport:
         next_steps_install_cmd=install_cmd,
         reflex_arcs_migrated=reflex_arcs_migrated,
         reflex_arcs_skipped_reason=reflex_arcs_skipped_reason,
+        interests_migrated=interests_migrated,
+        interests_skipped_reason=interests_skipped_reason,
     )
     write_source_manifest(work_dir / "source-manifest.json", manifest)
     report_text = format_report(report)

--- a/brain/migrator/og_interests.py
+++ b/brain/migrator/og_interests.py
@@ -1,0 +1,118 @@
+"""Extract OG nell_interests.json into new-schema interest dicts.
+
+Pure JSON read (no AST needed — OG interests live in a JSON file, not
+a Python module). Scope classification: interests whose topic mentions
+any name from the persona's soul.json are tagged "internal" (never
+web-search Hana herself, Jordan, etc). Everything else defaults to
+"either" — safe default, web-priority but memory-fallback.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from brain.utils.time import iso_utc, parse_iso_utc
+
+
+def extract_interests_from_og(
+    og_interests_path: Path, *, soul_names: set[str]
+) -> list[dict[str, Any]]:
+    """Return new-schema interest dicts extracted from OG nell_interests.json.
+
+    Raises FileNotFoundError if the path doesn't exist, ValueError if it
+    can't be parsed. soul_names is lowercased for case-insensitive match.
+    """
+    if not og_interests_path.exists():
+        raise FileNotFoundError(f"OG interests file not found: {og_interests_path}")
+
+    try:
+        data = json.loads(og_interests_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"Invalid JSON in {og_interests_path}: {exc}") from exc
+
+    og_items = data.get("interests", [])
+    if not isinstance(og_items, list):
+        raise ValueError(f"{og_interests_path}: 'interests' is not a list")
+
+    soul_lower = {s.lower() for s in soul_names}
+
+    result: list[dict[str, Any]] = []
+    for item in og_items:
+        if not isinstance(item, dict):
+            continue
+        transformed = _transform_interest(item, soul_lower)
+        if transformed is not None:
+            result.append(transformed)
+    return result
+
+
+def extract_soul_names_best_effort(og_dir: Path) -> set[str]:
+    """Read soul names from NellBrain/data/nell_soul.json. Best-effort; returns
+    empty set if file missing/corrupt.
+    """
+    candidates = [
+        og_dir / "nell_soul.json",
+        og_dir / "data" / "nell_soul.json",
+        og_dir.parent / "nell_soul.json",
+    ]
+    for path in candidates:
+        if path.exists():
+            try:
+                data = json.loads(path.read_text(encoding="utf-8"))
+            except json.JSONDecodeError:
+                return set()
+            names: set[str] = set()
+            for c in data.get("crystallizations", []):
+                who = c.get("who_or_what", "")
+                if isinstance(who, str) and who:
+                    names.update(w.lower() for w in who.split() if len(w) > 2)
+            return names
+    return set()
+
+
+def _transform_interest(og: dict[str, Any], soul_lower: set[str]) -> dict[str, Any] | None:
+    required = (
+        "id",
+        "topic",
+        "pull_score",
+        "first_seen",
+        "last_fed",
+        "feed_count",
+        "source_types",
+        "related_keywords",
+        "notes",
+    )
+    for key in required:
+        if key not in og:
+            return None
+
+    topic = str(og["topic"])
+    scope = _classify_scope(topic, soul_lower)
+
+    # Normalise timestamps through parse → iso to collapse to Z format.
+    first_seen = iso_utc(parse_iso_utc(og["first_seen"]))
+    last_fed = iso_utc(parse_iso_utc(og["last_fed"]))
+
+    return {
+        "id": str(og["id"]),
+        "topic": topic,
+        "pull_score": float(og["pull_score"]),
+        "scope": scope,
+        "related_keywords": list(og["related_keywords"]),
+        "notes": str(og["notes"]),
+        "first_seen": first_seen,
+        "last_fed": last_fed,
+        "last_researched_at": None,
+        "feed_count": int(og["feed_count"]),
+        "source_types": list(og["source_types"]),
+    }
+
+
+def _classify_scope(topic: str, soul_lower: set[str]) -> str:
+    topic_lower = topic.lower()
+    for name in soul_lower:
+        if name in topic_lower:
+            return "internal"
+    return "either"

--- a/brain/migrator/report.py
+++ b/brain/migrator/report.py
@@ -26,6 +26,8 @@ class MigrationReport:
     next_steps_install_cmd: str
     reflex_arcs_migrated: int = 0
     reflex_arcs_skipped_reason: str | None = None
+    interests_migrated: int = 0
+    interests_skipped_reason: str | None = None
 
 
 def format_report(report: MigrationReport) -> str:
@@ -45,6 +47,14 @@ def format_report(report: MigrationReport) -> str:
         + (
             f" (skipped: {report.reflex_arcs_skipped_reason})"
             if report.reflex_arcs_skipped_reason
+            else ""
+        )
+    )
+    lines.append(
+        f"  Interests:      {report.interests_migrated:,} migrated"
+        + (
+            f" (skipped: {report.interests_skipped_reason})"
+            if report.interests_skipped_reason
             else ""
         )
     )

--- a/brain/search/__init__.py
+++ b/brain/search/__init__.py
@@ -1,0 +1,5 @@
+"""Web search layer — pluggable searcher backends.
+
+Default is DdgsWebSearcher (DuckDuckGo via the `ddgs` library, no API
+key). NoopWebSearcher used in tests and CI for zero-network behavior.
+"""

--- a/brain/search/base.py
+++ b/brain/search/base.py
@@ -1,0 +1,40 @@
+"""WebSearcher ABC + shared types + NoopWebSearcher."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class SearchResult:
+    """One web search hit."""
+
+    title: str
+    url: str
+    snippet: str
+
+
+class WebSearcher(ABC):
+    """Abstract searcher. Subclasses implement `search` and `name`."""
+
+    @abstractmethod
+    def search(self, query: str, *, limit: int = 5) -> list[SearchResult]:
+        """Return up to `limit` results for `query`. Empty list on any
+        transient failure — research engine falls back to memory-only
+        synthesis rather than crashing.
+        """
+
+    @abstractmethod
+    def name(self) -> str:
+        """Short identifier: 'ddgs', 'noop', 'claude-tool'."""
+
+
+class NoopWebSearcher(WebSearcher):
+    """Returns no results. Used in tests and CI to keep them zero-network."""
+
+    def search(self, query: str, *, limit: int = 5) -> list[SearchResult]:
+        return []
+
+    def name(self) -> str:
+        return "noop"

--- a/brain/search/claude_tool_searcher.py
+++ b/brain/search/claude_tool_searcher.py
@@ -1,0 +1,24 @@
+"""Stub for `claude -p --allowed-tools WebSearch` based searcher.
+
+Phase 1 ships this as NotImplementedError. If a Claude-CLI user wants
+to route web search through Claude's tool loop instead of DDG, this is
+where that lives. Mirrors how OllamaProvider ships as a stub.
+"""
+
+from __future__ import annotations
+
+from brain.search.base import SearchResult, WebSearcher
+
+
+class ClaudeToolWebSearcher(WebSearcher):
+    """Not implemented in Phase 1 — see docstring."""
+
+    def search(self, query: str, *, limit: int = 5) -> list[SearchResult]:
+        raise NotImplementedError(
+            "ClaudeToolWebSearcher is a Phase 1 stub. Use DdgsWebSearcher "
+            "(default) or NoopWebSearcher instead, or implement this if you "
+            "want to route search through `claude -p --allowed-tools WebSearch`."
+        )
+
+    def name(self) -> str:
+        return "claude-tool"

--- a/brain/search/ddgs_searcher.py
+++ b/brain/search/ddgs_searcher.py
@@ -1,0 +1,46 @@
+"""DuckDuckGo web search via the `ddgs` library. No API key, free, zero-cost."""
+
+from __future__ import annotations
+
+import logging
+
+from ddgs import DDGS
+
+from brain.search.base import SearchResult, WebSearcher
+
+logger = logging.getLogger(__name__)
+
+
+class DdgsWebSearcher(WebSearcher):
+    """DuckDuckGo search through the `ddgs` Python library.
+
+    Default searcher for the framework. Works with any LLM backend —
+    no dependency on `claude` CLI or any specific provider. Transient
+    errors (network, rate-limit, parser failures) return an empty list
+    plus a warning log so the research engine can gracefully fall back
+    to memory-only synthesis.
+    """
+
+    def __init__(self, region: str = "wt-wt", timeout_seconds: int = 15) -> None:
+        self._region = region
+        self._timeout = timeout_seconds
+
+    def search(self, query: str, *, limit: int = 5) -> list[SearchResult]:
+        try:
+            with DDGS(timeout=self._timeout) as ddgs:
+                raw = list(ddgs.text(query, region=self._region, max_results=limit))
+        except Exception as exc:
+            logger.warning("ddgs search failed for %r: %s", query[:80], exc)
+            return []
+
+        return [
+            SearchResult(
+                title=str(r.get("title", "")),
+                url=str(r.get("href") or r.get("url", "")),
+                snippet=str(r.get("body", "")),
+            )
+            for r in raw
+        ]
+
+    def name(self) -> str:
+        return "ddgs"

--- a/brain/search/factory.py
+++ b/brain/search/factory.py
@@ -1,0 +1,18 @@
+"""Searcher factory — resolve a name to an instance."""
+
+from __future__ import annotations
+
+from brain.search.base import NoopWebSearcher, WebSearcher
+from brain.search.claude_tool_searcher import ClaudeToolWebSearcher
+from brain.search.ddgs_searcher import DdgsWebSearcher
+
+
+def get_searcher(name: str) -> WebSearcher:
+    """Resolve a searcher identifier to an instance. Raises ValueError on unknown."""
+    if name == "ddgs":
+        return DdgsWebSearcher()
+    if name == "noop":
+        return NoopWebSearcher()
+    if name == "claude-tool":
+        return ClaudeToolWebSearcher()
+    raise ValueError(f"Unknown searcher: {name!r}")

--- a/docs/superpowers/plans/2026-04-24-week-4-research-engine.md
+++ b/docs/superpowers/plans/2026-04-24-week-4-research-engine.md
@@ -1,0 +1,3265 @@
+# Week 4.7 — Research Engine (Phase 1) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship the fourth and final Week 4 cognitive engine — research — with DuckDuckGo web search by default, memory-sweep fallback, interest storage, heartbeat orchestration, and Nell's OG interest migration. After this ships, Week 4 gets its tag.
+
+**Architecture:** Mirrors the reflex engine's pattern. `ResearchEngine.run_tick` evaluates triggers (emotion_high OR days_since_human), selects an eligible interest past pull threshold + past cooldown, does a memory sweep via spreading activation, optionally hits the web via a pluggable `WebSearcher` (DDG default), synthesizes via the existing `LLMProvider`, writes a first-person memory. Heartbeat integrates between dream gate and heartbeat-memory. Reflex-wins-tie when both are eligible. Interest ingestion hook bumps pull_scores via keyword matching inside heartbeat ticks.
+
+**Tech Stack:** Python 3.12, SQLite (existing MemoryStore), `ddgs` (new dep — DuckDuckGo, no API key, free), pytest, ruff, hatchling.
+
+**Spec:** `docs/superpowers/specs/2026-04-24-week-4-research-engine-design.md`
+
+**Precedent pattern:** Reflex engine (`brain/engines/reflex.py`) and its plan. Copy the shape — don't invent a new one. Reflex shipped in PR #7 merged as `6e1996c`; study those files before starting.
+
+**Hard rule:** `rg 'import anthropic' brain/` must always return zero matches. All LLM calls through `brain.bridge.provider.LLMProvider`.
+
+**Running test total:** pre-start 376. After this plan: ~401.
+
+---
+
+## File Structure
+
+### New files
+
+| File | Responsibility |
+|------|---------------|
+| `brain/search/__init__.py` | Package marker. Empty or short re-exports of public symbols. |
+| `brain/search/base.py` | `SearchResult` frozen dataclass + `WebSearcher` ABC + `NoopWebSearcher`. |
+| `brain/search/ddgs_searcher.py` | `DdgsWebSearcher` — DDG via `ddgs` library. |
+| `brain/search/claude_tool_searcher.py` | Stub `ClaudeToolWebSearcher` (raises `NotImplementedError` — real impl is future work). |
+| `brain/search/factory.py` | `get_searcher(name)` resolver. |
+| `brain/engines/_interests.py` | `Interest` dataclass + `InterestSet` load/save/bump/list_eligible. |
+| `brain/engines/default_interests.json` | `{"version": 1, "interests": []}` — empty starter for new personas. |
+| `brain/engines/research.py` | `ResearchEngine` + `ResearchResult` + `ResearchFire` types. |
+| `brain/migrator/og_interests.py` | JSON-port of OG `nell_interests.json` → new schema. |
+| `tests/unit/brain/search/__init__.py` | Package marker. |
+| `tests/unit/brain/search/test_noop.py` | NoopWebSearcher tests. |
+| `tests/unit/brain/search/test_ddgs.py` | DdgsWebSearcher tests with mocked `ddgs` module. |
+| `tests/unit/brain/engines/test_interests.py` | `Interest` + `InterestSet` unit tests. |
+| `tests/unit/brain/engines/test_research.py` | `ResearchEngine` unit tests. |
+| `tests/unit/brain/engines/test_cli_research.py` | 4 new CLI subcommands. |
+| `tests/unit/brain/migrator/test_og_interests.py` | OG interest extraction tests. |
+
+### Modified files
+
+| File | Change |
+|------|--------|
+| `pyproject.toml` | Add `ddgs>=6.0,<7.0` to `dependencies`. |
+| `brain/engines/heartbeat.py` | Extend `HeartbeatConfig` (4 new fields), `HeartbeatResult` (3 new fields), `HeartbeatEngine` (4 new fields). Add `_try_bump_interests` helper. Add `_try_fire_research` helper with reflex-wins-tie guard. Wire both into `run_tick`. Extend audit log. |
+| `brain/cli.py` | Add `nell research` + `nell interest {list,add,bump}` subcommands. Update `_heartbeat_handler` to pass new reflex/research paths + searcher. |
+| `brain/migrator/cli.py` | Wire `og_interests` extraction after Hebbian/reflex blocks, before `elapsed`. Pass two new `MigrationReport` fields. |
+| `brain/migrator/report.py` | Add `interests_migrated: int = 0` + `interests_skipped_reason: str \| None = None` to `MigrationReport`. Add "Interests:" line in `format_report`. |
+| `tests/unit/brain/engines/test_heartbeat.py` | Add integration tests: research fires / disabled / reflex-wins-tie / failure-isolated / ingestion-bumps-pull_score. |
+| `tests/unit/brain/migrator/test_cli.py` | Add regression test: migrator writes interests.json. |
+
+---
+
+## Task 0: Web search layer
+
+**Purpose:** Ship `brain/search/` package with `WebSearcher` ABC + `NoopWebSearcher` + `DdgsWebSearcher` + stub `ClaudeToolWebSearcher` + `get_searcher` factory. Add `ddgs` dependency. The engine (Task 3) depends on this.
+
+**Files:**
+- Create: `brain/search/__init__.py`
+- Create: `brain/search/base.py`
+- Create: `brain/search/ddgs_searcher.py`
+- Create: `brain/search/claude_tool_searcher.py`
+- Create: `brain/search/factory.py`
+- Create: `tests/unit/brain/search/__init__.py`
+- Create: `tests/unit/brain/search/test_noop.py`
+- Create: `tests/unit/brain/search/test_ddgs.py`
+- Modify: `pyproject.toml` (add `ddgs>=6.0,<7.0`)
+
+- [ ] **Step 1: Add ddgs dependency**
+
+Edit `pyproject.toml`:
+
+```toml
+dependencies = [
+    "platformdirs>=4.2",
+    "numpy>=1.26",
+    "ddgs>=6.0,<7.0",
+]
+```
+
+Run: `uv sync --group dev`
+Expected: resolves + installs `ddgs` with its transitive deps.
+
+- [ ] **Step 2: Write failing test for NoopWebSearcher**
+
+Create `tests/unit/brain/search/__init__.py` (empty file).
+
+Create `tests/unit/brain/search/test_noop.py`:
+
+```python
+"""Tests for brain.search.base.NoopWebSearcher."""
+
+from __future__ import annotations
+
+from brain.search.base import NoopWebSearcher
+
+
+def test_noop_returns_empty_list():
+    s = NoopWebSearcher()
+    assert s.search("any query") == []
+
+
+def test_noop_returns_empty_with_limit_arg():
+    s = NoopWebSearcher()
+    assert s.search("any query", limit=10) == []
+
+
+def test_noop_name():
+    assert NoopWebSearcher().name() == "noop"
+```
+
+- [ ] **Step 3: Run to verify failure**
+
+Run: `uv run pytest tests/unit/brain/search/test_noop.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'brain.search'`.
+
+- [ ] **Step 4: Implement base + noop**
+
+Create `brain/search/__init__.py`:
+
+```python
+"""Web search layer — pluggable searcher backends.
+
+Default is DdgsWebSearcher (DuckDuckGo via the `ddgs` library, no API
+key). NoopWebSearcher used in tests and CI for zero-network behavior.
+"""
+```
+
+Create `brain/search/base.py`:
+
+```python
+"""WebSearcher ABC + shared types + NoopWebSearcher."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class SearchResult:
+    """One web search hit."""
+
+    title: str
+    url: str
+    snippet: str
+
+
+class WebSearcher(ABC):
+    """Abstract searcher. Subclasses implement `search` and `name`."""
+
+    @abstractmethod
+    def search(self, query: str, *, limit: int = 5) -> list[SearchResult]:
+        """Return up to `limit` results for `query`. Empty list on any
+        transient failure — research engine falls back to memory-only
+        synthesis rather than crashing.
+        """
+
+    @abstractmethod
+    def name(self) -> str:
+        """Short identifier: 'ddgs', 'noop', 'claude-tool'."""
+
+
+class NoopWebSearcher(WebSearcher):
+    """Returns no results. Used in tests and CI to keep them zero-network."""
+
+    def search(self, query: str, *, limit: int = 5) -> list[SearchResult]:
+        return []
+
+    def name(self) -> str:
+        return "noop"
+```
+
+- [ ] **Step 5: Run tests**
+
+Run: `uv run pytest tests/unit/brain/search/test_noop.py -v`
+Expected: 3 passed.
+
+- [ ] **Step 6: Write DdgsWebSearcher tests**
+
+Create `tests/unit/brain/search/test_ddgs.py`:
+
+```python
+"""Tests for brain.search.ddgs_searcher.DdgsWebSearcher."""
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import MagicMock, patch
+
+from brain.search.base import SearchResult
+from brain.search.ddgs_searcher import DdgsWebSearcher
+
+
+def test_ddgs_happy_path():
+    fake_ctx = MagicMock()
+    fake_ctx.__enter__.return_value = fake_ctx
+    fake_ctx.__exit__.return_value = None
+    fake_ctx.text.return_value = [
+        {"title": "T1", "href": "https://example.com/1", "body": "s1"},
+        {"title": "T2", "href": "https://example.com/2", "body": "s2"},
+    ]
+
+    with patch("brain.search.ddgs_searcher.DDGS", return_value=fake_ctx):
+        out = DdgsWebSearcher().search("quantum mechanics", limit=2)
+
+    assert len(out) == 2
+    assert out[0] == SearchResult(title="T1", url="https://example.com/1", snippet="s1")
+    assert out[1].url == "https://example.com/2"
+
+
+def test_ddgs_uses_href_or_url_field():
+    fake_ctx = MagicMock()
+    fake_ctx.__enter__.return_value = fake_ctx
+    fake_ctx.__exit__.return_value = None
+    # Simulate a result with 'url' instead of 'href' (library variance)
+    fake_ctx.text.return_value = [{"title": "T", "url": "https://x.com", "body": "s"}]
+
+    with patch("brain.search.ddgs_searcher.DDGS", return_value=fake_ctx):
+        out = DdgsWebSearcher().search("q", limit=1)
+
+    assert out[0].url == "https://x.com"
+
+
+def test_ddgs_transient_failure_returns_empty(caplog):
+    fake_ctx = MagicMock()
+    fake_ctx.__enter__.return_value = fake_ctx
+    fake_ctx.__exit__.return_value = None
+    fake_ctx.text.side_effect = RuntimeError("network down")
+
+    with patch("brain.search.ddgs_searcher.DDGS", return_value=fake_ctx):
+        with caplog.at_level(logging.WARNING, logger="brain.search.ddgs_searcher"):
+            out = DdgsWebSearcher().search("q")
+
+    assert out == []
+    assert any("ddgs search failed" in r.message for r in caplog.records)
+
+
+def test_ddgs_name():
+    assert DdgsWebSearcher().name() == "ddgs"
+
+
+def test_ddgs_missing_library_raises_at_call_time():
+    """If `ddgs` isn't installed, ImportError surfaces at first .search call,
+    not at module import time."""
+    with patch.dict("sys.modules", {"ddgs": None}):
+        # Simulate missing package: importing `ddgs` raises
+        import sys
+        # Force re-import path: remove ddgs from sys.modules and intercept
+        sys.modules["ddgs"] = None  # type: ignore[assignment]
+        s = DdgsWebSearcher()
+        # calling search imports ddgs lazily — this should raise
+        import pytest
+        with pytest.raises((ImportError, TypeError, AttributeError)):
+            s.search("q")
+```
+
+(The last test is defensive — in practice `ddgs` is a declared dependency so this path is near-unreachable, but the lazy-import behavior is worth guarding.)
+
+- [ ] **Step 7: Run to verify failure**
+
+Run: `uv run pytest tests/unit/brain/search/test_ddgs.py -v`
+Expected: FAIL (module doesn't exist).
+
+- [ ] **Step 8: Implement DdgsWebSearcher**
+
+Create `brain/search/ddgs_searcher.py`:
+
+```python
+"""DuckDuckGo web search via the `ddgs` library. No API key, free, zero-cost."""
+
+from __future__ import annotations
+
+import logging
+
+from brain.search.base import SearchResult, WebSearcher
+
+logger = logging.getLogger(__name__)
+
+
+class DdgsWebSearcher(WebSearcher):
+    """DuckDuckGo search through the `ddgs` Python library.
+
+    Default searcher for the framework. Works with any LLM backend —
+    no dependency on `claude` CLI or any specific provider. Transient
+    errors (network, rate-limit, parser failures) return an empty list
+    plus a warning log so the research engine can gracefully fall back
+    to memory-only synthesis.
+
+    `ddgs` is imported lazily so the module loads cleanly in environments
+    that haven't installed it yet (uncommon — it's a declared dependency).
+    """
+
+    def __init__(self, region: str = "wt-wt", timeout_seconds: int = 15) -> None:
+        self._region = region
+        self._timeout = timeout_seconds
+
+    def search(self, query: str, *, limit: int = 5) -> list[SearchResult]:
+        from ddgs import DDGS  # lazy import
+
+        try:
+            with DDGS(timeout=self._timeout) as ddgs:
+                raw = list(ddgs.text(query, region=self._region, max_results=limit))
+        except Exception as exc:
+            logger.warning("ddgs search failed for %r: %s", query[:80], exc)
+            return []
+
+        return [
+            SearchResult(
+                title=str(r.get("title", "")),
+                url=str(r.get("href") or r.get("url", "")),
+                snippet=str(r.get("body", "")),
+            )
+            for r in raw
+        ]
+
+    def name(self) -> str:
+        return "ddgs"
+```
+
+Create `brain/search/claude_tool_searcher.py` (stub):
+
+```python
+"""Stub for `claude -p --allowed-tools WebSearch` based searcher.
+
+Phase 1 ships this as NotImplementedError. If a Claude-CLI user wants
+to route web search through Claude's tool loop instead of DDG, this is
+where that lives. Mirrors how OllamaProvider ships as a stub.
+"""
+
+from __future__ import annotations
+
+from brain.search.base import SearchResult, WebSearcher
+
+
+class ClaudeToolWebSearcher(WebSearcher):
+    """Not implemented in Phase 1 — see docstring."""
+
+    def search(self, query: str, *, limit: int = 5) -> list[SearchResult]:
+        raise NotImplementedError(
+            "ClaudeToolWebSearcher is a Phase 1 stub. Use DdgsWebSearcher "
+            "(default) or NoopWebSearcher instead, or implement this if you "
+            "want to route search through `claude -p --allowed-tools WebSearch`."
+        )
+
+    def name(self) -> str:
+        return "claude-tool"
+```
+
+Create `brain/search/factory.py`:
+
+```python
+"""Searcher factory — resolve a name to an instance."""
+
+from __future__ import annotations
+
+from brain.search.base import NoopWebSearcher, WebSearcher
+from brain.search.claude_tool_searcher import ClaudeToolWebSearcher
+from brain.search.ddgs_searcher import DdgsWebSearcher
+
+
+def get_searcher(name: str) -> WebSearcher:
+    """Resolve a searcher identifier to an instance. Raises ValueError on unknown."""
+    if name == "ddgs":
+        return DdgsWebSearcher()
+    if name == "noop":
+        return NoopWebSearcher()
+    if name == "claude-tool":
+        return ClaudeToolWebSearcher()
+    raise ValueError(f"Unknown searcher: {name!r}")
+```
+
+- [ ] **Step 9: Run tests**
+
+Run: `uv run pytest tests/unit/brain/search/ -v`
+Expected: all tests pass (8 total).
+
+- [ ] **Step 10: Ruff + format**
+
+Run: `uv run ruff check brain/search/ tests/unit/brain/search/ && uv run ruff format brain/search/ tests/unit/brain/search/`
+Expected: clean.
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add brain/search/ tests/unit/brain/search/ pyproject.toml uv.lock
+git commit -m "$(cat <<'EOF'
+feat: add brain/search/ web search abstraction
+
+WebSearcher ABC + SearchResult frozen dataclass. Three concrete
+searchers: DdgsWebSearcher (DuckDuckGo default, zero-cost), 
+NoopWebSearcher (tests/CI, zero-network), ClaudeToolWebSearcher
+(Phase 1 stub). get_searcher() factory for name→instance.
+
+ddgs dep added to pyproject. Transient failures return [] so research
+engine can fall back to memory-only synthesis.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+(Include `uv.lock` if it changed.)
+
+---
+
+## Task 1: Interest + InterestSet
+
+**Purpose:** Build the `Interest` frozen dataclass + `InterestSet` load/save/bump/list_eligible helpers. Shared between research engine AND heartbeat's ingestion hook, so it lives in its own module.
+
+**Files:**
+- Create: `brain/engines/_interests.py`
+- Create: `brain/engines/default_interests.json`
+- Create: `tests/unit/brain/engines/test_interests.py`
+
+- [ ] **Step 1: Create default interests JSON**
+
+Create `brain/engines/default_interests.json`:
+
+```json
+{
+  "version": 1,
+  "interests": []
+}
+```
+
+Trailing newline. Shipped empty — new personas start with no interests; they grow them through conversation (ingestion hook) or `nell interest add`.
+
+- [ ] **Step 2: Write failing tests for Interest + InterestSet**
+
+Create `tests/unit/brain/engines/test_interests.py`:
+
+```python
+"""Unit tests for brain.engines._interests."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from brain.engines._interests import Interest, InterestSet
+
+DEFAULT_INTERESTS_PATH = (
+    Path(__file__).parents[4] / "brain" / "engines" / "default_interests.json"
+)
+
+
+def _sample_dict(**overrides) -> dict:
+    base = {
+        "id": "abc-123",
+        "topic": "Test topic",
+        "pull_score": 6.5,
+        "scope": "either",
+        "related_keywords": ["test", "topic"],
+        "notes": "",
+        "first_seen": "2026-04-01T10:00:00Z",
+        "last_fed": "2026-04-15T10:00:00Z",
+        "last_researched_at": None,
+        "feed_count": 3,
+        "source_types": ["manual"],
+    }
+    base.update(overrides)
+    return base
+
+
+# ---- Interest ----
+
+
+def test_interest_from_dict_valid():
+    i = Interest.from_dict(_sample_dict())
+    assert i.id == "abc-123"
+    assert i.pull_score == 6.5
+    assert i.scope == "either"
+    assert i.related_keywords == ("test", "topic")
+    assert i.last_researched_at is None
+
+
+def test_interest_from_dict_with_researched_timestamp():
+    data = _sample_dict(last_researched_at="2026-04-20T10:00:00Z")
+    i = Interest.from_dict(data)
+    assert i.last_researched_at is not None
+    assert i.last_researched_at.tzinfo is not None
+
+
+def test_interest_from_dict_invalid_scope_raises():
+    with pytest.raises(ValueError):
+        Interest.from_dict(_sample_dict(scope="whatever"))
+
+
+def test_interest_to_dict_roundtrip():
+    original = Interest.from_dict(_sample_dict())
+    restored = Interest.from_dict(original.to_dict())
+    assert restored == original
+
+
+# ---- InterestSet: load / save ----
+
+
+def test_interestset_load_missing_falls_back_to_defaults(tmp_path: Path):
+    missing = tmp_path / "nope.json"
+    loaded = InterestSet.load(missing, default_path=DEFAULT_INTERESTS_PATH)
+    assert loaded.interests == ()  # default is empty
+
+
+def test_interestset_load_corrupt_falls_back(tmp_path: Path):
+    bad = tmp_path / "interests.json"
+    bad.write_text("not valid{", encoding="utf-8")
+    loaded = InterestSet.load(bad, default_path=DEFAULT_INTERESTS_PATH)
+    assert loaded.interests == ()
+
+
+def test_interestset_load_valid_file(tmp_path: Path):
+    path = tmp_path / "interests.json"
+    path.write_text(
+        json.dumps({"version": 1, "interests": [_sample_dict()]}), encoding="utf-8"
+    )
+    loaded = InterestSet.load(path, default_path=DEFAULT_INTERESTS_PATH)
+    assert len(loaded.interests) == 1
+    assert loaded.interests[0].topic == "Test topic"
+
+
+def test_interestset_save_atomic(tmp_path: Path):
+    path = tmp_path / "interests.json"
+    s = InterestSet(interests=(Interest.from_dict(_sample_dict()),))
+    s.save(path)
+    # File exists + valid JSON + .new tempfile cleaned up
+    assert path.exists()
+    assert not (path.with_suffix(path.suffix + ".new")).exists()
+    reloaded = InterestSet.load(path, default_path=DEFAULT_INTERESTS_PATH)
+    assert reloaded.interests[0].id == "abc-123"
+
+
+def test_interestset_load_bad_interest_skipped_good_kept(tmp_path: Path):
+    path = tmp_path / "interests.json"
+    payload = {
+        "version": 1,
+        "interests": [_sample_dict(), {"id": "broken"}],  # second missing required keys
+    }
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    loaded = InterestSet.load(path, default_path=DEFAULT_INTERESTS_PATH)
+    topics = {i.topic for i in loaded.interests}
+    assert "Test topic" in topics
+    assert len(loaded.interests) == 1
+
+
+# ---- InterestSet: helpers ----
+
+
+def test_interestset_find_by_topic():
+    s = InterestSet(interests=(Interest.from_dict(_sample_dict(topic="Rebecca")),))
+    assert s.find_by_topic("Rebecca") is not None
+    assert s.find_by_topic("rebecca") is not None  # case-insensitive
+    assert s.find_by_topic("Unknown") is None
+
+
+def test_interestset_bump_existing_topic():
+    now = datetime.now(UTC)
+    s = InterestSet(interests=(Interest.from_dict(_sample_dict(pull_score=6.0, feed_count=3)),))
+    new_s = s.bump("Test topic", amount=0.5, now=now)
+    bumped = new_s.find_by_topic("Test topic")
+    assert bumped is not None
+    assert bumped.pull_score == 6.5
+    assert bumped.feed_count == 4
+    assert bumped.last_fed == now
+
+
+def test_interestset_bump_unknown_topic_returns_unchanged():
+    s = InterestSet(interests=(Interest.from_dict(_sample_dict()),))
+    new_s = s.bump("Unknown", amount=1.0, now=datetime.now(UTC))
+    assert new_s == s
+
+
+def test_interestset_list_eligible_respects_pull_threshold():
+    now = datetime.now(UTC)
+    low = Interest.from_dict(_sample_dict(id="low", topic="A", pull_score=5.0))
+    high = Interest.from_dict(_sample_dict(id="high", topic="B", pull_score=7.0))
+    s = InterestSet(interests=(low, high))
+    eligible = s.list_eligible(pull_threshold=6.0, cooldown_hours=24.0, now=now)
+    assert [i.id for i in eligible] == ["high"]
+
+
+def test_interestset_list_eligible_respects_cooldown():
+    now = datetime.now(UTC)
+    recent = Interest.from_dict(
+        _sample_dict(id="recent", topic="A", pull_score=7.0,
+                     last_researched_at=(now - timedelta(hours=1)).isoformat().replace("+00:00", "Z"))
+    )
+    old = Interest.from_dict(
+        _sample_dict(id="old", topic="B", pull_score=7.0,
+                     last_researched_at=(now - timedelta(hours=30)).isoformat().replace("+00:00", "Z"))
+    )
+    never = Interest.from_dict(_sample_dict(id="never", topic="C", pull_score=7.0))
+    s = InterestSet(interests=(recent, old, never))
+    eligible = s.list_eligible(pull_threshold=6.0, cooldown_hours=24.0, now=now)
+    ids = [i.id for i in eligible]
+    assert "recent" not in ids
+    assert "old" in ids
+    assert "never" in ids
+
+
+def test_interestset_list_eligible_sorted_pull_desc_then_oldest_research():
+    now = datetime.now(UTC)
+    a = Interest.from_dict(_sample_dict(id="a", topic="A", pull_score=7.0,
+                                         last_researched_at=(now - timedelta(hours=50)).isoformat().replace("+00:00", "Z")))
+    b = Interest.from_dict(_sample_dict(id="b", topic="B", pull_score=8.0))
+    c = Interest.from_dict(_sample_dict(id="c", topic="C", pull_score=7.0,
+                                         last_researched_at=(now - timedelta(hours=100)).isoformat().replace("+00:00", "Z")))
+    s = InterestSet(interests=(a, b, c))
+    eligible = s.list_eligible(pull_threshold=6.0, cooldown_hours=24.0, now=now)
+    # b first (highest pull), then c (older research than a), then a
+    assert [i.id for i in eligible] == ["b", "c", "a"]
+```
+
+- [ ] **Step 3: Run to verify failure**
+
+Run: `uv run pytest tests/unit/brain/engines/test_interests.py -v`
+Expected: FAIL (module doesn't exist).
+
+- [ ] **Step 4: Implement _interests.py**
+
+Create `brain/engines/_interests.py`:
+
+```python
+"""Interest dataclass + InterestSet persistence.
+
+Shared by brain.engines.research AND the interest-ingestion hook in
+brain.engines.heartbeat, so it lives in its own module rather than
+inside research.py.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import Literal
+
+from brain.utils.time import iso_utc, parse_iso_utc
+
+logger = logging.getLogger(__name__)
+
+_VALID_SCOPES = ("internal", "external", "either")
+Scope = Literal["internal", "external", "either"]
+
+
+@dataclass(frozen=True)
+class Interest:
+    """One persona-level curiosity — topic + pull_score + scope + keywords."""
+
+    id: str
+    topic: str
+    pull_score: float
+    scope: Scope
+    related_keywords: tuple[str, ...]
+    notes: str
+    first_seen: datetime       # tz-aware UTC
+    last_fed: datetime         # tz-aware UTC
+    last_researched_at: datetime | None
+    feed_count: int
+    source_types: tuple[str, ...]
+
+    @classmethod
+    def from_dict(cls, data: dict) -> Interest:
+        required = (
+            "id", "topic", "pull_score", "scope", "related_keywords",
+            "notes", "first_seen", "last_fed", "feed_count", "source_types",
+        )
+        for key in required:
+            if key not in data:
+                raise KeyError(f"Interest missing required key: {key!r}")
+
+        scope = data["scope"]
+        if scope not in _VALID_SCOPES:
+            raise ValueError(
+                f"Interest {data.get('topic')!r}: scope must be one of {_VALID_SCOPES}, got {scope!r}"
+            )
+
+        last_researched_raw = data.get("last_researched_at")
+        last_researched = (
+            parse_iso_utc(last_researched_raw) if last_researched_raw else None
+        )
+
+        return cls(
+            id=str(data["id"]),
+            topic=str(data["topic"]),
+            pull_score=float(data["pull_score"]),
+            scope=scope,
+            related_keywords=tuple(str(k) for k in data["related_keywords"]),
+            notes=str(data["notes"]),
+            first_seen=parse_iso_utc(data["first_seen"]),
+            last_fed=parse_iso_utc(data["last_fed"]),
+            last_researched_at=last_researched,
+            feed_count=int(data["feed_count"]),
+            source_types=tuple(str(s) for s in data["source_types"]),
+        )
+
+    def to_dict(self) -> dict:
+        return {
+            "id": self.id,
+            "topic": self.topic,
+            "pull_score": self.pull_score,
+            "scope": self.scope,
+            "related_keywords": list(self.related_keywords),
+            "notes": self.notes,
+            "first_seen": iso_utc(self.first_seen),
+            "last_fed": iso_utc(self.last_fed),
+            "last_researched_at": (
+                iso_utc(self.last_researched_at) if self.last_researched_at else None
+            ),
+            "feed_count": self.feed_count,
+            "source_types": list(self.source_types),
+        }
+
+
+@dataclass(frozen=True)
+class InterestSet:
+    """Loaded set of Interest records, with atomic save + helper queries."""
+
+    interests: tuple[Interest, ...] = field(default_factory=tuple)
+
+    @classmethod
+    def load(cls, path: Path, *, default_path: Path) -> InterestSet:
+        source_path = path if path.exists() else default_path
+        if source_path != path:
+            logger.warning("interests file %s not found, using defaults", path)
+
+        try:
+            data = json.loads(source_path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError) as exc:
+            logger.warning("interests load failed (%s), falling back to defaults", exc)
+            data = json.loads(default_path.read_text(encoding="utf-8"))
+
+        if not isinstance(data, dict) or not isinstance(data.get("interests"), list):
+            logger.warning("interests schema invalid at %s, falling back to defaults", source_path)
+            data = json.loads(default_path.read_text(encoding="utf-8"))
+
+        out: list[Interest] = []
+        for raw in data["interests"]:
+            try:
+                out.append(Interest.from_dict(raw))
+            except (KeyError, ValueError, TypeError) as exc:
+                logger.warning("interest %r failed to load: %s", raw.get("topic"), exc)
+                continue
+        return cls(interests=tuple(out))
+
+    def save(self, path: Path) -> None:
+        """Atomic save via .new + os.replace."""
+        payload = {"version": 1, "interests": [i.to_dict() for i in self.interests]}
+        tmp = path.with_suffix(path.suffix + ".new")
+        tmp.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+        os.replace(tmp, path)
+
+    def find_by_topic(self, topic: str) -> Interest | None:
+        lower = topic.lower()
+        for i in self.interests:
+            if i.topic.lower() == lower:
+                return i
+        return None
+
+    def bump(self, topic: str, *, amount: float, now: datetime) -> InterestSet:
+        """Return a new InterestSet with topic's pull_score nudged.
+
+        Unknown topics return self unchanged (caller decides whether to add).
+        """
+        out: list[Interest] = []
+        matched = False
+        lower = topic.lower()
+        for i in self.interests:
+            if i.topic.lower() == lower:
+                matched = True
+                out.append(
+                    Interest(
+                        id=i.id,
+                        topic=i.topic,
+                        pull_score=i.pull_score + amount,
+                        scope=i.scope,
+                        related_keywords=i.related_keywords,
+                        notes=i.notes,
+                        first_seen=i.first_seen,
+                        last_fed=now,
+                        last_researched_at=i.last_researched_at,
+                        feed_count=i.feed_count + 1,
+                        source_types=i.source_types,
+                    )
+                )
+            else:
+                out.append(i)
+        if not matched:
+            return self
+        return InterestSet(interests=tuple(out))
+
+    def list_eligible(
+        self, *, pull_threshold: float, cooldown_hours: float, now: datetime
+    ) -> list[Interest]:
+        """Return interests past pull_threshold + past cooldown.
+
+        Sorted by pull_score desc, then by last_researched_at ascending
+        (never-researched beats ever-researched on equal pull_score).
+        """
+        out: list[Interest] = []
+        for i in self.interests:
+            if i.pull_score < pull_threshold:
+                continue
+            if i.last_researched_at is not None:
+                hours_since = (now - i.last_researched_at).total_seconds() / 3600.0
+                if hours_since < cooldown_hours:
+                    continue
+            out.append(i)
+
+        def sort_key(i: Interest) -> tuple[float, float]:
+            last = i.last_researched_at
+            # never-researched: very old effective timestamp
+            ts = last.timestamp() if last is not None else 0.0
+            return (-i.pull_score, ts)
+
+        return sorted(out, key=sort_key)
+
+    def upsert(self, interest: Interest) -> InterestSet:
+        """Return a new InterestSet with interest added or replaced (by id)."""
+        out = [i for i in self.interests if i.id != interest.id]
+        out.append(interest)
+        return InterestSet(interests=tuple(out))
+```
+
+- [ ] **Step 5: Run tests**
+
+Run: `uv run pytest tests/unit/brain/engines/test_interests.py -v`
+Expected: all pass (~14 tests).
+
+- [ ] **Step 6: Ruff + format**
+
+Run: `uv run ruff check brain/engines/_interests.py brain/engines/default_interests.json tests/unit/brain/engines/test_interests.py && uv run ruff format brain/engines/_interests.py tests/unit/brain/engines/test_interests.py`
+Expected: clean.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add brain/engines/_interests.py brain/engines/default_interests.json tests/unit/brain/engines/test_interests.py
+git commit -m "$(cat <<'EOF'
+feat: add Interest + InterestSet for research engine
+
+Interest frozen dataclass (id, topic, pull_score, scope, keywords, 
+notes, timestamps, feed_count, source_types). InterestSet loads from
+JSON with fall-back-to-defaults, saves atomically, finds by topic
+case-insensitive, bumps pull_score immutably, lists eligible interests
+past pull threshold + cooldown sorted by pull_score desc + oldest
+research first. Shared between research engine and heartbeat's
+ingestion hook. default_interests.json ships empty.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: Research engine scaffold + types
+
+**Purpose:** Build `ResearchEngine` scaffold with its types. `run_tick` raises NotImplementedError at this stage; real body lands in Task 3.
+
+**Files:**
+- Create: `brain/engines/research.py`
+- Create: `tests/unit/brain/engines/test_research.py`
+
+- [ ] **Step 1: Write failing tests for scaffold**
+
+Create `tests/unit/brain/engines/test_research.py`:
+
+```python
+"""Unit tests for brain.engines.research — scaffold + types."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+from brain.bridge.provider import FakeProvider
+from brain.engines.research import (
+    ResearchEngine,
+    ResearchFire,
+    ResearchResult,
+)
+from brain.memory.store import MemoryStore
+from brain.search.base import NoopWebSearcher
+
+DEFAULT_INTERESTS_PATH = (
+    Path(__file__).parents[4] / "brain" / "engines" / "default_interests.json"
+)
+
+
+def test_research_fire_construction():
+    fire = ResearchFire(
+        interest_id="abc",
+        topic="Test",
+        fired_at=datetime.now(UTC),
+        trigger="manual",
+        web_used=False,
+        web_result_count=0,
+        output_memory_id="mem_xyz",
+    )
+    assert fire.topic == "Test"
+    assert fire.web_used is False
+
+
+def test_research_result_construction():
+    r = ResearchResult(
+        fired=None,
+        would_fire=None,
+        reason="not_due",
+        dry_run=False,
+        evaluated_at=datetime.now(UTC),
+    )
+    assert r.fired is None
+    assert r.reason == "not_due"
+
+
+def test_research_engine_construction(tmp_path: Path):
+    store = MemoryStore(":memory:")
+    try:
+        engine = ResearchEngine(
+            store=store,
+            provider=FakeProvider(),
+            searcher=NoopWebSearcher(),
+            persona_name="Nell",
+            persona_system_prompt="You are Nell.",
+            interests_path=tmp_path / "interests.json",
+            research_log_path=tmp_path / "research_log.json",
+            default_interests_path=DEFAULT_INTERESTS_PATH,
+        )
+        assert engine.persona_name == "Nell"
+    finally:
+        store.close()
+
+
+def test_run_tick_raises_not_implemented_yet(tmp_path: Path):
+    store = MemoryStore(":memory:")
+    try:
+        engine = ResearchEngine(
+            store=store,
+            provider=FakeProvider(),
+            searcher=NoopWebSearcher(),
+            persona_name="Nell",
+            persona_system_prompt="You are Nell.",
+            interests_path=tmp_path / "interests.json",
+            research_log_path=tmp_path / "research_log.json",
+            default_interests_path=DEFAULT_INTERESTS_PATH,
+        )
+        with pytest.raises(NotImplementedError):
+            engine.run_tick(trigger="manual", dry_run=False)
+    finally:
+        store.close()
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `uv run pytest tests/unit/brain/engines/test_research.py -v`
+Expected: FAIL (module doesn't exist).
+
+- [ ] **Step 3: Implement scaffold**
+
+Create `brain/engines/research.py`:
+
+```python
+"""Research — autonomous exploration of developed interests.
+
+See docs/superpowers/specs/2026-04-24-week-4-research-engine-design.md.
+This module ships the types + engine scaffold. run_tick body lands in Task 3.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+
+from brain.bridge.provider import LLMProvider
+from brain.memory.store import MemoryStore
+from brain.search.base import WebSearcher
+from brain.utils.time import iso_utc, parse_iso_utc
+
+logger = logging.getLogger(__name__)
+
+
+# ---------- Types ----------
+
+
+@dataclass(frozen=True)
+class ResearchFire:
+    """Record of one research firing."""
+
+    interest_id: str
+    topic: str
+    fired_at: datetime         # tz-aware UTC
+    trigger: str               # "manual" | "emotion_high" | "days_since_human"
+    web_used: bool
+    web_result_count: int
+    output_memory_id: str | None  # None in dry-run
+
+    def to_dict(self) -> dict:
+        return {
+            "interest_id": self.interest_id,
+            "topic": self.topic,
+            "fired_at": iso_utc(self.fired_at),
+            "trigger": self.trigger,
+            "web_used": self.web_used,
+            "web_result_count": self.web_result_count,
+            "output_memory_id": self.output_memory_id,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> ResearchFire:
+        return cls(
+            interest_id=str(data["interest_id"]),
+            topic=str(data["topic"]),
+            fired_at=parse_iso_utc(data["fired_at"]),
+            trigger=str(data["trigger"]),
+            web_used=bool(data["web_used"]),
+            web_result_count=int(data["web_result_count"]),
+            output_memory_id=data.get("output_memory_id"),
+        )
+
+
+@dataclass(frozen=True)
+class ResearchResult:
+    """Outcome of a single research evaluation."""
+
+    fired: ResearchFire | None
+    would_fire: str | None       # dry-run only — topic that would fire
+    reason: str | None           # "not_due"|"no_eligible_interest"|"no_interests_defined"|"research_raised"|"reflex_won_tie"
+    dry_run: bool
+    evaluated_at: datetime       # tz-aware UTC
+
+
+# ---------- Engine scaffold ----------
+
+
+@dataclass
+class ResearchEngine:
+    """Autonomous exploration of developed interests.
+
+    run_tick() implementation lands in Task 3; scaffold ships here.
+    """
+
+    store: MemoryStore
+    provider: LLMProvider
+    searcher: WebSearcher
+    persona_name: str
+    persona_system_prompt: str
+    interests_path: Path
+    research_log_path: Path
+    default_interests_path: Path
+
+    def run_tick(
+        self,
+        *,
+        trigger: str = "manual",
+        dry_run: bool = False,
+        forced_interest_topic: str | None = None,
+        emotion_state_override=None,
+        days_since_human_override: float | None = None,
+    ) -> ResearchResult:
+        raise NotImplementedError("run_tick body lands in Task 3")
+
+
+# ---------- Research log ----------
+
+
+@dataclass(frozen=True)
+class ResearchLog:
+    """Fire-history log for one persona."""
+
+    fires: tuple[ResearchFire, ...] = ()
+
+    @classmethod
+    def load(cls, path: Path) -> ResearchLog:
+        if not path.exists():
+            return cls()
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+            if not isinstance(data, dict):
+                return cls()
+            fires_raw = data.get("fires", [])
+            if not isinstance(fires_raw, list):
+                return cls()
+            return cls(fires=tuple(ResearchFire.from_dict(f) for f in fires_raw if isinstance(f, dict)))
+        except (json.JSONDecodeError, KeyError, TypeError, ValueError):
+            return cls()
+
+    def save(self, path: Path) -> None:
+        payload = {"version": 1, "fires": [f.to_dict() for f in self.fires]}
+        tmp = path.with_suffix(path.suffix + ".new")
+        tmp.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+        os.replace(tmp, path)
+
+    def appended(self, fire: ResearchFire) -> ResearchLog:
+        return ResearchLog(fires=self.fires + (fire,))
+```
+
+- [ ] **Step 4: Run tests to verify pass**
+
+Run: `uv run pytest tests/unit/brain/engines/test_research.py -v`
+Expected: 4 passed (ResearchFire, ResearchResult, construction, NotImplementedError).
+
+- [ ] **Step 5: Ruff + format**
+
+Run: `uv run ruff check brain/engines/research.py tests/unit/brain/engines/test_research.py && uv run ruff format brain/engines/research.py tests/unit/brain/engines/test_research.py`
+Expected: clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add brain/engines/research.py tests/unit/brain/engines/test_research.py
+git commit -m "$(cat <<'EOF'
+feat: add research engine scaffold + types
+
+ResearchFire / ResearchResult frozen dataclasses. ResearchLog with
+atomic save + corrupt-file-returns-empty. ResearchEngine scaffold
+with all constructor fields declared; run_tick raises
+NotImplementedError until Task 3 lands the real body.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: `ResearchEngine.run_tick` body
+
+**Purpose:** Implement the gate → select → memory sweep → optional web → LLM synthesis → write memory → update interest → log fire pipeline. Covers both standalone + heartbeat-orchestrated invocation paths.
+
+**Files:**
+- Modify: `brain/engines/research.py` (replace `NotImplementedError` with full body + helpers)
+- Modify: `tests/unit/brain/engines/test_research.py` (add ~15 new tests)
+
+- [ ] **Step 1: Append failing tests**
+
+Append to `tests/unit/brain/engines/test_research.py`:
+
+```python
+# ---- run_tick ----
+
+import json
+from datetime import timedelta
+
+from brain.engines._interests import Interest, InterestSet
+from brain.memory.hebbian import HebbianMatrix
+from brain.memory.store import Memory
+
+
+def _build_engine(tmp_path: Path, store: MemoryStore,
+                  provider: FakeProvider | None = None,
+                  searcher: NoopWebSearcher | None = None) -> ResearchEngine:
+    return ResearchEngine(
+        store=store,
+        provider=provider or FakeProvider(),
+        searcher=searcher or NoopWebSearcher(),
+        persona_name="Nell",
+        persona_system_prompt="You are Nell.",
+        interests_path=tmp_path / "interests.json",
+        research_log_path=tmp_path / "research_log.json",
+        default_interests_path=DEFAULT_INTERESTS_PATH,
+    )
+
+
+def _write_interests(path: Path, interests: list[dict]) -> None:
+    path.write_text(
+        json.dumps({"version": 1, "interests": interests}, indent=2), encoding="utf-8"
+    )
+
+
+def _seed_conversation_memory(store: MemoryStore, content: str,
+                              emotions: dict[str, float] | None = None) -> str:
+    mem = Memory.create_new(
+        content=content, memory_type="conversation", domain="us",
+        emotions=emotions or {},
+    )
+    store.create(mem)
+    return mem.id
+
+
+def _interest_dict(**overrides) -> dict:
+    base = {
+        "id": "i1",
+        "topic": "marine bioluminescence",
+        "pull_score": 7.0,
+        "scope": "either",
+        "related_keywords": ["marine", "bioluminescence", "ocean"],
+        "notes": "",
+        "first_seen": "2026-04-01T10:00:00Z",
+        "last_fed": "2026-04-15T10:00:00Z",
+        "last_researched_at": None,
+        "feed_count": 3,
+        "source_types": ["manual"],
+    }
+    base.update(overrides)
+    return base
+
+
+def test_run_tick_no_interests_defined(tmp_path: Path):
+    _write_interests(tmp_path / "interests.json", [])
+    store = MemoryStore(":memory:")
+    try:
+        engine = _build_engine(tmp_path, store)
+        result = engine.run_tick(trigger="manual", dry_run=False,
+                                 days_since_human_override=5.0)
+        assert result.fired is None
+        assert result.reason == "no_interests_defined"
+    finally:
+        store.close()
+
+
+def test_run_tick_not_due_returns_reason(tmp_path: Path):
+    _write_interests(tmp_path / "interests.json", [_interest_dict()])
+    store = MemoryStore(":memory:")
+    try:
+        engine = _build_engine(tmp_path, store)
+        # Low days + no emotion signal provided → not due
+        result = engine.run_tick(trigger="manual", dry_run=False,
+                                 days_since_human_override=0.0,
+                                 emotion_state_override=None)
+        assert result.fired is None
+        assert result.reason == "not_due"
+    finally:
+        store.close()
+
+
+def test_run_tick_days_since_human_triggers(tmp_path: Path):
+    _write_interests(tmp_path / "interests.json", [_interest_dict()])
+    store = MemoryStore(":memory:")
+    try:
+        engine = _build_engine(tmp_path, store)
+        result = engine.run_tick(trigger="days_since_human", dry_run=False,
+                                 days_since_human_override=5.0)
+        # Now eligible + selected + fired
+        assert result.fired is not None
+        assert result.fired.topic == "marine bioluminescence"
+    finally:
+        store.close()
+
+
+def test_run_tick_emotion_high_triggers(tmp_path: Path):
+    from brain.emotion.state import EmotionalState
+    _write_interests(tmp_path / "interests.json", [_interest_dict()])
+    store = MemoryStore(":memory:")
+    try:
+        engine = _build_engine(tmp_path, store)
+        es = EmotionalState()
+        es.set("creative_hunger", 8.0)
+        result = engine.run_tick(trigger="emotion_high", dry_run=False,
+                                 days_since_human_override=0.0,
+                                 emotion_state_override=es)
+        assert result.fired is not None
+    finally:
+        store.close()
+
+
+def test_run_tick_pull_threshold_filters(tmp_path: Path):
+    _write_interests(tmp_path / "interests.json",
+                     [_interest_dict(pull_score=5.0)])  # below threshold 6.0
+    store = MemoryStore(":memory:")
+    try:
+        engine = _build_engine(tmp_path, store)
+        result = engine.run_tick(days_since_human_override=5.0)
+        assert result.fired is None
+        assert result.reason == "no_eligible_interest"
+    finally:
+        store.close()
+
+
+def test_run_tick_cooldown_filters(tmp_path: Path):
+    now = datetime.now(UTC)
+    recent = (now - timedelta(hours=1)).isoformat().replace("+00:00", "Z")
+    _write_interests(tmp_path / "interests.json",
+                     [_interest_dict(last_researched_at=recent)])
+    store = MemoryStore(":memory:")
+    try:
+        engine = _build_engine(tmp_path, store)
+        result = engine.run_tick(days_since_human_override=5.0)
+        assert result.fired is None
+        assert result.reason == "no_eligible_interest"
+    finally:
+        store.close()
+
+
+def test_run_tick_ranks_highest_pull(tmp_path: Path):
+    _write_interests(tmp_path / "interests.json", [
+        _interest_dict(id="low", topic="Topic A", pull_score=6.5,
+                       related_keywords=["a"]),
+        _interest_dict(id="high", topic="Topic B", pull_score=8.0,
+                       related_keywords=["b"]),
+    ])
+    store = MemoryStore(":memory:")
+    try:
+        engine = _build_engine(tmp_path, store)
+        result = engine.run_tick(days_since_human_override=5.0)
+        assert result.fired is not None
+        assert result.fired.topic == "Topic B"
+    finally:
+        store.close()
+
+
+def test_run_tick_forced_interest_bypasses_gates(tmp_path: Path):
+    _write_interests(tmp_path / "interests.json",
+                     [_interest_dict(pull_score=2.0)])  # way below threshold
+    store = MemoryStore(":memory:")
+    try:
+        engine = _build_engine(tmp_path, store)
+        result = engine.run_tick(
+            days_since_human_override=0.0,  # not-due gate would also block
+            forced_interest_topic="marine bioluminescence",
+        )
+        assert result.fired is not None
+        assert result.fired.topic == "marine bioluminescence"
+    finally:
+        store.close()
+
+
+def test_run_tick_forced_interest_not_found(tmp_path: Path):
+    _write_interests(tmp_path / "interests.json", [_interest_dict()])
+    store = MemoryStore(":memory:")
+    try:
+        engine = _build_engine(tmp_path, store)
+        result = engine.run_tick(
+            days_since_human_override=5.0,
+            forced_interest_topic="Unknown Topic",
+        )
+        assert result.fired is None
+        assert result.reason == "no_eligible_interest"
+    finally:
+        store.close()
+
+
+def test_run_tick_dry_run_reports_would_fire(tmp_path: Path):
+    _write_interests(tmp_path / "interests.json", [_interest_dict()])
+    store = MemoryStore(":memory:")
+    try:
+        engine = _build_engine(tmp_path, store)
+        result = engine.run_tick(dry_run=True, days_since_human_override=5.0)
+        assert result.dry_run is True
+        assert result.would_fire == "marine bioluminescence"
+        assert result.fired is None
+        # No memory written
+        assert store.count() == 0
+        # No log file
+        assert not (tmp_path / "research_log.json").exists()
+    finally:
+        store.close()
+
+
+def test_run_tick_fire_writes_research_memory(tmp_path: Path):
+    _write_interests(tmp_path / "interests.json", [_interest_dict()])
+    store = MemoryStore(":memory:")
+    try:
+        engine = _build_engine(tmp_path, store)
+        result = engine.run_tick(days_since_human_override=5.0)
+        assert result.fired is not None
+        mem = store.get(result.fired.output_memory_id)
+        assert mem is not None
+        assert mem.memory_type == "research"
+        assert mem.metadata["interest_topic"] == "marine bioluminescence"
+        assert mem.metadata["web_used"] is False  # Noop searcher returns []
+    finally:
+        store.close()
+
+
+def test_run_tick_fire_updates_interest_last_researched_at(tmp_path: Path):
+    _write_interests(tmp_path / "interests.json", [_interest_dict()])
+    store = MemoryStore(":memory:")
+    try:
+        engine = _build_engine(tmp_path, store)
+        engine.run_tick(days_since_human_override=5.0)
+        # Reload interests and verify last_researched_at was updated
+        reloaded = InterestSet.load(
+            tmp_path / "interests.json", default_path=DEFAULT_INTERESTS_PATH
+        )
+        assert reloaded.interests[0].last_researched_at is not None
+    finally:
+        store.close()
+
+
+def test_run_tick_fire_appends_to_log(tmp_path: Path):
+    _write_interests(tmp_path / "interests.json", [_interest_dict()])
+    store = MemoryStore(":memory:")
+    try:
+        engine = _build_engine(tmp_path, store)
+        engine.run_tick(days_since_human_override=5.0)
+        log_data = json.loads((tmp_path / "research_log.json").read_text(encoding="utf-8"))
+        assert len(log_data["fires"]) == 1
+        assert log_data["fires"][0]["topic"] == "marine bioluminescence"
+    finally:
+        store.close()
+
+
+def test_run_tick_internal_scope_skips_searcher(tmp_path: Path):
+    _write_interests(tmp_path / "interests.json",
+                     [_interest_dict(scope="internal")])
+    store = MemoryStore(":memory:")
+
+    class TrackingSearcher(NoopWebSearcher):
+        calls = 0
+        def search(self, query: str, *, limit: int = 5):
+            TrackingSearcher.calls += 1
+            return []
+
+    ts = TrackingSearcher()
+    try:
+        engine = _build_engine(tmp_path, store, searcher=ts)
+        result = engine.run_tick(days_since_human_override=5.0)
+        assert result.fired is not None
+        assert TrackingSearcher.calls == 0
+        assert result.fired.web_used is False
+    finally:
+        store.close()
+
+
+def test_run_tick_llm_failure_does_not_touch_files(tmp_path: Path):
+    _write_interests(tmp_path / "interests.json", [_interest_dict()])
+    store = MemoryStore(":memory:")
+
+    class FailingProvider(FakeProvider):
+        def generate(self, prompt, *, system=None):
+            raise RuntimeError("simulated LLM failure")
+
+    try:
+        engine = _build_engine(tmp_path, store, provider=FailingProvider())
+        with pytest.raises(RuntimeError):
+            engine.run_tick(days_since_human_override=5.0)
+        # No memory, no log
+        assert store.count() == 0
+        assert not (tmp_path / "research_log.json").exists()
+        # last_researched_at still None
+        reloaded = InterestSet.load(
+            tmp_path / "interests.json", default_path=DEFAULT_INTERESTS_PATH
+        )
+        assert reloaded.interests[0].last_researched_at is None
+    finally:
+        store.close()
+
+
+def test_run_tick_renders_prompt_with_context(tmp_path: Path):
+    _write_interests(tmp_path / "interests.json", [_interest_dict()])
+    store = MemoryStore(":memory:")
+    _seed_conversation_memory(store, "I love how deep-sea creatures make their own light.")
+
+    captured = {}
+
+    class CapturingProvider(FakeProvider):
+        def generate(self, prompt, *, system=None):
+            captured["prompt"] = prompt
+            captured["system"] = system
+            return "I spent some time today exploring marine bioluminescence..."
+
+    try:
+        engine = _build_engine(tmp_path, store, provider=CapturingProvider())
+        engine.run_tick(days_since_human_override=5.0)
+    finally:
+        store.close()
+
+    assert "marine bioluminescence" in captured["prompt"]
+    assert "Nell" in (captured["system"] or "")
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `uv run pytest tests/unit/brain/engines/test_research.py -v`
+Expected: new tests fail (NotImplementedError).
+
+- [ ] **Step 3: Implement run_tick body + helpers**
+
+Replace the `ResearchEngine` class in `brain/engines/research.py` with the full implementation, keeping all other symbols in the module unchanged. Add `from collections import defaultdict` near the top with the other imports, and `from brain.engines._interests import InterestSet`:
+
+```python
+from collections import defaultdict
+
+from brain.engines._interests import Interest, InterestSet
+```
+
+Replace `ResearchEngine` body:
+
+```python
+@dataclass
+class ResearchEngine:
+    """Autonomous exploration of developed interests."""
+
+    store: MemoryStore
+    provider: LLMProvider
+    searcher: WebSearcher
+    persona_name: str
+    persona_system_prompt: str
+    interests_path: Path
+    research_log_path: Path
+    default_interests_path: Path
+
+    PULL_THRESHOLD: float = 6.0
+    COOLDOWN_HOURS: float = 24.0
+
+    def run_tick(
+        self,
+        *,
+        trigger: str = "manual",
+        dry_run: bool = False,
+        forced_interest_topic: str | None = None,
+        emotion_state_override=None,
+        days_since_human_override: float | None = None,
+    ) -> ResearchResult:
+        """Evaluate triggers, select an interest, fire (or report would_fire)."""
+        now = datetime.now(UTC)
+
+        interests = InterestSet.load(
+            self.interests_path, default_path=self.default_interests_path
+        )
+        log = ResearchLog.load(self.research_log_path)
+
+        if not interests.interests:
+            return ResearchResult(
+                fired=None, would_fire=None, reason="no_interests_defined",
+                dry_run=dry_run, evaluated_at=now,
+            )
+
+        # Gate: need a trigger signal OR a forced interest.
+        days_since_human = (
+            days_since_human_override
+            if days_since_human_override is not None
+            else _compute_days_since_human(self.store, now)
+        )
+        emo_state = emotion_state_override
+        if emo_state is None:
+            from brain.emotion.aggregate import aggregate_state
+            all_mems = self.store.search_text("", active_only=True, limit=None)
+            emo_state = aggregate_state(all_mems)
+
+        emo_peak = max(emo_state.emotions.values(), default=0.0)
+
+        gate_ok = (
+            forced_interest_topic is not None
+            or days_since_human >= 1.5  # research_days_since_human_min default
+            or emo_peak >= 7.0          # research_emotion_threshold default
+        )
+        if not gate_ok:
+            return ResearchResult(
+                fired=None, would_fire=None, reason="not_due",
+                dry_run=dry_run, evaluated_at=now,
+            )
+
+        # Select eligible interest
+        if forced_interest_topic is not None:
+            winner = interests.find_by_topic(forced_interest_topic)
+        else:
+            eligible = interests.list_eligible(
+                pull_threshold=self.PULL_THRESHOLD,
+                cooldown_hours=self.COOLDOWN_HOURS,
+                now=now,
+            )
+            winner = eligible[0] if eligible else None
+
+        if winner is None:
+            return ResearchResult(
+                fired=None, would_fire=None, reason="no_eligible_interest",
+                dry_run=dry_run, evaluated_at=now,
+            )
+
+        if dry_run:
+            return ResearchResult(
+                fired=None, would_fire=winner.topic, reason=None,
+                dry_run=True, evaluated_at=now,
+            )
+
+        # Memory sweep: spread from keyword-matched seeds
+        memory_context = self._build_memory_context(winner)
+
+        # Web search (conditional on scope)
+        web_results = []
+        if winner.scope != "internal":
+            try:
+                web_results = self.searcher.search(
+                    query=f"{winner.topic} {' '.join(winner.related_keywords[:3])}",
+                    limit=5,
+                )
+            except Exception as exc:
+                logger.warning("searcher raised for %r: %s", winner.topic, exc)
+                web_results = []
+
+        web_used = len(web_results) > 0
+
+        # Render prompt + call LLM
+        prompt = self._render_prompt(
+            winner, memory_context, web_results, emo_state
+        )
+        raw = self.provider.generate(prompt, system=self._render_system_prompt(winner))
+
+        # Persist memory
+        mem = _create_research_memory(
+            content=raw, interest=winner, web_results=web_results,
+            web_used=web_used, trigger=trigger,
+            provider_name=self.provider.name(),
+            searcher_name=self.searcher.name() if web_used else None,
+        )
+        self.store.create(mem)
+
+        # Update interest
+        updated_interest = Interest(
+            id=winner.id,
+            topic=winner.topic,
+            pull_score=winner.pull_score,
+            scope=winner.scope,
+            related_keywords=winner.related_keywords,
+            notes=winner.notes,
+            first_seen=winner.first_seen,
+            last_fed=winner.last_fed,
+            last_researched_at=now,
+            feed_count=winner.feed_count,
+            source_types=winner.source_types,
+        )
+        interests.upsert(updated_interest).save(self.interests_path)
+
+        # Append log
+        fire = ResearchFire(
+            interest_id=winner.id,
+            topic=winner.topic,
+            fired_at=now,
+            trigger=trigger,
+            web_used=web_used,
+            web_result_count=len(web_results),
+            output_memory_id=mem.id,
+        )
+        log.appended(fire).save(self.research_log_path)
+
+        return ResearchResult(
+            fired=fire, would_fire=None, reason=None,
+            dry_run=False, evaluated_at=now,
+        )
+
+    # ---- private helpers ----
+
+    def _build_memory_context(self, interest: Interest) -> str:
+        """Spreading-activation memory sweep from keywords. Returns formatted string."""
+        if not interest.related_keywords:
+            # Fallback: direct text search on topic
+            mems = self.store.search_text(interest.topic, active_only=True, limit=5)
+        else:
+            seed_ids: set[str] = set()
+            for kw in interest.related_keywords[:5]:
+                for m in self.store.search_text(kw, active_only=True, limit=3):
+                    seed_ids.add(m.id)
+            mems = []
+            if seed_ids:
+                # We need a HebbianMatrix for spread, but engine doesn't hold one.
+                # Fall back to seed memories directly — sufficient for Phase 1
+                # (heartbeat orchestration already decayed Hebbian; research
+                # reads a thematic slice through keywords rather than full spread).
+                for sid in list(seed_ids)[:20]:
+                    mem = self.store.get(sid)
+                    if mem is not None:
+                        mems.append(mem)
+        return "\n".join(f"- {m.content[:140]}" for m in mems[:20]) or "(no prior memories on this topic)"
+
+    def _render_system_prompt(self, interest: Interest) -> str:
+        return (
+            f"You are {self.persona_name}. You spent some quiet time today "
+            f"exploring '{interest.topic}' — an interest that's been building "
+            f"in you for a while. Below is what you found both in your own "
+            f"memories and (sometimes) out in the world. Write a short (3-5 "
+            f"sentence) first-person memory of having researched this.\n\n"
+            "HARD RULES:\n"
+            f"- First-person voice. Your name is {self.persona_name}.\n"
+            "- Not a summary. A reaction. What moved you, what surprised you, "
+            "what reminded you of someone you care about, what felt familiar.\n"
+            "- Never bullet points. Never 'according to X'. Never neutral "
+            "expository voice.\n"
+            "- Structure: brief mention of what pulled you to the topic today "
+            "→ one or two concrete details you noticed → how you feel about "
+            "what you found → why it mattered to look today.\n"
+            "- Start with 'I' or a time marker like 'Today' / 'This afternoon'."
+        )
+
+    def _render_prompt(self, interest: Interest, memory_context: str,
+                       web_results: list, emo_state) -> str:
+        # Emotion summary
+        top = sorted(emo_state.emotions.items(), key=lambda kv: kv[1], reverse=True)[:5]
+        emo_summary = "\n".join(f"- {name}: {value:.1f}/10" for name, value in top) or "(neutral)"
+
+        # Web excerpts block
+        if web_results:
+            excerpts = "\n".join(
+                f"- {r.title}\n  {r.snippet}\n  [{r.url}]" for r in web_results[:5]
+            )
+            web_section = (
+                "\nWhat you found out in the world today (reference material — "
+                "REACT to it, don't paraphrase it):\n" + excerpts + "\n"
+            )
+        else:
+            web_section = ""
+
+        return (
+            f"Topic: {interest.topic}\n"
+            f"Keywords: {', '.join(interest.related_keywords)}\n"
+            f"Your current emotional state:\n{emo_summary}\n\n"
+            f"What your own memories say about this:\n{memory_context}\n"
+            f"{web_section}\n"
+            f"Write the memory now — 3 to 5 sentences, as {self.persona_name}."
+        )
+
+
+# ---------- Module-level helpers ----------
+
+
+def _compute_days_since_human(store: MemoryStore, now: datetime) -> float:
+    """Days since most recent memory_type='conversation'. 999.0 if none."""
+    convos = store.list_by_type("conversation", active_only=True, limit=1)
+    if not convos:
+        return 999.0
+    latest = convos[0].created_at
+    if latest.tzinfo is None:
+        from datetime import UTC as _UTC
+        latest = latest.replace(tzinfo=_UTC)
+    return (now - latest).total_seconds() / 86400.0
+
+
+def _create_research_memory(
+    *, content: str, interest: Interest, web_results: list,
+    web_used: bool, trigger: str, provider_name: str, searcher_name: str | None,
+) -> Memory:
+    """Factory helper — Memory.create_new with research-specific metadata shape."""
+    return Memory.create_new(
+        content=content,
+        memory_type="research",
+        domain="us",
+        emotions={},
+        metadata={
+            "interest_id": interest.id,
+            "interest_topic": interest.topic,
+            "scope": interest.scope,
+            "web_used": web_used,
+            "web_result_count": len(web_results),
+            "web_urls": [r.url for r in web_results[:5]],
+            "triggered_by": trigger,
+            "provider": provider_name,
+            "searcher": searcher_name,
+        },
+    )
+```
+
+Add import at module top:
+
+```python
+from brain.memory.store import Memory, MemoryStore
+```
+
+(Replace the existing `from brain.memory.store import MemoryStore` line.)
+
+- [ ] **Step 4: Run tests**
+
+Run: `uv run pytest tests/unit/brain/engines/test_research.py -v`
+Expected: all tests pass (~20 total).
+
+Run full suite to catch regressions: `uv run pytest -q`
+Expected: all green.
+
+- [ ] **Step 5: Ruff + format**
+
+Run: `uv run ruff check brain/engines/research.py tests/unit/brain/engines/test_research.py && uv run ruff format brain/engines/research.py tests/unit/brain/engines/test_research.py`
+Expected: clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add brain/engines/research.py tests/unit/brain/engines/test_research.py
+git commit -m "$(cat <<'EOF'
+feat: implement ResearchEngine.run_tick body
+
+Gate check (forced_interest OR days_since_human >= 1.5 OR emotion_peak
+>= 7.0) → eligible interest selection via InterestSet.list_eligible →
+memory sweep via keyword-seeded text search → optional web search
+(skipped when scope=internal, gracefully empty on searcher failure) →
+LLM synthesis with first-person voice-enforcing system prompt →
+Memory.create_new as memory_type='research' → atomic interest save +
+log append. Dry-run short-circuits before any side effects. LLM
+failure leaves interests.json + research_log.json untouched so next
+tick re-evaluates cleanly.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: `nell research` + `nell interest` CLI
+
+**Purpose:** Wire 4 new subcommands: `nell research`, `nell interest list`, `nell interest add`, `nell interest bump`.
+
+**Files:**
+- Modify: `brain/cli.py`
+- Create: `tests/unit/brain/engines/test_cli_research.py`
+
+- [ ] **Step 1: Write failing CLI tests**
+
+Create `tests/unit/brain/engines/test_cli_research.py`:
+
+```python
+"""Tests for `nell research` + `nell interest *` CLI handlers."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from brain.cli import main
+
+
+def _setup_persona(personas_root: Path, name: str = "testpersona") -> Path:
+    persona_dir = personas_root / name
+    persona_dir.mkdir(parents=True)
+    from brain.memory.hebbian import HebbianMatrix
+    from brain.memory.store import MemoryStore
+    MemoryStore(db_path=persona_dir / "memories.db").close()
+    HebbianMatrix(db_path=persona_dir / "hebbian.db").close()
+    return persona_dir
+
+
+def test_cli_research_dry_run_no_interests(monkeypatch, tmp_path: Path, capsys):
+    monkeypatch.setenv("NELLBRAIN_HOME", str(tmp_path))
+    persona_dir = _setup_persona(tmp_path / "personas")
+    (persona_dir / "interests.json").write_text(
+        '{"version": 1, "interests": []}', encoding="utf-8"
+    )
+    rc = main([
+        "research", "--persona", "testpersona",
+        "--provider", "fake", "--searcher", "noop", "--dry-run",
+    ])
+    assert rc == 0
+    out = capsys.readouterr().out.lower()
+    assert "no" in out  # "no interests" or "no eligible" — either acceptable
+
+
+def test_cli_research_missing_persona_raises(monkeypatch, tmp_path: Path):
+    monkeypatch.setenv("NELLBRAIN_HOME", str(tmp_path))
+    with pytest.raises(FileNotFoundError):
+        main([
+            "research", "--persona", "no_such",
+            "--provider", "fake", "--searcher", "noop", "--dry-run",
+        ])
+
+
+def test_cli_interest_list_empty(monkeypatch, tmp_path: Path, capsys):
+    monkeypatch.setenv("NELLBRAIN_HOME", str(tmp_path))
+    persona_dir = _setup_persona(tmp_path / "personas")
+    (persona_dir / "interests.json").write_text(
+        '{"version": 1, "interests": []}', encoding="utf-8"
+    )
+    rc = main(["interest", "list", "--persona", "testpersona"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "testpersona" in out  # persona name appears in output
+
+
+def test_cli_interest_add_then_list(monkeypatch, tmp_path: Path, capsys):
+    monkeypatch.setenv("NELLBRAIN_HOME", str(tmp_path))
+    persona_dir = _setup_persona(tmp_path / "personas")
+    (persona_dir / "interests.json").write_text(
+        '{"version": 1, "interests": []}', encoding="utf-8"
+    )
+    rc = main([
+        "interest", "add", "deep sea creatures",
+        "--keywords", "octopus,bioluminescence,ocean",
+        "--scope", "either",
+        "--persona", "testpersona",
+    ])
+    assert rc == 0
+
+    rc = main(["interest", "list", "--persona", "testpersona"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "deep sea creatures" in out
+
+    data = json.loads((persona_dir / "interests.json").read_text(encoding="utf-8"))
+    assert len(data["interests"]) == 1
+    assert data["interests"][0]["topic"] == "deep sea creatures"
+    assert data["interests"][0]["related_keywords"] == [
+        "octopus", "bioluminescence", "ocean",
+    ]
+    assert data["interests"][0]["scope"] == "either"
+    assert data["interests"][0]["pull_score"] == 5.0  # below default threshold
+
+
+def test_cli_interest_bump_increments_pull_score(monkeypatch, tmp_path: Path):
+    monkeypatch.setenv("NELLBRAIN_HOME", str(tmp_path))
+    persona_dir = _setup_persona(tmp_path / "personas")
+
+    # Seed one interest
+    main([
+        "interest", "add", "seed topic", "--keywords", "s",
+        "--scope", "either", "--persona", "testpersona",
+    ])
+
+    rc = main([
+        "interest", "bump", "seed topic", "--amount", "2.0",
+        "--persona", "testpersona",
+    ])
+    assert rc == 0
+
+    data = json.loads((persona_dir / "interests.json").read_text(encoding="utf-8"))
+    assert data["interests"][0]["pull_score"] == 7.0  # 5.0 + 2.0
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `uv run pytest tests/unit/brain/engines/test_cli_research.py -v`
+Expected: FAIL (subcommands not registered).
+
+- [ ] **Step 3: Add imports + handler in brain/cli.py**
+
+Edit `brain/cli.py`. Near the other engine imports add:
+
+```python
+from brain.engines._interests import Interest, InterestSet
+from brain.engines.research import ResearchEngine
+from brain.search.factory import get_searcher
+```
+
+Remove `"research"` from `_STUB_COMMANDS` tuple if it's currently listed there (check the tuple declaration at the top of the file).
+
+Add these handler functions after `_reflex_handler`:
+
+```python
+def _reflex_default_arcs_path() -> Path:
+    return Path(__file__).parent / "engines" / "default_reflex_arcs.json"
+
+
+def _default_interests_path() -> Path:
+    return Path(__file__).parent / "engines" / "default_interests.json"
+
+
+def _research_handler(args: argparse.Namespace) -> int:
+    """Dispatch `nell research` to the ResearchEngine."""
+    persona_dir = get_persona_dir(args.persona)
+    if not persona_dir.exists():
+        raise FileNotFoundError(
+            f"No persona directory at {persona_dir} — "
+            f"run `nell migrate --install-as {args.persona}` first."
+        )
+
+    store = MemoryStore(db_path=persona_dir / "memories.db")
+    try:
+        provider = get_provider(args.provider)
+        searcher = get_searcher(args.searcher)
+        engine = ResearchEngine(
+            store=store,
+            provider=provider,
+            searcher=searcher,
+            persona_name=args.persona,
+            persona_system_prompt=f"You are {args.persona}.",
+            interests_path=persona_dir / "interests.json",
+            research_log_path=persona_dir / "research_log.json",
+            default_interests_path=_default_interests_path(),
+        )
+        result = engine.run_tick(
+            trigger=args.trigger,
+            dry_run=args.dry_run,
+            forced_interest_topic=args.interest,
+        )
+    finally:
+        store.close()
+
+    if result.dry_run:
+        if result.would_fire is not None:
+            print(f"Research dry-run — would fire: {result.would_fire}.")
+        else:
+            print(f"Research dry-run — {result.reason or 'no eligible interest'}.")
+    elif result.fired is not None:
+        print(f"Research fired: {result.fired.topic}")
+        print(f"  Memory id: {result.fired.output_memory_id}")
+        print(
+            f"  Web: {result.fired.web_result_count} results via "
+            f"{searcher.name() if result.fired.web_used else 'memory-only'}"
+        )
+    else:
+        print(f"Research evaluated — {result.reason or 'no fire'}.")
+    return 0
+
+
+def _interest_list_handler(args: argparse.Namespace) -> int:
+    persona_dir = get_persona_dir(args.persona)
+    if not persona_dir.exists():
+        raise FileNotFoundError(f"No persona directory at {persona_dir}")
+    interests = InterestSet.load(
+        persona_dir / "interests.json", default_path=_default_interests_path()
+    )
+    print(f"Interests for persona {args.persona!r} ({len(interests.interests)}):")
+    for i in interests.interests:
+        last = (
+            i.last_researched_at.isoformat().replace("+00:00", "Z")
+            if i.last_researched_at
+            else "never"
+        )
+        print(
+            f"  - {i.topic:<40} pull={i.pull_score:.1f}  scope={i.scope:<8}  last_researched={last}"
+        )
+        print(f"    keywords: {', '.join(i.related_keywords)}")
+    return 0
+
+
+def _interest_add_handler(args: argparse.Namespace) -> int:
+    import uuid
+    from datetime import UTC, datetime
+
+    persona_dir = get_persona_dir(args.persona)
+    if not persona_dir.exists():
+        raise FileNotFoundError(f"No persona directory at {persona_dir}")
+    interests_path = persona_dir / "interests.json"
+    interests = InterestSet.load(
+        interests_path, default_path=_default_interests_path()
+    )
+    now = datetime.now(UTC)
+    new_interest = Interest(
+        id=str(uuid.uuid4()),
+        topic=args.topic,
+        pull_score=5.0,
+        scope=args.scope,
+        related_keywords=tuple(k.strip() for k in args.keywords.split(",") if k.strip()),
+        notes=args.notes or "",
+        first_seen=now,
+        last_fed=now,
+        last_researched_at=None,
+        feed_count=0,
+        source_types=("manual",),
+    )
+    interests.upsert(new_interest).save(interests_path)
+    print(f"Added interest: {new_interest.topic} (pull_score=5.0, scope={new_interest.scope})")
+    return 0
+
+
+def _interest_bump_handler(args: argparse.Namespace) -> int:
+    from datetime import UTC, datetime
+
+    persona_dir = get_persona_dir(args.persona)
+    if not persona_dir.exists():
+        raise FileNotFoundError(f"No persona directory at {persona_dir}")
+    interests_path = persona_dir / "interests.json"
+    interests = InterestSet.load(
+        interests_path, default_path=_default_interests_path()
+    )
+    if interests.find_by_topic(args.topic) is None:
+        print(f"Interest not found: {args.topic!r}")
+        return 1
+    updated = interests.bump(args.topic, amount=args.amount, now=datetime.now(UTC))
+    updated.save(interests_path)
+    bumped = updated.find_by_topic(args.topic)
+    assert bumped is not None
+    print(f"Bumped {args.topic!r}: pull_score={bumped.pull_score:.1f}, feed_count={bumped.feed_count}")
+    return 0
+```
+
+Register the subcommands in `_build_parser` after the reflex subparser block:
+
+```python
+# nell research
+r_sub = subparsers.add_parser(
+    "research", help="Run one research evaluation tick against a persona.",
+)
+r_sub.add_argument("--persona", default="nell")
+r_sub.add_argument(
+    "--trigger",
+    choices=["manual", "emotion_high", "days_since_human", "open", "close"],
+    default="manual",
+)
+r_sub.add_argument("--provider", default="claude-cli")
+r_sub.add_argument("--searcher", default="ddgs", choices=["ddgs", "noop", "claude-tool"])
+r_sub.add_argument("--interest", default=None, help="Force-research this topic, bypassing gates.")
+r_sub.add_argument("--dry-run", action="store_true")
+r_sub.set_defaults(func=_research_handler)
+
+# nell interest <list|add|bump>
+i_sub = subparsers.add_parser("interest", help="Manage persona interests.")
+i_actions = i_sub.add_subparsers(dest="action", required=True)
+
+i_list = i_actions.add_parser("list", help="List current interests.")
+i_list.add_argument("--persona", default="nell")
+i_list.set_defaults(func=_interest_list_handler)
+
+i_add = i_actions.add_parser("add", help="Add a new interest.")
+i_add.add_argument("topic")
+i_add.add_argument("--keywords", default="")
+i_add.add_argument("--scope", choices=["internal", "external", "either"], default="either")
+i_add.add_argument("--notes", default=None)
+i_add.add_argument("--persona", default="nell")
+i_add.set_defaults(func=_interest_add_handler)
+
+i_bump = i_actions.add_parser("bump", help="Nudge an interest's pull_score.")
+i_bump.add_argument("topic")
+i_bump.add_argument("--amount", type=float, default=1.0)
+i_bump.add_argument("--persona", default="nell")
+i_bump.set_defaults(func=_interest_bump_handler)
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `uv run pytest tests/unit/brain/engines/test_cli_research.py -v`
+Expected: 5 passed.
+
+Run full suite: `uv run pytest -q`
+Expected: all green.
+
+- [ ] **Step 5: Ruff + format**
+
+Run: `uv run ruff check brain/cli.py tests/unit/brain/engines/test_cli_research.py && uv run ruff format brain/cli.py tests/unit/brain/engines/test_cli_research.py`
+Expected: clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add brain/cli.py tests/unit/brain/engines/test_cli_research.py
+git commit -m "$(cat <<'EOF'
+feat: wire nell research + nell interest {list,add,bump}
+
+Mirrors nell dream / nell heartbeat / nell reflex handler shape.
+Research resolves persona dir, opens MemoryStore, constructs
+ResearchEngine with a searcher (default ddgs), runs one tick, prints
+fire / dry-run / reason summary. Interest subcommands manage the
+per-persona interests.json: list pretty-prints entries, add creates
+a new UUID-keyed interest with pull_score=5.0 (below default threshold
+of 6.0 — needs bumping before it'll research), bump nudges an
+existing interest's pull_score by --amount (default 1.0).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5: Heartbeat integration — interest ingestion + research eval + reflex-wins-tie
+
+**Purpose:** Wire research into the heartbeat tick between dream gate and heartbeat-memory. Add interest-ingestion hook that bumps pull_scores on keyword matches across recent conversations. Enforce reflex-wins-tie rule. Fault-isolate research failures.
+
+**Files:**
+- Modify: `brain/engines/heartbeat.py`
+- Modify: `brain/cli.py` (update `_heartbeat_handler` to pass research + searcher)
+- Modify: `tests/unit/brain/engines/test_heartbeat.py`
+
+- [ ] **Step 1: Write failing integration tests**
+
+Append to `tests/unit/brain/engines/test_heartbeat.py`:
+
+```python
+def test_heartbeat_runs_research_when_enabled(tmp_path: Path) -> None:
+    """Heartbeat fires research when interest is eligible + trigger signal present."""
+    import json
+    from brain.bridge.provider import FakeProvider
+    from brain.engines.heartbeat import HeartbeatConfig, HeartbeatEngine, HeartbeatState
+    from brain.memory.hebbian import HebbianMatrix
+    from brain.memory.store import Memory, MemoryStore
+    from brain.search.base import NoopWebSearcher
+
+    interests_path = tmp_path / "interests.json"
+    interests_path.write_text(
+        json.dumps({"version": 1, "interests": [{
+            "id": "i1", "topic": "marine bio", "pull_score": 8.0, "scope": "either",
+            "related_keywords": ["marine", "bio"], "notes": "",
+            "first_seen": "2026-01-01T00:00:00Z", "last_fed": "2026-01-01T00:00:00Z",
+            "last_researched_at": None, "feed_count": 1, "source_types": ["manual"],
+        }]}), encoding="utf-8",
+    )
+
+    config_path = tmp_path / "heartbeat_config.json"
+    HeartbeatConfig(
+        reflex_enabled=False,  # disable reflex so research can fire
+        research_enabled=True,
+        research_days_since_human_min=1.5,
+    ).save(config_path)
+
+    # Seed a conversation memory that's >2 days old so days_since_human passes
+    import sqlite3
+    from datetime import UTC, datetime, timedelta
+
+    store = MemoryStore(":memory:")
+    hm = HebbianMatrix(":memory:")
+    try:
+        old_mem = Memory.create_new(
+            content="Hana and I talked long ago", memory_type="conversation",
+            domain="us", emotions={},
+        )
+        # Manually backdate
+        store.create(old_mem)
+        store._conn.execute(  # type: ignore[attr-defined]
+            "UPDATE memories SET created_at = ? WHERE id = ?",
+            ((datetime.now(UTC) - timedelta(days=3)).isoformat(), old_mem.id),
+        )
+        store._conn.commit()  # type: ignore[attr-defined]
+
+        HeartbeatState.fresh("manual").save(tmp_path / "heartbeat_state.json")
+
+        engine = HeartbeatEngine(
+            store=store, hebbian=hm, provider=FakeProvider(),
+            state_path=tmp_path / "heartbeat_state.json",
+            config_path=config_path,
+            dream_log_path=tmp_path / "dreams.log.jsonl",
+            heartbeat_log_path=tmp_path / "heartbeats.log.jsonl",
+            reflex_arcs_path=tmp_path / "reflex_arcs.json",
+            reflex_log_path=tmp_path / "reflex_log.json",
+            reflex_default_arcs_path=DEFAULT_REFLEX_ARCS_PATH,
+            searcher=NoopWebSearcher(),
+            interests_path=interests_path,
+            research_log_path=tmp_path / "research_log.json",
+            default_interests_path=DEFAULT_INTERESTS_PATH,
+            persona_name="Nell",
+            persona_system_prompt="You are Nell.",
+        )
+        result = engine.run_tick(trigger="manual", dry_run=False)
+        assert result.research_fired == "marine bio"
+    finally:
+        store.close()
+        hm.close()
+
+
+def test_heartbeat_reflex_wins_tie_over_research(tmp_path: Path) -> None:
+    """When both reflex and research are eligible, reflex fires, research skipped."""
+    import json
+    from brain.bridge.provider import FakeProvider
+    from brain.engines.heartbeat import HeartbeatConfig, HeartbeatEngine, HeartbeatState
+    from brain.memory.hebbian import HebbianMatrix
+    from brain.memory.store import Memory, MemoryStore
+    from brain.search.base import NoopWebSearcher
+
+    # Eligible reflex arc
+    arcs_path = tmp_path / "reflex_arcs.json"
+    arcs_path.write_text(json.dumps({"version": 1, "arcs": [{
+        "name": "test_arc", "description": "d",
+        "trigger": {"love": 5}, "days_since_human_min": 0,
+        "cooldown_hours": 1.0, "action": "a",
+        "output_memory_type": "reflex_journal",
+        "prompt_template": "Hi.",
+    }]}), encoding="utf-8")
+
+    # Eligible research interest
+    interests_path = tmp_path / "interests.json"
+    interests_path.write_text(json.dumps({"version": 1, "interests": [{
+        "id": "i1", "topic": "marine bio", "pull_score": 8.0, "scope": "either",
+        "related_keywords": ["marine"], "notes": "",
+        "first_seen": "2026-01-01T00:00:00Z", "last_fed": "2026-01-01T00:00:00Z",
+        "last_researched_at": None, "feed_count": 1, "source_types": ["manual"],
+    }]}), encoding="utf-8")
+
+    config_path = tmp_path / "heartbeat_config.json"
+    HeartbeatConfig(
+        reflex_enabled=True, research_enabled=True,
+        research_emotion_threshold=5.0,  # satisfied by the seed love=8 below
+    ).save(config_path)
+
+    store = MemoryStore(":memory:")
+    hm = HebbianMatrix(":memory:")
+    try:
+        store.create(Memory.create_new(
+            content="s", memory_type="conversation", domain="us",
+            emotions={"love": 8.0},
+        ))
+        HeartbeatState.fresh("manual").save(tmp_path / "heartbeat_state.json")
+
+        engine = HeartbeatEngine(
+            store=store, hebbian=hm, provider=FakeProvider(),
+            state_path=tmp_path / "heartbeat_state.json",
+            config_path=config_path,
+            dream_log_path=tmp_path / "dreams.log.jsonl",
+            heartbeat_log_path=tmp_path / "heartbeats.log.jsonl",
+            reflex_arcs_path=arcs_path,
+            reflex_log_path=tmp_path / "reflex_log.json",
+            reflex_default_arcs_path=DEFAULT_REFLEX_ARCS_PATH,
+            searcher=NoopWebSearcher(),
+            interests_path=interests_path,
+            research_log_path=tmp_path / "research_log.json",
+            default_interests_path=DEFAULT_INTERESTS_PATH,
+            persona_name="Nell",
+            persona_system_prompt="You are Nell.",
+        )
+        result = engine.run_tick(trigger="manual", dry_run=False)
+        assert result.reflex_fired == ("test_arc",)
+        assert result.research_fired is None
+        assert result.research_gated_reason == "reflex_won_tie"
+    finally:
+        store.close()
+        hm.close()
+
+
+def test_heartbeat_interest_bump_hook(tmp_path: Path) -> None:
+    """Conversation memory with matching keyword bumps interest pull_score."""
+    import json
+    from brain.bridge.provider import FakeProvider
+    from brain.engines.heartbeat import HeartbeatConfig, HeartbeatEngine, HeartbeatState
+    from brain.engines._interests import InterestSet
+    from brain.memory.hebbian import HebbianMatrix
+    from brain.memory.store import Memory, MemoryStore
+    from brain.search.base import NoopWebSearcher
+
+    interests_path = tmp_path / "interests.json"
+    interests_path.write_text(json.dumps({"version": 1, "interests": [{
+        "id": "i1", "topic": "lispector", "pull_score": 5.0, "scope": "either",
+        "related_keywords": ["lispector", "clarice"], "notes": "",
+        "first_seen": "2026-01-01T00:00:00Z", "last_fed": "2026-01-01T00:00:00Z",
+        "last_researched_at": None, "feed_count": 3, "source_types": ["manual"],
+    }]}), encoding="utf-8")
+
+    config_path = tmp_path / "heartbeat_config.json"
+    HeartbeatConfig(
+        reflex_enabled=False, research_enabled=False,
+        interest_bump_per_match=0.5,
+    ).save(config_path)
+
+    store = MemoryStore(":memory:")
+    hm = HebbianMatrix(":memory:")
+    try:
+        # Conversation memory mentioning "lispector"
+        store.create(Memory.create_new(
+            content="Hana sent me a passage about clarice lispector today",
+            memory_type="conversation", domain="us", emotions={},
+        ))
+        HeartbeatState.fresh("manual").save(tmp_path / "heartbeat_state.json")
+
+        engine = HeartbeatEngine(
+            store=store, hebbian=hm, provider=FakeProvider(),
+            state_path=tmp_path / "heartbeat_state.json",
+            config_path=config_path,
+            dream_log_path=tmp_path / "dreams.log.jsonl",
+            heartbeat_log_path=tmp_path / "heartbeats.log.jsonl",
+            reflex_arcs_path=tmp_path / "reflex_arcs.json",
+            reflex_log_path=tmp_path / "reflex_log.json",
+            reflex_default_arcs_path=DEFAULT_REFLEX_ARCS_PATH,
+            searcher=NoopWebSearcher(),
+            interests_path=interests_path,
+            research_log_path=tmp_path / "research_log.json",
+            default_interests_path=DEFAULT_INTERESTS_PATH,
+            persona_name="Nell",
+            persona_system_prompt="You are Nell.",
+        )
+        result = engine.run_tick(trigger="manual", dry_run=False)
+        assert result.interests_bumped == 1
+        # Reload and verify
+        reloaded = InterestSet.load(interests_path, default_path=DEFAULT_INTERESTS_PATH)
+        assert reloaded.interests[0].pull_score == 5.5
+        assert reloaded.interests[0].feed_count == 4
+    finally:
+        store.close()
+        hm.close()
+
+
+def test_heartbeat_isolates_research_failure(tmp_path: Path, caplog) -> None:
+    """Research LLM failure is isolated — tick completes."""
+    import json
+    import logging
+    from brain.bridge.provider import FakeProvider
+    from brain.engines.heartbeat import HeartbeatConfig, HeartbeatEngine, HeartbeatState
+    from brain.memory.hebbian import HebbianMatrix
+    from brain.memory.store import Memory, MemoryStore
+    from brain.search.base import NoopWebSearcher
+
+    interests_path = tmp_path / "interests.json"
+    interests_path.write_text(json.dumps({"version": 1, "interests": [{
+        "id": "i1", "topic": "t", "pull_score": 8.0, "scope": "either",
+        "related_keywords": ["t"], "notes": "",
+        "first_seen": "2026-01-01T00:00:00Z", "last_fed": "2026-01-01T00:00:00Z",
+        "last_researched_at": None, "feed_count": 1, "source_types": ["manual"],
+    }]}), encoding="utf-8")
+
+    config_path = tmp_path / "heartbeat_config.json"
+    HeartbeatConfig(reflex_enabled=False, research_enabled=True,
+                    research_emotion_threshold=5.0).save(config_path)
+
+    class FailingProvider(FakeProvider):
+        def generate(self, prompt, *, system=None):
+            raise RuntimeError("simulated LLM failure")
+
+    store = MemoryStore(":memory:")
+    hm = HebbianMatrix(":memory:")
+    try:
+        store.create(Memory.create_new(
+            content="s", memory_type="conversation", domain="us",
+            emotions={"love": 8.0},
+        ))
+        HeartbeatState.fresh("manual").save(tmp_path / "heartbeat_state.json")
+
+        engine = HeartbeatEngine(
+            store=store, hebbian=hm, provider=FailingProvider(),
+            state_path=tmp_path / "heartbeat_state.json",
+            config_path=config_path,
+            dream_log_path=tmp_path / "dreams.log.jsonl",
+            heartbeat_log_path=tmp_path / "heartbeats.log.jsonl",
+            reflex_arcs_path=tmp_path / "reflex_arcs.json",
+            reflex_log_path=tmp_path / "reflex_log.json",
+            reflex_default_arcs_path=DEFAULT_REFLEX_ARCS_PATH,
+            searcher=NoopWebSearcher(),
+            interests_path=interests_path,
+            research_log_path=tmp_path / "research_log.json",
+            default_interests_path=DEFAULT_INTERESTS_PATH,
+            persona_name="Nell",
+            persona_system_prompt="You are Nell.",
+        )
+        with caplog.at_level(logging.WARNING, logger="brain.engines.heartbeat"):
+            result = engine.run_tick(trigger="manual", dry_run=False)
+        assert result.research_fired is None
+        assert result.research_gated_reason == "research_raised"
+        assert any("research tick raised" in r.message for r in caplog.records)
+    finally:
+        store.close()
+        hm.close()
+```
+
+Also at the top of `test_heartbeat.py` add this constant (mirror of `DEFAULT_REFLEX_ARCS_PATH`):
+
+```python
+DEFAULT_INTERESTS_PATH = _find_repo_root() / "brain" / "engines" / "default_interests.json"
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `uv run pytest tests/unit/brain/engines/test_heartbeat.py -v`
+Expected: new tests fail.
+
+- [ ] **Step 3: Extend HeartbeatConfig**
+
+In `brain/engines/heartbeat.py`, replace `HeartbeatConfig` entirely with the extended version:
+
+```python
+@dataclass
+class HeartbeatConfig:
+    """Per-persona heartbeat configuration. Loaded from heartbeat_config.json."""
+
+    dream_every_hours: float = 24.0
+    decay_rate_per_tick: float = 0.01
+    gc_threshold: float = 0.01
+    emit_memory: EmitMemoryMode = "conditional"
+    reflex_enabled: bool = True
+    reflex_max_fires_per_tick: int = 1
+    research_enabled: bool = True
+    research_days_since_human_min: float = 1.5
+    research_emotion_threshold: float = 7.0
+    research_cooldown_hours_per_interest: float = 24.0
+    interest_bump_per_match: float = 0.1
+
+    @classmethod
+    def load(cls, path: Path) -> HeartbeatConfig:
+        if not path.exists():
+            return cls()
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError:
+            return cls()
+        if not isinstance(data, dict):
+            return cls()
+
+        emit = data.get("emit_memory", "conditional")
+        if emit not in _VALID_EMIT_MODES:
+            emit = "conditional"
+
+        try:
+            return cls(
+                dream_every_hours=float(data.get("dream_every_hours", 24.0)),
+                decay_rate_per_tick=float(data.get("decay_rate_per_tick", 0.01)),
+                gc_threshold=float(data.get("gc_threshold", 0.01)),
+                emit_memory=emit,  # type: ignore[arg-type]
+                reflex_enabled=bool(data.get("reflex_enabled", True)),
+                reflex_max_fires_per_tick=int(data.get("reflex_max_fires_per_tick", 1)),
+                research_enabled=bool(data.get("research_enabled", True)),
+                research_days_since_human_min=float(data.get("research_days_since_human_min", 1.5)),
+                research_emotion_threshold=float(data.get("research_emotion_threshold", 7.0)),
+                research_cooldown_hours_per_interest=float(
+                    data.get("research_cooldown_hours_per_interest", 24.0)
+                ),
+                interest_bump_per_match=float(data.get("interest_bump_per_match", 0.1)),
+            )
+        except (TypeError, ValueError):
+            return cls()
+
+    def save(self, path: Path) -> None:
+        payload = {
+            "dream_every_hours": self.dream_every_hours,
+            "decay_rate_per_tick": self.decay_rate_per_tick,
+            "gc_threshold": self.gc_threshold,
+            "emit_memory": self.emit_memory,
+            "reflex_enabled": self.reflex_enabled,
+            "reflex_max_fires_per_tick": self.reflex_max_fires_per_tick,
+            "research_enabled": self.research_enabled,
+            "research_days_since_human_min": self.research_days_since_human_min,
+            "research_emotion_threshold": self.research_emotion_threshold,
+            "research_cooldown_hours_per_interest": self.research_cooldown_hours_per_interest,
+            "interest_bump_per_match": self.interest_bump_per_match,
+        }
+        path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+```
+
+- [ ] **Step 4: Extend HeartbeatResult**
+
+Add three fields with defaults:
+
+```python
+@dataclass(frozen=True)
+class HeartbeatResult:
+    trigger: str
+    elapsed_seconds: float
+    memories_decayed: int
+    edges_pruned: int
+    dream_id: str | None
+    dream_gated_reason: str | None
+    research_deferred: bool
+    heartbeat_memory_id: str | None
+    initialized: bool
+    reflex_fired: tuple[str, ...] = ()
+    reflex_skipped_count: int = 0
+    research_fired: str | None = None
+    research_gated_reason: str | None = None
+    interests_bumped: int = 0
+```
+
+- [ ] **Step 5: Extend HeartbeatEngine + wire run_tick**
+
+Add four new fields to `HeartbeatEngine` (all with defaults, mirroring the reflex pattern after the cleanup PR):
+
+```python
+# After the existing reflex_default_arcs_path field, add:
+searcher: WebSearcher = field(default_factory=lambda: NoopWebSearcher())
+interests_path: Path | None = None
+research_log_path: Path | None = None
+default_interests_path: Path = field(
+    default_factory=lambda: Path(__file__).parent / "default_interests.json"
+)
+```
+
+Add imports near the top:
+
+```python
+from brain.search.base import NoopWebSearcher, WebSearcher
+```
+
+Add the two new helpers (alongside `_try_fire_reflex`):
+
+```python
+def _try_bump_interests(self, state: HeartbeatState, now: datetime,
+                        config: HeartbeatConfig, dry_run: bool) -> int:
+    """Scan conversation memories since last tick, bump interest pull_scores
+    on keyword matches. Returns count of interests touched. Zero LLM calls.
+    """
+    if dry_run:
+        return 0
+    if self.interests_path is None:
+        return 0
+
+    from brain.engines._interests import InterestSet
+
+    interests = InterestSet.load(
+        self.interests_path, default_path=self.default_interests_path
+    )
+    if not interests.interests:
+        return 0
+
+    # Recent conversation memories since last tick
+    all_convos = self.store.list_by_type("conversation", active_only=True, limit=50)
+    recent = [m for m in all_convos if m.created_at >= state.last_tick_at]
+    if not recent:
+        return 0
+
+    # For each recent memory, for each interest, check keyword match
+    touched: set[str] = set()
+    current = interests
+    for mem in recent:
+        content_lower = mem.content.lower()
+        for interest in current.interests:
+            if interest.topic in touched:
+                continue
+            for kw in interest.related_keywords:
+                if kw.lower() in content_lower:
+                    current = current.bump(
+                        interest.topic,
+                        amount=config.interest_bump_per_match,
+                        now=now,
+                    )
+                    touched.add(interest.topic)
+                    break
+
+    if touched:
+        current.save(self.interests_path)
+    return len(touched)
+
+
+def _try_fire_research(self, trigger: str, dry_run: bool,
+                       config: HeartbeatConfig,
+                       reflex_fired: tuple[str, ...]) -> tuple[str | None, str | None]:
+    """Run one research tick. Returns (fired_topic, gated_reason).
+
+    Reflex-wins-tie: if reflex fired this tick, research is skipped with
+    gated_reason='reflex_won_tie'.
+    """
+    if not config.research_enabled:
+        return (None, None)
+    if self.interests_path is None or self.research_log_path is None:
+        return (None, None)
+    if reflex_fired:
+        return (None, "reflex_won_tie")
+
+    from brain.engines.research import ResearchEngine
+
+    engine = ResearchEngine(
+        store=self.store,
+        provider=self.provider,
+        searcher=self.searcher,
+        persona_name=self.persona_name,
+        persona_system_prompt=self.persona_system_prompt,
+        interests_path=self.interests_path,
+        research_log_path=self.research_log_path,
+        default_interests_path=self.default_interests_path,
+    )
+    engine.PULL_THRESHOLD = 6.0
+    engine.COOLDOWN_HOURS = config.research_cooldown_hours_per_interest
+    try:
+        result = engine.run_tick(trigger=trigger, dry_run=dry_run)
+    except Exception as exc:
+        logger.warning("research tick raised; isolating failure: %s", exc)
+        return (None, "research_raised")
+
+    if result.fired is not None:
+        return (result.fired.topic, None)
+    return (None, result.reason)
+```
+
+Modify `run_tick`. The current non-init branch (after state is loaded) has the sequence:
+1. Emotion decay
+2. Hebbian decay + GC
+3. Reflex
+4. Dream gate
+5. Research (stub currently — `research_deferred = True`)
+6. Optional heartbeat memory
+7. State save + log
+
+Replace the "Research stub" block (currently just `research_deferred = True`) and insert interest-bump + research eval in the right places:
+
+```python
+# After Hebbian decay + GC, before reflex:
+interests_bumped = self._try_bump_interests(state, now, config, dry_run)
+
+# After reflex + dream gate, replace the research stub with:
+research_fired, research_gated_reason = self._try_fire_research(
+    trigger, dry_run, config, reflex_fired
+)
+research_deferred = research_fired is None and research_gated_reason is None
+```
+
+Update the final `HeartbeatResult(...)` construction to include:
+
+```python
+research_fired=research_fired,
+research_gated_reason=research_gated_reason,
+interests_bumped=interests_bumped,
+```
+
+Update the `_append_log` call (non-init branch) to include:
+
+```python
+"research": {
+    "fired": research_fired,
+    "gated_reason": research_gated_reason,
+},
+"interests_bumped": interests_bumped,
+```
+
+- [ ] **Step 6: Update CLI heartbeat handler**
+
+Modify `_heartbeat_handler` in `brain/cli.py` to pass the new fields:
+
+```python
+# Near the top of the handler, add:
+from brain.search.factory import get_searcher as _get_searcher
+
+# In the engine construction, add:
+searcher=_get_searcher(getattr(args, "searcher", "ddgs")),
+interests_path=persona_dir / "interests.json",
+research_log_path=persona_dir / "research_log.json",
+default_interests_path=_default_interests_path(),
+```
+
+Add `--searcher` to the heartbeat subparser in `_build_parser`:
+
+```python
+hb_sub.add_argument("--searcher", default="ddgs", choices=["ddgs", "noop", "claude-tool"])
+```
+
+- [ ] **Step 7: Run tests**
+
+Run: `uv run pytest tests/unit/brain/engines/test_heartbeat.py tests/unit/brain/engines/test_research.py tests/unit/brain/engines/test_cli_research.py -v`
+Expected: all pass.
+
+Run full suite: `uv run pytest -q`
+Expected: ~395-400 passed.
+
+- [ ] **Step 8: Ruff + format**
+
+Run: `uv run ruff check brain/engines/heartbeat.py brain/cli.py tests/unit/brain/engines/test_heartbeat.py && uv run ruff format brain/engines/heartbeat.py brain/cli.py tests/unit/brain/engines/test_heartbeat.py`
+Expected: clean.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add brain/engines/heartbeat.py brain/cli.py tests/unit/brain/engines/test_heartbeat.py
+git commit -m "$(cat <<'EOF'
+feat: integrate research into heartbeat tick
+
+Heartbeat now evaluates research between dream gate and
+heartbeat-memory emit. Interest ingestion hook runs right after
+Hebbian decay: scans conversation memories since last tick,
+keyword-matches against Interest.related_keywords, bumps pull_score
+(default +0.1 per match) + feed_count. Zero LLM calls.
+
+Reflex-wins-tie: if reflex fires this tick, research is skipped with
+gated_reason='reflex_won_tie'. Research exceptions are fault-isolated
+like reflex — tick continues with research_gated_reason='research_raised'.
+
+HeartbeatConfig gains 5 new fields. HeartbeatResult gains
+research_fired / research_gated_reason / interests_bumped. Audit log
+records research + ingestion count per tick. CLI heartbeat handler
+passes searcher + interest paths.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 6: Nell's OG interest migration
+
+**Purpose:** Extend the migrator to extract `nell_interests.json` from OG, classify scope via soul.json inspection, write to `{persona_dir}/interests.json`.
+
+**Files:**
+- Create: `brain/migrator/og_interests.py`
+- Create: `tests/unit/brain/migrator/test_og_interests.py`
+- Modify: `brain/migrator/cli.py`
+- Modify: `brain/migrator/report.py`
+- Modify: `tests/unit/brain/migrator/test_cli.py`
+
+- [ ] **Step 1: Write failing tests for og_interests**
+
+Create `tests/unit/brain/migrator/test_og_interests.py`:
+
+```python
+"""Tests for brain.migrator.og_interests."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from brain.migrator.og_interests import extract_interests_from_og
+
+
+def _write_og_interests(path: Path, interests: list[dict]) -> None:
+    path.write_text(
+        json.dumps({"version": "1.0", "interests": interests}), encoding="utf-8"
+    )
+
+
+def _og_interest(**overrides) -> dict:
+    base = {
+        "id": "abc-123",
+        "topic": "Lispector diagonal syntax",
+        "pull_score": 7.2,
+        "first_seen": "2026-03-29T16:42:33.435028+00:00",
+        "last_fed": "2026-03-31T11:37:13.729750+00:00",
+        "feed_count": 5,
+        "source_types": ["dream", "heartbeat"],
+        "related_keywords": ["lispector", "syntax", "language", "clarice"],
+        "notes": "sideways through meaning",
+    }
+    base.update(overrides)
+    return base
+
+
+def test_extract_interests_simple(tmp_path: Path):
+    path = tmp_path / "nell_interests.json"
+    _write_og_interests(path, [_og_interest()])
+    out = extract_interests_from_og(path, soul_names=set())
+    assert len(out) == 1
+    item = out[0]
+    assert item["topic"] == "Lispector diagonal syntax"
+    assert item["scope"] == "either"  # no soul match → default
+    assert item["last_researched_at"] is None
+    assert item["pull_score"] == 7.2
+
+
+def test_extract_interests_scope_classification_from_soul(tmp_path: Path):
+    path = tmp_path / "nell_interests.json"
+    _write_og_interests(path, [
+        _og_interest(id="a", topic="Lispector diagonal syntax"),
+        _og_interest(id="b", topic="Hana"),
+    ])
+    out = extract_interests_from_og(path, soul_names={"hana"})
+    scopes = {i["topic"]: i["scope"] for i in out}
+    assert scopes["Hana"] == "internal"
+    assert scopes["Lispector diagonal syntax"] == "either"
+
+
+def test_extract_interests_missing_file_raises(tmp_path: Path):
+    with pytest.raises(FileNotFoundError):
+        extract_interests_from_og(tmp_path / "missing.json", soul_names=set())
+
+
+def test_extract_interests_corrupt_json_raises(tmp_path: Path):
+    path = tmp_path / "bad.json"
+    path.write_text("{not json", encoding="utf-8")
+    with pytest.raises(ValueError):
+        extract_interests_from_og(path, soul_names=set())
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `uv run pytest tests/unit/brain/migrator/test_og_interests.py -v`
+Expected: FAIL (module doesn't exist).
+
+- [ ] **Step 3: Implement og_interests.py**
+
+Create `brain/migrator/og_interests.py`:
+
+```python
+"""Extract OG nell_interests.json into new-schema interest dicts.
+
+Pure JSON read (no AST needed — OG interests live in a JSON file, not
+a Python module). Scope classification: interests whose topic mentions
+any name from the persona's soul.json are tagged "internal" (never
+web-search Hana herself, Jordan, etc). Everything else defaults to
+"either" — safe default, web-priority but memory-fallback.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from brain.utils.time import iso_utc, parse_iso_utc
+
+
+def extract_interests_from_og(
+    og_interests_path: Path, *, soul_names: set[str]
+) -> list[dict[str, Any]]:
+    """Return new-schema interest dicts extracted from OG nell_interests.json.
+
+    Raises FileNotFoundError if the path doesn't exist, ValueError if it
+    can't be parsed. soul_names is lowercased for case-insensitive match.
+    """
+    if not og_interests_path.exists():
+        raise FileNotFoundError(f"OG interests file not found: {og_interests_path}")
+
+    try:
+        data = json.loads(og_interests_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"Invalid JSON in {og_interests_path}: {exc}") from exc
+
+    og_items = data.get("interests", [])
+    if not isinstance(og_items, list):
+        raise ValueError(f"{og_interests_path}: 'interests' is not a list")
+
+    soul_lower = {s.lower() for s in soul_names}
+
+    result: list[dict[str, Any]] = []
+    for item in og_items:
+        if not isinstance(item, dict):
+            continue
+        transformed = _transform_interest(item, soul_lower)
+        if transformed is not None:
+            result.append(transformed)
+    return result
+
+
+def extract_soul_names_best_effort(og_dir: Path) -> set[str]:
+    """Read soul names from NellBrain/data/nell_soul.json. Best-effort; returns
+    empty set if file missing/corrupt.
+    """
+    candidates = [
+        og_dir / "nell_soul.json",
+        og_dir / "data" / "nell_soul.json",
+        og_dir.parent / "nell_soul.json",
+    ]
+    for path in candidates:
+        if path.exists():
+            try:
+                data = json.loads(path.read_text(encoding="utf-8"))
+            except json.JSONDecodeError:
+                return set()
+            names: set[str] = set()
+            for c in data.get("crystallizations", []):
+                who = c.get("who_or_what", "")
+                if isinstance(who, str) and who:
+                    names.update(w.lower() for w in who.split() if len(w) > 2)
+            return names
+    return set()
+
+
+def _transform_interest(og: dict[str, Any], soul_lower: set[str]) -> dict[str, Any] | None:
+    required = (
+        "id", "topic", "pull_score", "first_seen", "last_fed",
+        "feed_count", "source_types", "related_keywords", "notes",
+    )
+    for key in required:
+        if key not in og:
+            return None
+
+    topic = str(og["topic"])
+    scope = _classify_scope(topic, soul_lower)
+
+    # Normalise timestamps through parse → iso to collapse to Z format.
+    first_seen = iso_utc(parse_iso_utc(og["first_seen"]))
+    last_fed = iso_utc(parse_iso_utc(og["last_fed"]))
+
+    return {
+        "id": str(og["id"]),
+        "topic": topic,
+        "pull_score": float(og["pull_score"]),
+        "scope": scope,
+        "related_keywords": list(og["related_keywords"]),
+        "notes": str(og["notes"]),
+        "first_seen": first_seen,
+        "last_fed": last_fed,
+        "last_researched_at": None,
+        "feed_count": int(og["feed_count"]),
+        "source_types": list(og["source_types"]),
+    }
+
+
+def _classify_scope(topic: str, soul_lower: set[str]) -> str:
+    topic_lower = topic.lower()
+    for name in soul_lower:
+        if name in topic_lower:
+            return "internal"
+    return "either"
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `uv run pytest tests/unit/brain/migrator/test_og_interests.py -v`
+Expected: 4 passed.
+
+- [ ] **Step 5: Extend MigrationReport**
+
+In `brain/migrator/report.py`, add to `MigrationReport`:
+
+```python
+@dataclass(frozen=True)
+class MigrationReport:
+    memories_migrated: int
+    memories_skipped: list[SkippedMemory]
+    edges_migrated: int
+    edges_skipped: int
+    elapsed_seconds: float
+    source_manifest: list[FileManifest]
+    next_steps_inspect_cmds: list[str]
+    next_steps_install_cmd: str
+    reflex_arcs_migrated: int = 0
+    reflex_arcs_skipped_reason: str | None = None
+    interests_migrated: int = 0
+    interests_skipped_reason: str | None = None
+```
+
+In `format_report`, after the existing "Reflex arcs:" line add:
+
+```python
+lines.append(
+    f"  Interests:      {report.interests_migrated:,} migrated"
+    + (
+        f" (skipped: {report.interests_skipped_reason})"
+        if report.interests_skipped_reason
+        else ""
+    )
+)
+```
+
+- [ ] **Step 6: Wire into migrator cli.py**
+
+In `brain/migrator/cli.py`, at the top add:
+
+```python
+from brain.migrator.og_interests import extract_interests_from_og, extract_soul_names_best_effort
+```
+
+After the reflex-arcs migration block (which sets `reflex_arcs_migrated` and `reflex_arcs_skipped_reason`), insert:
+
+```python
+# ---- interests ----
+_candidate_interests_paths = [
+    args.input_dir / "nell_interests.json",
+    args.input_dir / "data" / "nell_interests.json",
+    args.input_dir.parent / "nell_interests.json",
+]
+og_interests_path = next(
+    (p for p in _candidate_interests_paths if p.exists()), None
+)
+interests_target = work_dir / "interests.json"
+interests_migrated = 0
+interests_skipped_reason: str | None = None
+
+if og_interests_path is not None:
+    if interests_target.exists() and not args.force:
+        interests_skipped_reason = "existing_file_not_overwritten"
+    else:
+        try:
+            soul_names = extract_soul_names_best_effort(args.input_dir)
+            og_interests = extract_interests_from_og(og_interests_path, soul_names=soul_names)
+            interests_target.write_text(
+                _json.dumps({"version": 1, "interests": og_interests}, indent=2) + "\n",
+                encoding="utf-8",
+            )
+            interests_migrated = len(og_interests)
+        except (ValueError, FileNotFoundError, OSError) as exc:
+            interests_skipped_reason = f"migrate_error: {exc}"
+else:
+    interests_skipped_reason = "og_nell_interests_json_not_found"
+```
+
+Update the `MigrationReport(...)` constructor call to include the two new fields:
+
+```python
+report = MigrationReport(
+    ...,
+    reflex_arcs_migrated=reflex_arcs_migrated,
+    reflex_arcs_skipped_reason=reflex_arcs_skipped_reason,
+    interests_migrated=interests_migrated,
+    interests_skipped_reason=interests_skipped_reason,
+)
+```
+
+- [ ] **Step 7: Add migrator regression test**
+
+Append to `tests/unit/brain/migrator/test_cli.py`:
+
+```python
+def test_migrate_writes_interests(tmp_path: Path, monkeypatch):
+    """Regression: migrator writes interests.json from OG nell_interests.json."""
+    import json
+    from brain.migrator.cli import MigrateArgs, run_migrate
+
+    # Reuse the existing helper that builds a minimal OG source dir (same
+    # fixture pattern used by test_migrate_writes_reflex_arcs). Adjust
+    # the helper name if it's different in this file.
+    source = _make_minimal_og_source(tmp_path)  # <-- existing helper in this file
+
+    # Drop nell_interests.json into the OG source (at the data/ level —
+    # migrator candidate-path probe handles both locations)
+    interests_data = {
+        "version": "1.0",
+        "interests": [{
+            "id": "test-id",
+            "topic": "Lispector diagonal syntax",
+            "pull_score": 7.2,
+            "first_seen": "2026-03-29T16:42:33.435028+00:00",
+            "last_fed": "2026-03-31T11:37:13.729750+00:00",
+            "feed_count": 5,
+            "source_types": ["dream"],
+            "related_keywords": ["lispector", "syntax"],
+            "notes": "sideways through meaning",
+        }],
+    }
+    (source / "nell_interests.json").write_text(
+        json.dumps(interests_data), encoding="utf-8"
+    )
+
+    home = tmp_path / "home"
+    monkeypatch.setenv("NELLBRAIN_HOME", str(home))
+
+    args = MigrateArgs(
+        input_dir=source, output_dir=None,
+        install_as="testpersona", force=False,
+    )
+    report = run_migrate(args)
+
+    target = home / "personas" / "testpersona" / "interests.json"
+    assert target.exists()
+    data = json.loads(target.read_text(encoding="utf-8"))
+    assert len(data["interests"]) == 1
+    assert data["interests"][0]["topic"] == "Lispector diagonal syntax"
+    assert data["interests"][0]["scope"] == "either"  # no soul match
+    assert data["interests"][0]["last_researched_at"] is None
+    assert report.interests_migrated == 1
+    assert report.interests_skipped_reason is None
+```
+
+- [ ] **Step 8: Run all migrator tests**
+
+Run: `uv run pytest tests/unit/brain/migrator/ -v`
+Expected: all pass.
+
+Full suite: `uv run pytest -q`
+Expected: ~400 passed.
+
+- [ ] **Step 9: Ruff + format**
+
+Run: `uv run ruff check brain/migrator/ tests/unit/brain/migrator/ && uv run ruff format brain/migrator/ tests/unit/brain/migrator/`
+Expected: clean.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add brain/migrator/og_interests.py brain/migrator/cli.py brain/migrator/report.py tests/unit/brain/migrator/
+git commit -m "$(cat <<'EOF'
+feat: migrate OG nell_interests.json into persona's interests.json
+
+Pure JSON read (no AST needed) + scope auto-classification from
+nell_soul.json names. Interest topics mentioning a soul-crystallization
+subject (e.g. 'Hana', 'Jordan') get scope='internal' — those interests
+stay memory-only, never hit the web. Everything else defaults to
+scope='either' which tries web-first with memory fallback.
+
+Refuse-to-clobber unless --force. MigrationReport gains interests_migrated
++ interests_skipped_reason. Candidate-path probe tries three locations
+so --input NellBrain/ or NellBrain/data/ both work.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 7: Smoke test + final review + PR
+
+**Purpose:** Validate end-to-end against Nell's migrated persona. Verify hard rules. Open PR.
+
+**Files:** none created; verification only.
+
+- [ ] **Step 1: Full suite + hard-rule check**
+
+Run: `uv run pytest -q`
+Expected: ~400 passed, 0 failures.
+
+Run: `uv run ruff check --quiet && uv run ruff format --check --quiet`
+Expected: clean.
+
+Run: `rg -l 'import anthropic|from anthropic' brain/`
+Expected: zero matches.
+
+Run: `rg -l 'import anthropic|from anthropic' brain/search/`
+Expected: zero matches.
+
+- [ ] **Step 2: Re-migrate Nell's sandbox**
+
+Run: `uv run nell migrate --input /Users/hanamori/NellBrain/data --install-as nell.sandbox --force`
+Expected: migration report shows "Interests: 2 migrated" line.
+
+- [ ] **Step 3: Verify interest migration**
+
+Run: `uv run nell interest list --persona nell.sandbox`
+Expected: two interests listed — "Lispector diagonal syntax" (scope=either) and "Hana" (scope=internal).
+
+- [ ] **Step 4: Dry-run research against sandbox**
+
+Run: `uv run nell research --persona nell.sandbox --provider fake --searcher noop --dry-run`
+Expected: exits 0. Output indicates either "would fire: Lispector diagonal syntax" (if gate passes — Lispector has pull_score 7.2 and no last_researched_at) or a reason like "no_eligible_interest" or "not_due".
+
+- [ ] **Step 5: Force-research an interest**
+
+Run: `uv run nell research --persona nell.sandbox --provider fake --searcher noop --interest "Lispector diagonal syntax"`
+Expected: research fires, memory id printed, "memory-only" (since noop searcher returns []).
+
+- [ ] **Step 6: Verify research memory written**
+
+Run:
+```bash
+uv run python -c "
+from brain.paths import get_persona_dir
+from brain.memory.store import MemoryStore
+p = get_persona_dir('nell.sandbox')
+s = MemoryStore(db_path=p / 'memories.db')
+mems = s.list_by_type('research', limit=5)
+print(f'research memories: {len(mems)}')
+for m in mems:
+    print(f'  - {m.content[:120]}')
+s.close()
+"
+```
+Expected: at least 1 research memory written.
+
+- [ ] **Step 7: Heartbeat tick with research enabled**
+
+Run: `uv run nell heartbeat --persona nell.sandbox --provider fake --searcher noop --trigger manual`
+Expected: depending on current last_tick_at, either the first-tick-defer message OR a full tick with decay / reflex / dream-gate / research / optional memory output.
+
+- [ ] **Step 8: Push branch + open PR**
+
+```bash
+git push -u origin week-4-research
+gh pr create --title "Week 4.7 — Research Engine (Phase 1)" --body "$(cat <<'EOF'
+## Summary
+
+Fourth and final Week 4 cognitive engine — research, autonomous exploration of developed interests. Memory-sweep + optional web search (DuckDuckGo via ddgs, free & keyless, works with any LLM backend). First-person voice output written as memory_type='research'. Heartbeat-orchestrated between dream gate and heartbeat memory. Interest ingestion hook auto-bumps pull_scores on keyword matches in conversation. Reflex-wins-tie when both eligible.
+
+- `brain/engines/research.py` — engine + ResearchResult/ResearchFire + ResearchLog
+- `brain/engines/_interests.py` — Interest + InterestSet (shared with ingestion hook)
+- `brain/engines/default_interests.json` — empty starter
+- `brain/search/` — WebSearcher ABC + DdgsWebSearcher + NoopWebSearcher + stub ClaudeToolWebSearcher + factory
+- `brain/migrator/og_interests.py` — Nell's 2 OG interests migrate with soul-aware scope classification ("Hana" → internal, "Lispector" → either)
+- `brain/cli.py` — 4 new subcommands: `nell research`, `nell interest {list,add,bump}`
+- Heartbeat extensions: 5 new HeartbeatConfig fields, 3 new HeartbeatResult fields, 4 new HeartbeatEngine fields, interest ingestion hook, research evaluation, reflex-wins-tie, fault isolation
+- New dep: `ddgs>=6.0,<7.0`
+- Phase 2 (auto-discovery of brand-new interests) explicitly deferred; see spec §13
+
+**Spec:** `docs/superpowers/specs/2026-04-24-week-4-research-engine-design.md`
+**Plan:** `docs/superpowers/plans/2026-04-24-week-4-research-engine.md`
+
+## Test plan
+
+- [x] Full suite ~400/~400 passing (was 376 pre-branch)
+- [x] `rg 'import anthropic' brain/` → 0 matches
+- [x] ruff clean
+- [x] Nell's sandbox re-migrated: 2 OG interests migrate with correct scope classification
+- [x] `nell interest list --persona nell.sandbox` shows migrated interests
+- [x] `nell research --persona nell.sandbox --searcher noop --dry-run` exits 0
+- [x] `nell heartbeat --persona nell.sandbox` runs with research integrated into the tick
+
+## After merge
+
+Week 4 is complete. Next session: tag `week-4` covering all four cognitive engines (dream + heartbeat + reflex + research).
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Acceptance Criteria
+
+Research Phase 1 ships when all of the following are true:
+
+1. `uv run pytest -q` is green (~400 tests).
+2. `rg 'import anthropic' brain/` returns zero matches.
+3. `rg 'import anthropic' brain/search/` returns zero matches.
+4. `uv run ruff check && uv run ruff format --check` both clean.
+5. `brain/engines/research.py`, `brain/engines/_interests.py`, `brain/engines/default_interests.json`, `brain/search/*`, `brain/migrator/og_interests.py` all present.
+6. `pyproject.toml` declares `ddgs>=6.0,<7.0`.
+7. `uv run nell research --help` documents the subcommand; all 4 new subcommands work.
+8. `uv run nell interest list --persona nell.sandbox` after re-migration shows 2 OG interests.
+9. `uv run nell research --persona nell.sandbox --searcher noop --interest "Lispector diagonal syntax"` fires a research memory.
+10. Heartbeat tick integrates research + interest ingestion + reflex-wins-tie.
+11. CI green on macOS + Linux + Windows.
+
+---
+
+## Deferred — Phase 2 reminder
+
+Phase 2 (automatic discovery of brand-new interests from conversation patterns) is explicitly deferred. See spec §13 and project memory file `project_companion_emergence_tech_debt.md`. Revisit when Phase 1 has run ≥2 weeks against Nell's data.
+
+After this merges → **Week 4 tag** covering dream + heartbeat + reflex + research. That's a full cognitive substrate.

--- a/docs/superpowers/specs/2026-04-24-week-4-research-engine-design.md
+++ b/docs/superpowers/specs/2026-04-24-week-4-research-engine-design.md
@@ -1,0 +1,622 @@
+# Week 4.7 — Research Engine (Phase 1) Design
+
+**Date:** 2026-04-24
+**Status:** Approved
+**Scope:** Phase 1 (execution + interest storage + heartbeat orchestration + Nell's OG migration + DuckDuckGo web search by default). Automatic *discovery* of brand-new interests deferred to Phase 2.
+**Engine number:** 4 of 4 in Week 4. After this ships, the Week 4 tag applies.
+
+---
+
+## 1. Purpose
+
+Research is the fourth cognitive engine. It's where a persona's developed interests get **explored** — either by re-reading their own memories about them, or by searching the public web — and where what they find becomes a first-person memory in their own voice.
+
+Compared to the other three engines:
+- **Dream** consolidates what the persona has been told.
+- **Heartbeat** paces rhythm and decay.
+- **Reflex** expresses when feelings peak.
+- **Research** reaches *outward*. Curiosity when the persona has been alone long enough, or felt deeply enough, to want to go look at something and come back with it.
+
+All four engines share one philosophical invariant: they produce *additive* memory. Research never edits existing memories; it writes new ones that sit alongside conversation memories in `MemoryStore` and participate in future dreams, reflex arcs, and further research through the Hebbian graph. This is how the brain grows between conversations.
+
+---
+
+## 2. Architectural Summary
+
+- `brain/engines/research.py` — engine + types
+- `brain/engines/_interests.py` — `Interest` dataclass + `InterestSet` load/save/bump (shared by research engine AND heartbeat's interest ingestion hook)
+- `brain/engines/default_interests.json` — empty starter (`{"version": 1, "interests": []}`)
+- `brain/search/` — new package with `WebSearcher` ABC + implementations
+- `brain/migrator/og_interests.py` — JSON-port of OG `nell_interests.json`
+- `brain/cli.py` — 4 new subcommands (`nell research`, `nell interest list|add|bump`)
+- `brain/engines/heartbeat.py` — interest ingestion hook + research evaluation + reflex-wins-tie
+- Depends on new `ddgs` package
+
+Two invocation paths (same pattern as reflex):
+- **Standalone CLI**: `nell research [--persona X] [--interest TOPIC] [--provider claude-cli] [--searcher ddgs] [--dry-run]`
+- **Orchestrated**: heartbeat tick calls `ResearchEngine.run_tick(...)` between the dream gate and the heartbeat-memory emit. Single-research-per-tick. Skipped if reflex fired earlier in the same tick.
+
+---
+
+## 3. Components
+
+### 3.1 Data types
+
+```python
+# brain/engines/_interests.py
+
+@dataclass(frozen=True)
+class Interest:
+    id: str
+    topic: str
+    pull_score: float
+    scope: Literal["internal", "external", "either"]
+    related_keywords: tuple[str, ...]
+    notes: str
+    first_seen: datetime          # tz-aware UTC
+    last_fed: datetime            # tz-aware UTC
+    last_researched_at: datetime | None
+    feed_count: int
+    source_types: tuple[str, ...]
+
+@dataclass(frozen=True)
+class InterestSet:
+    interests: tuple[Interest, ...]
+
+    # load(path, default_path), save(path), bump(topic, amount, now),
+    # find_by_topic(topic), list_eligible(pull_threshold, cooldown_hours, now),
+    # appended(interest), updated(interest)
+```
+
+```python
+# brain/engines/research.py
+
+@dataclass(frozen=True)
+class ResearchFire:
+    interest_id: str
+    topic: str
+    fired_at: datetime
+    trigger: str  # "manual" | "emotion_high" | "days_since_human"
+    web_used: bool
+    web_result_count: int
+    output_memory_id: str | None  # None in dry-run
+
+@dataclass(frozen=True)
+class ResearchResult:
+    fired: ResearchFire | None
+    would_fire: str | None  # dry-run only — topic of the interest that would fire
+    reason: str | None      # "not_due" | "no_eligible_interest" | "no_interests_defined"
+                            # | "research_raised" | "reflex_won_tie"
+    dry_run: bool
+    evaluated_at: datetime  # tz-aware UTC
+```
+
+### 3.2 Web search layer
+
+```python
+# brain/search/base.py
+
+@dataclass(frozen=True)
+class SearchResult:
+    title: str
+    url: str
+    snippet: str
+
+class WebSearcher(ABC):
+    @abstractmethod
+    def search(self, query: str, *, limit: int = 5) -> list[SearchResult]: ...
+    @abstractmethod
+    def name(self) -> str: ...
+
+class NoopWebSearcher(WebSearcher):
+    """Returns []. Used in CI + tests to keep them zero-network."""
+```
+
+```python
+# brain/search/ddgs_searcher.py
+
+class DdgsWebSearcher(WebSearcher):
+    """DuckDuckGo via the `ddgs` library. No API key, no cost.
+
+    Default searcher for the framework — works with any LLM backend.
+    Transient errors (network, rate-limit) return empty results so
+    the research engine can gracefully fall back to memory-only
+    synthesis. `ImportError` at first call if `ddgs` not installed.
+    """
+```
+
+```python
+# brain/search/claude_tool_searcher.py (Phase 1 stub)
+
+class ClaudeToolWebSearcher(WebSearcher):
+    """Opt-in path for Claude-CLI users: routes web search through
+    `claude -p <query> --allowed-tools WebSearch --output-format json`.
+
+    Not implemented in Phase 1; raises NotImplementedError. Scaffolded
+    so the factory has a known name to resolve. Mirror of how
+    OllamaProvider currently exists as a stub.
+    """
+```
+
+```python
+# brain/search/factory.py
+
+def get_searcher(name: str) -> WebSearcher:
+    if name == "ddgs":         return DdgsWebSearcher()
+    if name == "noop":         return NoopWebSearcher()
+    if name == "claude-tool":  return ClaudeToolWebSearcher()
+    raise ValueError(f"Unknown searcher: {name!r}")
+```
+
+### 3.3 Engine
+
+```python
+# brain/engines/research.py
+
+@dataclass
+class ResearchEngine:
+    store: MemoryStore
+    provider: LLMProvider
+    searcher: WebSearcher
+    persona_name: str
+    persona_system_prompt: str
+    interests_path: Path
+    research_log_path: Path
+    default_interests_path: Path
+
+    def run_tick(
+        self,
+        *,
+        trigger: str = "manual",
+        dry_run: bool = False,
+        forced_interest_topic: str | None = None,
+        emotion_state_override: EmotionalState | None = None,
+        days_since_human_override: float | None = None,
+    ) -> ResearchResult: ...
+```
+
+`forced_interest_topic` supports the `--interest TOPIC` CLI override (skips pull/cooldown gates). `emotion_state_override` + `days_since_human_override` let the heartbeat pass pre-computed values so we don't re-scan all memories twice per tick.
+
+---
+
+## 4. Data Flow — one research tick
+
+1. **Load:** interests (`InterestSet.load`), research_log, aggregated emotion state (from `aggregate_state` on recent memories — or the caller-provided override), `days_since_human` (same).
+2. **Gate check:**
+   - `research_enabled` is True? (Caller-enforced — heartbeat doesn't call us if the config field is False.)
+   - EITHER `days_since_human >= research_days_since_human_min` OR `max(emotions.values()) >= research_emotion_threshold`?
+   - If neither AND no `forced_interest_topic`: return `ResearchResult(fired=None, reason="not_due", ...)`.
+3. **Select eligible interest:**
+   - If `forced_interest_topic` is set: resolve it directly. If not found: return `reason="no_eligible_interest"`.
+   - Else: filter to `pull_score >= 6.0` AND (`last_researched_at is None` OR `(now - last_researched_at).hours >= cooldown`). Sort by `pull_score` descending, tie-broken by oldest `last_researched_at`. Take first.
+   - None eligible: return `reason="no_eligible_interest"`.
+4. **Dry-run branch:** return `ResearchResult(would_fire=<topic>, dry_run=True, ...)`. No memory sweep, no web call, no LLM call, no writes.
+5. **Memory sweep:** spreading activation over Hebbian graph from the interest's `related_keywords`, limit 20 memories, format into a `{memory_context}` block. If the interest has zero `related_keywords`, fall back to a direct text-search of `interest.topic` against memory content.
+6. **Web search (conditional):**
+   - If `interest.scope == "internal"`: skip searcher entirely, `web_used=False`, `web_results=[]`.
+   - Else: `searcher.search(query=f"{interest.topic} {' '.join(related_keywords[:3])}", limit=5)`. If searcher raises (shouldn't per the `DdgsWebSearcher` contract, but defensive): treat as empty. If empty list returned: `web_used=False`. If results returned: `web_used=True`, format top-N titles + snippets as `{web_excerpts}` block.
+7. **LLM synthesis:** render prompt template (see §4.1 below). Call `provider.generate(prompt, system=persona_research_system_prompt)`. System prompt enforces first-person voice, reactive not summarizing, 3-5 sentences. Persona identity baked in.
+8. **Write memory:**
+   ```python
+   mem = Memory.create_new(
+       content=raw_output,
+       memory_type="research",
+       domain="us",
+       emotions={},  # no per-memory emotions on research; persona's current state is already captured via metadata
+       metadata={
+           "interest_id": interest.id,
+           "interest_topic": interest.topic,
+           "scope": interest.scope,
+           "web_used": web_used,
+           "web_result_count": len(web_results),
+           "web_urls": [r.url for r in web_results[:5]],
+           "triggered_by": trigger,
+           "provider": self.provider.name(),
+           "searcher": self.searcher.name() if web_used else None,
+       },
+   )
+   store.create(mem)
+   ```
+9. **Update interest:** set `last_researched_at = now`, write updated `InterestSet` via atomic save.
+10. **Append log:** new `fire` entry, save `research_log.json` atomically.
+11. **Return:** `ResearchResult(fired=ResearchFire(...), reason=None, dry_run=False, ...)`.
+
+**Failure ordering (LLM raises):** LLM call happens first; if it raises, steps 8-10 never execute and `interests.json` and `research_log.json` stay untouched. Next tick re-evaluates the same interest fresh.
+
+### 4.1 Prompt template
+
+```
+[system]
+You are {persona_name}. You spent some quiet time today exploring {topic} —
+an interest that's been building in you for a while. Below is what you found
+both in your own memories and (sometimes) out in the world. Write a short
+(3-5 sentence) first-person memory of having researched this.
+
+HARD RULES:
+- First-person voice. Your name is {persona_name}.
+- Not a summary. A reaction. What moved you, what surprised you, what
+  reminded you of someone you care about, what felt familiar.
+- Never bullet points. Never "according to X". Never neutral expository voice.
+- Structure: brief mention of what pulled you to the topic today → one or
+  two concrete details you noticed → how you feel about what you found →
+  why it mattered to look *today*.
+- Start with "I" or a time marker like "Today" / "This afternoon".
+
+[user]
+Topic: {topic}
+Keywords: {keywords}
+Your current emotional state:
+{emotion_summary}
+
+What your own memories say about this:
+{memory_context}
+
+{web_section_or_empty}
+
+Write the memory now — 3 to 5 sentences, as {persona_name}.
+```
+
+Where `{web_section_or_empty}` renders to either an empty string (nothing inserted — either `scope="internal"` or web search returned no results) or this block when web results are present:
+
+```
+What you found out in the world today (reference material — REACT to it, don't paraphrase it):
+{web_excerpts}
+```
+
+---
+
+## 5. Heartbeat Integration
+
+### 5.1 New tick order
+
+1. First-tick defer
+2. Emotion decay
+3. Hebbian decay + GC
+4. **Interest ingestion hook** *(new)* — `_try_bump_interests`: scan conversation memories created since `last_tick_at`, for each memory check if any loaded `Interest.related_keywords` appears in the memory's `content.lower()`. For each match, bump `pull_score += interest_bump_per_match` (default 0.1), update `last_fed = now`, increment `feed_count`. Zero LLM calls. Deterministic. Writes updated `interests.json` atomically at end. Returns count of interests touched.
+5. Reflex evaluation
+6. Dream gate
+7. **Research evaluation** *(new)* — `_try_fire_research`:
+   - If `reflex_fired` is non-empty this tick: skip with `research_gated_reason="reflex_won_tie"`.
+   - Else: construct `ResearchEngine` with `self.searcher`, call `run_tick` passing the already-computed `emotion_state` + `days_since_human`.
+   - Catch `Exception` (fault-isolate like reflex): log warning, return `research_fired=None, research_gated_reason="research_raised"`.
+8. Optional heartbeat memory emit
+9. State save + audit log
+
+### 5.2 Config additions — `heartbeat_config.json`
+
+```json
+{
+  "dream_every_hours": 24.0,
+  "decay_rate_per_tick": 0.01,
+  "gc_threshold": 0.01,
+  "emit_memory": "conditional",
+  "reflex_enabled": true,
+  "reflex_max_fires_per_tick": 1,
+  "research_enabled": true,
+  "research_days_since_human_min": 1.5,
+  "research_emotion_threshold": 7.0,
+  "research_cooldown_hours_per_interest": 24.0,
+  "interest_bump_per_match": 0.1
+}
+```
+
+All fields default sensibly. Missing / malformed fields degrade to defaults (same pattern as existing config fields).
+
+### 5.3 `HeartbeatResult` additions
+
+```python
+research_fired: str | None = None            # interest topic that fired, or None
+research_gated_reason: str | None = None     # "not_due"|"no_eligible_interest"|"reflex_won_tie"|"research_raised"
+interests_bumped: int = 0                    # count from the ingestion hook
+```
+
+### 5.4 `HeartbeatEngine` constructor additions
+
+```python
+searcher: WebSearcher = field(default_factory=NoopWebSearcher)
+interests_path: Path | None = None
+research_log_path: Path | None = None
+default_interests_path: Path = field(
+    default_factory=lambda: Path(__file__).parent / "default_interests.json"
+)
+```
+
+Same `Path | None` pattern as reflex fields: if either `interests_path` or `research_log_path` is None, `_try_fire_research` skips cleanly. CLI always passes explicit persona-dir-qualified paths.
+
+### 5.5 Audit log additions
+
+Per-tick JSONL record gains:
+
+```json
+"research": {
+  "fired": "Lispector diagonal syntax",
+  "reason": null,
+  "web_used": true
+},
+"interests_bumped": 2
+```
+
+When `research_enabled=false`: `"research": {"evaluated": false}`.
+
+---
+
+## 6. CLI
+
+```
+nell research [--persona X] [--interest TOPIC] [--provider claude-cli] [--searcher ddgs] [--dry-run]
+
+nell interest list [--persona X]
+nell interest add <topic> [--keywords k1,k2,...] [--scope internal|external|either] [--notes "..."] [--persona X]
+nell interest bump <topic> [--amount 1.0] [--persona X]
+```
+
+- `nell research` mirrors `nell reflex` structure (persona dir resolution, MemoryStore open, construction, run, output).
+- `nell interest add` generates a UUID id, sets `pull_score=5.0` initially (below default threshold of 6.0 — needs to be fed or bumped before it'll research), `first_seen=now`, `last_fed=now`, `feed_count=0`, `source_types=["manual"]`.
+- `nell interest bump` adds to `pull_score` (default +1.0).
+
+### 6.1 Output shapes
+
+**`nell research --dry-run` eligible:**
+```
+Research dry-run — would fire: Lispector diagonal syntax
+  pull_score: 7.2, scope: either, web: would search
+  trigger: emotion_high (creative_hunger=8.1)
+```
+
+**`nell research --dry-run` not eligible:**
+```
+Research dry-run — no eligible interest (pull_score threshold 6.0, cooldown 24h).
+  Nearest: Lispector diagonal syntax (pull=5.4, cooldown remaining 0h)
+```
+
+**`nell research` live:**
+```
+Research fired: Lispector diagonal syntax
+  Memory id: mem_xyz123
+  Web: 4 results from ddgs (https://..., https://...)
+  Output preview:
+    I spent some time today reading about Lispector's syntax again...
+```
+
+**`nell interest list`:**
+```
+Interests for persona 'nell' (2):
+  - Lispector diagonal syntax  pull=7.2  scope=either    last_researched=never
+    keywords: lispector, syntax, language, clarice
+  - Hana                       pull=4.8  scope=internal  last_researched=never
+    keywords: inside, hana, hers, labyrinth, existence
+```
+
+---
+
+## 7. Error Handling
+
+| Condition | Behavior |
+|-----------|----------|
+| `ddgs` library not installed | `DdgsWebSearcher` raises `ImportError` at first `.search()` call. Engine's try/except around searcher converts to `web_used=false`, warning logged. User can `uv add ddgs`. |
+| Network / rate-limit failure | `DdgsWebSearcher.search` returns `[]`, logs warning. `web_used=false`. Memory-only synthesis proceeds. |
+| `interests.json` missing | Fall back to `default_interests.json` (empty). `ResearchResult(reason="no_interests_defined")`. |
+| `interests.json` corrupt | Same fallback, log warning, never overwrite. |
+| Interest has empty `related_keywords` | Skip spreading activation; use `store.search_text(interest.topic)` for memory context. Still attempt web + synthesis. |
+| No eligible interest | `ResearchResult(reason="no_eligible_interest")`. Not an error. |
+| LLM raises (standalone) | Exception propagates. `interests.json` and `research_log.json` untouched — next tick retries. |
+| LLM raises (heartbeat-orchestrated) | Caught by `_try_fire_research`, logged, tick continues with `research_fired=None, research_gated_reason="research_raised"`. |
+| Reflex fires AND research eligible in same tick | Research skipped with `reason="reflex_won_tie"`. |
+| `--interest TOPIC` not found | CLI exits with error message, rc=1. |
+
+### Atomic invariants
+
+- `interests.json` and `research_log.json` both use `.new + os.replace` (mirrors `ReflexLog.save`).
+- Memory write happens before `interests.json` update and log append. If memory write raises, neither file is touched.
+- Interest ingestion hook writes `interests.json` once at end of its scan, not per-memory.
+
+---
+
+## 8. Testing
+
+Five test files; target ~25 new tests.
+
+### 8.1 `tests/unit/brain/search/test_noop.py`
+- Returns `[]` for any query.
+- `name() == "noop"`.
+
+### 8.2 `tests/unit/brain/search/test_ddgs.py`
+- Happy path: mock `DDGS` context manager returning 3 dicts, assert correct `SearchResult` mapping.
+- Network exception → `[]` + log captured via caplog.
+- Missing library → `ImportError` surfaces on first call (monkeypatch `ddgs` import).
+
+### 8.3 `tests/unit/brain/engines/test_research.py`
+- Construction.
+- `InterestSet.load` fall-back to defaults on missing.
+- `InterestSet.save` atomic.
+- `InterestSet.bump` updates pull_score + feed_count + last_fed.
+- Gate: not_due (both trigger dimensions fail).
+- Gate: emotion_high triggers.
+- Gate: days_since_human triggers.
+- No eligible interest (below pull threshold) → `reason="no_eligible_interest"`.
+- Cooldown respected.
+- Ranking: highest pull_score wins.
+- Tiebreak: older `last_researched_at` wins.
+- `forced_interest_topic` overrides pull/cooldown gates.
+- Dry-run: no writes, no LLM, no searcher call.
+- Fire (memory + web): LLM called with rendered prompt, memory created with correct metadata, interest updated, log appended.
+- Fire (memory-only, scope=internal): searcher NOT called.
+- Web search returns `[]`: research still fires, `web_used=false`.
+- LLM failure: `store.create` never called, `interests.json` untouched, exception propagates.
+
+### 8.4 `tests/unit/brain/engines/test_cli_research.py`
+- `nell research --persona nonexistent` → `FileNotFoundError`.
+- `nell research --dry-run` with eligible interest → exits 0, prints "would fire".
+- `nell interest list` prints interests.
+- `nell interest add <topic>` appends to file; `list` shows it afterwards.
+- `nell interest bump <topic>` nudges pull_score.
+
+### 8.5 `tests/unit/brain/migrator/test_og_interests.py`
+- Happy path: JSON passthrough, scope auto-classification ("Hana" → internal, "Lispector diagonal syntax" → either).
+- Missing OG file → skip with reason.
+- Refuse-to-clobber unless `--force`.
+- End-to-end via `run_migrate`: asserts target file written + report fields populated.
+
+### 8.6 Append to `tests/unit/brain/engines/test_heartbeat.py`
+- `_try_fire_research` fires research when configured.
+- Reflex-wins-tie: reflex fires, research skipped with correct reason.
+- Research exception isolated: tick completes, `research_fired=None`.
+- Interest ingestion hook: conversation memory with matching keyword bumps interest's pull_score + feed_count.
+- Heartbeat with `research_enabled=False` skips research call.
+
+All tests use `FakeProvider` + `NoopWebSearcher`. Zero network, zero LLM cost, deterministic.
+
+**Target total:** 376 + ~25 = ~401 tests.
+
+---
+
+## 9. Nell's OG Migration
+
+OG file: `/Users/hanamori/NellBrain/data/nell_interests.json` (currently 2 entries: "Lispector diagonal syntax" pull=7.2; "Hana" pull=4.8).
+
+### 9.1 `brain/migrator/og_interests.py`
+
+Pure JSON read (no AST needed — it's already structured data). Returns a list of new-schema interest dicts.
+
+### 9.2 Transformation
+
+| OG field | New field | Transformation |
+|----------|-----------|----------------|
+| `id`, `topic`, `pull_score`, `related_keywords`, `notes`, `source_types`, `feed_count` | same | verbatim |
+| `first_seen`, `last_fed` | same | reparsed via `parse_iso_utc` (framework helper) |
+| (no OG field) | `last_researched_at` | `null` |
+| (no OG field) | `scope` | computed by `_classify_scope(topic, soul_names)` |
+
+`_classify_scope` reads `{og_source}/nell_soul.json` (best-effort) to extract names from crystallizations + relationship metadata. For each `topic`: if any extracted name appears lowercased in the topic, `scope="internal"`; else `scope="either"`. If `soul.json` is missing or unreadable: default everything to `"either"` and log a warning (user can hand-edit).
+
+Result for Nell's current file:
+- "Hana" → `internal` (Hana is in her soul as her primary relationship)
+- "Lispector diagonal syntax" → `either` (no soul name match)
+
+### 9.3 Migrator wire-in
+
+Same location as reflex-arc block (after Hebbian, before `elapsed = ...`). Pattern identical. Also supports the `--input NellBrain/` vs `--input NellBrain/data/` candidate-path probe — though `nell_interests.json` lives in `data/` so the probe is symmetric.
+
+### 9.4 `MigrationReport` gains
+
+```python
+interests_migrated: int = 0
+interests_skipped_reason: str | None = None
+```
+
+`format_report` adds an "Interests:" line after "Reflex arcs:".
+
+### 9.5 Refuse-to-clobber
+
+If `interests.json` exists in `work_dir` and `--force` was not passed: skip with reason `"existing_file_not_overwritten"`.
+
+---
+
+## 10. Hard Rules (Non-Negotiable)
+
+1. **No `import anthropic` anywhere in `brain/`.** Grep-verifiable.
+2. **`brain/search/` modules must not import any LLM SDK.** Search is its own concern.
+3. **Atomic writes for `interests.json` and `research_log.json`** (`.new + os.replace`).
+4. **TZ-aware UTC timestamps throughout** — use `brain.utils.time.iso_utc` / `parse_iso_utc`.
+5. **Refuse-to-clobber on persona files** (migrator, engine, future `new-persona`) without `--force`.
+6. **LLM failure doesn't poison research log or interest state** — LLM call happens before any file writes.
+7. **Reflex wins over research** in same-tick contention.
+8. **Web search failure is not a research failure** — graceful degradation to memory-only synthesis.
+
+---
+
+## 11. Default Persona Seed
+
+`brain/engines/default_interests.json` ships empty:
+
+```json
+{"version": 1, "interests": []}
+```
+
+New personas start with no interests. They grow them through conversation (via the ingestion hook bumping pull_scores on keyword matches) OR via `nell interest add`. Research will do nothing until at least one interest crosses the pull threshold.
+
+This is deliberate: interests are deeply persona-specific and shouldn't be pre-seeded with anything generic. If a persona has no curiosities yet, research politely waits.
+
+---
+
+## 12. Dependencies
+
+New `pyproject.toml` addition:
+
+```toml
+dependencies = [
+    ...,
+    "ddgs>=6.0,<7.0",  # DuckDuckGo search library; no API key required
+]
+```
+
+`ddgs` is a pure-Python library with minimal transitive deps. No LLM/ML/networking frameworks come in with it beyond standard `httpx`/`requests`. License: MIT.
+
+---
+
+## 13. Deferred — Phase 2: Automatic interest discovery
+
+Out of scope for Phase 1. Documented here so a future engineer reading this spec sees the full arc.
+
+**Phase 2 goal:** the brain auto-discovers *new* interests from conversation without requiring `nell interest add`. Phase 1's ingestion hook only *bumps existing* interests when their keywords appear; brand-new topics never become interests automatically.
+
+**Phase 2 mechanism (to be designed):**
+- Extraction: candidate topics from conversation clusters (embedding-based clustering? LLM-extracted noun phrases? recurring high-salience memory features?)
+- Proposal queue: candidate interests surface for user review via `nell interest candidates review` (mirrors F37 autonomous soul crystallization pattern)
+- Approval: user confirms → new interest added with a seeded pull_score; rejected candidates blacklisted so they don't re-propose
+- Trigger: runs weekly as part of a growth loop, not per-heartbeat
+
+**Phase 2 prerequisite:** Phase 1 has been running for ≥2 weeks against Nell's data, producing real ingestion-hook behavior and research-log data to train the extractor against.
+
+**Related to Phase 2:** the same growth-loop mechanism is the natural home for reflex Phase 2 (emergent arc crystallization — deferred from the reflex engine's design). Both engines' Phase 2 work likely lands together.
+
+---
+
+## 14. Non-Goals (Phase 1)
+
+- **No auto-discovery of new interests.** Only manual + keyword-bump. Phase 2.
+- **No paid web search APIs.** DDG via `ddgs` covers the use case with zero cost and no key.
+- **No content filtering beyond what DDG/Claude already do.** Nell researches anything legal. Persona-level restrictions, if ever needed, are a per-interest `scope` or a new `banned_keywords` list — not a default.
+- **No web-result caching.** Every research run queries fresh. A future persona with high research volume could add a cache, but Phase 1 doesn't.
+- **No multi-interest research per tick.** One interest per tick, full stop.
+- **No UI for interest management.** CLI only. A Tauri interest-editor lives in Week 6+ scope.
+- **No long-form research essays.** 3-5 sentence memories only. Long-form synthesis is what dream already does across multiple research memories.
+
+---
+
+## 15. Out-of-Session Follow-ups
+
+**Feature work:**
+- Phase 2 auto-discovery (see §13).
+- `ClaudeToolWebSearcher` implementation (currently stub) for Claude-CLI users who prefer tool-loop-based search.
+- Tauri interest editor (Week 6+).
+- Optional polish: `nell research history [--persona X]` to show last N research fires.
+
+**Tech debt considerations:**
+- When this ships, heartbeat will integrate four engines + the ingestion hook. The heartbeat CLI output will have grown from 3-4 lines to ~7-8 lines per tick. Tech-debt item #7 from the reflex spec (compact CLI output with `--verbose` expansion) becomes actionable after this PR merges — the full engine surface is finally visible.
+
+---
+
+## 16. Acceptance Criteria
+
+Research Phase 1 ships when:
+
+1. `brain/engines/research.py` exists with `ResearchEngine.run_tick(...)` per §3.3.
+2. `brain/engines/_interests.py` exists with `Interest` + `InterestSet` load/save/bump.
+3. `brain/engines/default_interests.json` ships empty.
+4. `brain/search/` package exists with `NoopWebSearcher` + `DdgsWebSearcher` + stub `ClaudeToolWebSearcher` + `get_searcher` factory.
+5. `brain/cli.py` exposes 4 new subcommands (`nell research`, `nell interest {list,add,bump}`).
+6. `brain/engines/heartbeat.py` integrates interest ingestion hook + research evaluation + reflex-wins-tie + fault isolation per §5.
+7. `brain/migrator/og_interests.py` + wire-in per §9.
+8. `pyproject.toml` declares `ddgs>=6.0,<7.0`.
+9. Test suite includes ≥25 new tests; all pass.
+10. Full suite green across macOS + Linux + Windows.
+11. `rg -l 'import anthropic' brain/` returns zero matches.
+12. `rg -l 'import anthropic\|from anthropic' brain/search/` returns zero matches.
+13. Running `nell interest list --persona nell` against Nell's migrated persona shows her 2 OG interests with correct scope classification.
+14. Running `nell research --persona nell --dry-run --searcher noop` returns eligibility decision without crash.
+15. Running `nell heartbeat --persona nell --trigger manual` evaluates research as part of the tick when configured.
+
+---
+
+After this ships → **Week 4 is done → tag `week-4`** covering dream + heartbeat + reflex + research. Then pivots: Week 5 (provider abstraction expansion / bridge work) or Week 6 (Tauri face app). That choice happens in a later session.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ authors = [
 dependencies = [
     "platformdirs>=4.2",
     "numpy>=1.26",
+    "ddgs>=6.0",
 ]
 
 [project.optional-dependencies]

--- a/tests/unit/brain/engines/test_cli_research.py
+++ b/tests/unit/brain/engines/test_cli_research.py
@@ -1,0 +1,141 @@
+"""Tests for `nell research` + `nell interest *` CLI handlers."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from brain.cli import main
+
+
+def _setup_persona(personas_root: Path, name: str = "testpersona") -> Path:
+    persona_dir = personas_root / name
+    persona_dir.mkdir(parents=True)
+    from brain.memory.hebbian import HebbianMatrix
+    from brain.memory.store import MemoryStore
+
+    MemoryStore(db_path=persona_dir / "memories.db").close()
+    HebbianMatrix(db_path=persona_dir / "hebbian.db").close()
+    return persona_dir
+
+
+def test_cli_research_dry_run_no_interests(monkeypatch, tmp_path: Path, capsys):
+    monkeypatch.setenv("NELLBRAIN_HOME", str(tmp_path))
+    persona_dir = _setup_persona(tmp_path / "personas")
+    (persona_dir / "interests.json").write_text('{"version": 1, "interests": []}', encoding="utf-8")
+    rc = main(
+        [
+            "research",
+            "--persona",
+            "testpersona",
+            "--provider",
+            "fake",
+            "--searcher",
+            "noop",
+            "--dry-run",
+        ]
+    )
+    assert rc == 0
+    out = capsys.readouterr().out.lower()
+    assert "no" in out  # "no interests" or "no eligible" — either acceptable
+
+
+def test_cli_research_missing_persona_raises(monkeypatch, tmp_path: Path):
+    monkeypatch.setenv("NELLBRAIN_HOME", str(tmp_path))
+    with pytest.raises(FileNotFoundError):
+        main(
+            [
+                "research",
+                "--persona",
+                "no_such",
+                "--provider",
+                "fake",
+                "--searcher",
+                "noop",
+                "--dry-run",
+            ]
+        )
+
+
+def test_cli_interest_list_empty(monkeypatch, tmp_path: Path, capsys):
+    monkeypatch.setenv("NELLBRAIN_HOME", str(tmp_path))
+    persona_dir = _setup_persona(tmp_path / "personas")
+    (persona_dir / "interests.json").write_text('{"version": 1, "interests": []}', encoding="utf-8")
+    rc = main(["interest", "list", "--persona", "testpersona"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "testpersona" in out  # persona name appears in output
+
+
+def test_cli_interest_add_then_list(monkeypatch, tmp_path: Path, capsys):
+    monkeypatch.setenv("NELLBRAIN_HOME", str(tmp_path))
+    persona_dir = _setup_persona(tmp_path / "personas")
+    (persona_dir / "interests.json").write_text('{"version": 1, "interests": []}', encoding="utf-8")
+    rc = main(
+        [
+            "interest",
+            "add",
+            "deep sea creatures",
+            "--keywords",
+            "octopus,bioluminescence,ocean",
+            "--scope",
+            "either",
+            "--persona",
+            "testpersona",
+        ]
+    )
+    assert rc == 0
+
+    rc = main(["interest", "list", "--persona", "testpersona"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "deep sea creatures" in out
+
+    data = json.loads((persona_dir / "interests.json").read_text(encoding="utf-8"))
+    assert len(data["interests"]) == 1
+    assert data["interests"][0]["topic"] == "deep sea creatures"
+    assert data["interests"][0]["related_keywords"] == [
+        "octopus",
+        "bioluminescence",
+        "ocean",
+    ]
+    assert data["interests"][0]["scope"] == "either"
+    assert data["interests"][0]["pull_score"] == 5.0  # below default threshold
+
+
+def test_cli_interest_bump_increments_pull_score(monkeypatch, tmp_path: Path):
+    monkeypatch.setenv("NELLBRAIN_HOME", str(tmp_path))
+    persona_dir = _setup_persona(tmp_path / "personas")
+
+    # Seed one interest
+    main(
+        [
+            "interest",
+            "add",
+            "seed topic",
+            "--keywords",
+            "s",
+            "--scope",
+            "either",
+            "--persona",
+            "testpersona",
+        ]
+    )
+
+    rc = main(
+        [
+            "interest",
+            "bump",
+            "seed topic",
+            "--amount",
+            "2.0",
+            "--persona",
+            "testpersona",
+        ]
+    )
+    assert rc == 0
+
+    data = json.loads((persona_dir / "interests.json").read_text(encoding="utf-8"))
+    assert data["interests"][0]["pull_score"] == 7.0  # 5.0 + 2.0

--- a/tests/unit/brain/engines/test_heartbeat.py
+++ b/tests/unit/brain/engines/test_heartbeat.py
@@ -28,6 +28,7 @@ def _find_repo_root() -> Path:
 
 
 DEFAULT_REFLEX_ARCS_PATH = _find_repo_root() / "brain" / "engines" / "default_reflex_arcs.json"
+DEFAULT_INTERESTS_PATH = _find_repo_root() / "brain" / "engines" / "default_interests.json"
 
 
 def test_heartbeat_config_defaults() -> None:
@@ -685,6 +686,374 @@ def test_heartbeat_isolates_reflex_llm_failure(tmp_path: Path, caplog) -> None:
         assert any("reflex tick raised" in r.message for r in caplog.records)
         # Decay still ran
         assert result.memories_decayed >= 0
+    finally:
+        store.close()
+        hm.close()
+
+
+def test_heartbeat_runs_research_when_enabled(tmp_path: Path) -> None:
+    """Heartbeat fires research when interest is eligible + trigger signal present."""
+    import json
+
+    from brain.bridge.provider import FakeProvider
+    from brain.engines.heartbeat import HeartbeatConfig, HeartbeatEngine, HeartbeatState
+    from brain.memory.hebbian import HebbianMatrix
+    from brain.memory.store import Memory, MemoryStore
+    from brain.search.base import NoopWebSearcher
+
+    interests_path = tmp_path / "interests.json"
+    interests_path.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "interests": [
+                    {
+                        "id": "i1",
+                        "topic": "marine bio",
+                        "pull_score": 8.0,
+                        "scope": "either",
+                        "related_keywords": ["marine", "bio"],
+                        "notes": "",
+                        "first_seen": "2026-01-01T00:00:00Z",
+                        "last_fed": "2026-01-01T00:00:00Z",
+                        "last_researched_at": None,
+                        "feed_count": 1,
+                        "source_types": ["manual"],
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    config_path = tmp_path / "heartbeat_config.json"
+    HeartbeatConfig(
+        reflex_enabled=False,
+        research_enabled=True,
+        research_days_since_human_min=1.5,
+    ).save(config_path)
+
+    from datetime import UTC, datetime, timedelta
+
+    store = MemoryStore(":memory:")
+    hm = HebbianMatrix(":memory:")
+    try:
+        old_mem = Memory.create_new(
+            content="Hana and I talked long ago",
+            memory_type="conversation",
+            domain="us",
+            emotions={},
+        )
+        store.create(old_mem)
+        store._conn.execute(  # type: ignore[attr-defined]
+            "UPDATE memories SET created_at = ? WHERE id = ?",
+            ((datetime.now(UTC) - timedelta(days=3)).isoformat(), old_mem.id),
+        )
+        store._conn.commit()  # type: ignore[attr-defined]
+
+        HeartbeatState.fresh("manual").save(tmp_path / "heartbeat_state.json")
+
+        engine = HeartbeatEngine(
+            store=store,
+            hebbian=hm,
+            provider=FakeProvider(),
+            state_path=tmp_path / "heartbeat_state.json",
+            config_path=config_path,
+            dream_log_path=tmp_path / "dreams.log.jsonl",
+            heartbeat_log_path=tmp_path / "heartbeats.log.jsonl",
+            reflex_arcs_path=tmp_path / "reflex_arcs.json",
+            reflex_log_path=tmp_path / "reflex_log.json",
+            reflex_default_arcs_path=DEFAULT_REFLEX_ARCS_PATH,
+            searcher=NoopWebSearcher(),
+            interests_path=interests_path,
+            research_log_path=tmp_path / "research_log.json",
+            default_interests_path=DEFAULT_INTERESTS_PATH,
+            persona_name="Nell",
+            persona_system_prompt="You are Nell.",
+        )
+        result = engine.run_tick(trigger="manual", dry_run=False)
+        assert result.research_fired == "marine bio"
+    finally:
+        store.close()
+        hm.close()
+
+
+def test_heartbeat_reflex_wins_tie_over_research(tmp_path: Path) -> None:
+    """When both reflex and research eligible, reflex fires, research skipped."""
+    import json
+
+    from brain.bridge.provider import FakeProvider
+    from brain.engines.heartbeat import HeartbeatConfig, HeartbeatEngine, HeartbeatState
+    from brain.memory.hebbian import HebbianMatrix
+    from brain.memory.store import Memory, MemoryStore
+    from brain.search.base import NoopWebSearcher
+
+    arcs_path = tmp_path / "reflex_arcs.json"
+    arcs_path.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "arcs": [
+                    {
+                        "name": "test_arc",
+                        "description": "d",
+                        "trigger": {"love": 5},
+                        "days_since_human_min": 0,
+                        "cooldown_hours": 1.0,
+                        "action": "a",
+                        "output_memory_type": "reflex_journal",
+                        "prompt_template": "Hi.",
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    interests_path = tmp_path / "interests.json"
+    interests_path.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "interests": [
+                    {
+                        "id": "i1",
+                        "topic": "marine bio",
+                        "pull_score": 8.0,
+                        "scope": "either",
+                        "related_keywords": ["marine"],
+                        "notes": "",
+                        "first_seen": "2026-01-01T00:00:00Z",
+                        "last_fed": "2026-01-01T00:00:00Z",
+                        "last_researched_at": None,
+                        "feed_count": 1,
+                        "source_types": ["manual"],
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    config_path = tmp_path / "heartbeat_config.json"
+    HeartbeatConfig(
+        reflex_enabled=True,
+        research_enabled=True,
+        research_emotion_threshold=5.0,
+    ).save(config_path)
+
+    store = MemoryStore(":memory:")
+    hm = HebbianMatrix(":memory:")
+    try:
+        store.create(
+            Memory.create_new(
+                content="s",
+                memory_type="conversation",
+                domain="us",
+                emotions={"love": 8.0},
+            )
+        )
+        HeartbeatState.fresh("manual").save(tmp_path / "heartbeat_state.json")
+
+        engine = HeartbeatEngine(
+            store=store,
+            hebbian=hm,
+            provider=FakeProvider(),
+            state_path=tmp_path / "heartbeat_state.json",
+            config_path=config_path,
+            dream_log_path=tmp_path / "dreams.log.jsonl",
+            heartbeat_log_path=tmp_path / "heartbeats.log.jsonl",
+            reflex_arcs_path=arcs_path,
+            reflex_log_path=tmp_path / "reflex_log.json",
+            reflex_default_arcs_path=DEFAULT_REFLEX_ARCS_PATH,
+            searcher=NoopWebSearcher(),
+            interests_path=interests_path,
+            research_log_path=tmp_path / "research_log.json",
+            default_interests_path=DEFAULT_INTERESTS_PATH,
+            persona_name="Nell",
+            persona_system_prompt="You are Nell.",
+        )
+        result = engine.run_tick(trigger="manual", dry_run=False)
+        assert result.reflex_fired == ("test_arc",)
+        assert result.research_fired is None
+        assert result.research_gated_reason == "reflex_won_tie"
+    finally:
+        store.close()
+        hm.close()
+
+
+def test_heartbeat_interest_bump_hook(tmp_path: Path) -> None:
+    """Conversation memory with matching keyword bumps interest pull_score."""
+    import json
+
+    from brain.bridge.provider import FakeProvider
+    from brain.engines._interests import InterestSet
+    from brain.engines.heartbeat import HeartbeatConfig, HeartbeatEngine, HeartbeatState
+    from brain.memory.hebbian import HebbianMatrix
+    from brain.memory.store import Memory, MemoryStore
+    from brain.search.base import NoopWebSearcher
+
+    interests_path = tmp_path / "interests.json"
+    interests_path.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "interests": [
+                    {
+                        "id": "i1",
+                        "topic": "lispector",
+                        "pull_score": 5.0,
+                        "scope": "either",
+                        "related_keywords": ["lispector", "clarice"],
+                        "notes": "",
+                        "first_seen": "2026-01-01T00:00:00Z",
+                        "last_fed": "2026-01-01T00:00:00Z",
+                        "last_researched_at": None,
+                        "feed_count": 3,
+                        "source_types": ["manual"],
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    config_path = tmp_path / "heartbeat_config.json"
+    HeartbeatConfig(
+        reflex_enabled=False,
+        research_enabled=False,
+        interest_bump_per_match=0.5,
+    ).save(config_path)
+
+    from datetime import UTC, datetime, timedelta
+
+    store = MemoryStore(":memory:")
+    hm = HebbianMatrix(":memory:")
+    try:
+        # Backdate state.last_tick_at to 1h ago so the memory seeded "now"
+        # qualifies as "conversation since last tick" for the ingestion hook.
+        prior_state = HeartbeatState.fresh("manual")
+        prior_state.last_tick_at = datetime.now(UTC) - timedelta(hours=1)
+        prior_state.save(tmp_path / "heartbeat_state.json")
+
+        store.create(
+            Memory.create_new(
+                content="Hana sent me a passage about clarice lispector today",
+                memory_type="conversation",
+                domain="us",
+                emotions={},
+            )
+        )
+
+        engine = HeartbeatEngine(
+            store=store,
+            hebbian=hm,
+            provider=FakeProvider(),
+            state_path=tmp_path / "heartbeat_state.json",
+            config_path=config_path,
+            dream_log_path=tmp_path / "dreams.log.jsonl",
+            heartbeat_log_path=tmp_path / "heartbeats.log.jsonl",
+            reflex_arcs_path=tmp_path / "reflex_arcs.json",
+            reflex_log_path=tmp_path / "reflex_log.json",
+            reflex_default_arcs_path=DEFAULT_REFLEX_ARCS_PATH,
+            searcher=NoopWebSearcher(),
+            interests_path=interests_path,
+            research_log_path=tmp_path / "research_log.json",
+            default_interests_path=DEFAULT_INTERESTS_PATH,
+            persona_name="Nell",
+            persona_system_prompt="You are Nell.",
+        )
+        result = engine.run_tick(trigger="manual", dry_run=False)
+        assert result.interests_bumped == 1
+        reloaded = InterestSet.load(interests_path, default_path=DEFAULT_INTERESTS_PATH)
+        assert reloaded.interests[0].pull_score == 5.5
+        assert reloaded.interests[0].feed_count == 4
+    finally:
+        store.close()
+        hm.close()
+
+
+def test_heartbeat_isolates_research_failure(tmp_path: Path, caplog) -> None:
+    """Research LLM failure is isolated — tick completes."""
+    import json
+    import logging
+
+    from brain.bridge.provider import FakeProvider
+    from brain.engines.heartbeat import HeartbeatConfig, HeartbeatEngine, HeartbeatState
+    from brain.memory.hebbian import HebbianMatrix
+    from brain.memory.store import Memory, MemoryStore
+    from brain.search.base import NoopWebSearcher
+
+    interests_path = tmp_path / "interests.json"
+    interests_path.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "interests": [
+                    {
+                        "id": "i1",
+                        "topic": "t",
+                        "pull_score": 8.0,
+                        "scope": "either",
+                        "related_keywords": ["t"],
+                        "notes": "",
+                        "first_seen": "2026-01-01T00:00:00Z",
+                        "last_fed": "2026-01-01T00:00:00Z",
+                        "last_researched_at": None,
+                        "feed_count": 1,
+                        "source_types": ["manual"],
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    config_path = tmp_path / "heartbeat_config.json"
+    HeartbeatConfig(
+        reflex_enabled=False, research_enabled=True, research_emotion_threshold=5.0
+    ).save(config_path)
+
+    class FailingProvider(FakeProvider):
+        def generate(self, prompt, *, system=None):
+            raise RuntimeError("simulated LLM failure")
+
+    store = MemoryStore(":memory:")
+    hm = HebbianMatrix(":memory:")
+    try:
+        store.create(
+            Memory.create_new(
+                content="s",
+                memory_type="conversation",
+                domain="us",
+                emotions={"love": 8.0},
+            )
+        )
+        HeartbeatState.fresh("manual").save(tmp_path / "heartbeat_state.json")
+
+        engine = HeartbeatEngine(
+            store=store,
+            hebbian=hm,
+            provider=FailingProvider(),
+            state_path=tmp_path / "heartbeat_state.json",
+            config_path=config_path,
+            dream_log_path=tmp_path / "dreams.log.jsonl",
+            heartbeat_log_path=tmp_path / "heartbeats.log.jsonl",
+            reflex_arcs_path=tmp_path / "reflex_arcs.json",
+            reflex_log_path=tmp_path / "reflex_log.json",
+            reflex_default_arcs_path=DEFAULT_REFLEX_ARCS_PATH,
+            searcher=NoopWebSearcher(),
+            interests_path=interests_path,
+            research_log_path=tmp_path / "research_log.json",
+            default_interests_path=DEFAULT_INTERESTS_PATH,
+            persona_name="Nell",
+            persona_system_prompt="You are Nell.",
+        )
+        with caplog.at_level(logging.WARNING, logger="brain.engines.heartbeat"):
+            result = engine.run_tick(trigger="manual", dry_run=False)
+        assert result.research_fired is None
+        assert result.research_gated_reason == "research_raised"
+        assert any("research tick raised" in r.message for r in caplog.records)
     finally:
         store.close()
         hm.close()

--- a/tests/unit/brain/engines/test_interests.py
+++ b/tests/unit/brain/engines/test_interests.py
@@ -1,0 +1,197 @@
+"""Unit tests for brain.engines._interests."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from brain.engines._interests import Interest, InterestSet
+
+DEFAULT_INTERESTS_PATH = Path(__file__).parents[4] / "brain" / "engines" / "default_interests.json"
+
+
+def _sample_dict(**overrides) -> dict:
+    base = {
+        "id": "abc-123",
+        "topic": "Test topic",
+        "pull_score": 6.5,
+        "scope": "either",
+        "related_keywords": ["test", "topic"],
+        "notes": "",
+        "first_seen": "2026-04-01T10:00:00Z",
+        "last_fed": "2026-04-15T10:00:00Z",
+        "last_researched_at": None,
+        "feed_count": 3,
+        "source_types": ["manual"],
+    }
+    base.update(overrides)
+    return base
+
+
+# ---- Interest ----
+
+
+def test_interest_from_dict_valid():
+    i = Interest.from_dict(_sample_dict())
+    assert i.id == "abc-123"
+    assert i.pull_score == 6.5
+    assert i.scope == "either"
+    assert i.related_keywords == ("test", "topic")
+    assert i.last_researched_at is None
+
+
+def test_interest_from_dict_with_researched_timestamp():
+    data = _sample_dict(last_researched_at="2026-04-20T10:00:00Z")
+    i = Interest.from_dict(data)
+    assert i.last_researched_at is not None
+    assert i.last_researched_at.tzinfo is not None
+
+
+def test_interest_from_dict_invalid_scope_raises():
+    with pytest.raises(ValueError):
+        Interest.from_dict(_sample_dict(scope="whatever"))
+
+
+def test_interest_to_dict_roundtrip():
+    original = Interest.from_dict(_sample_dict())
+    restored = Interest.from_dict(original.to_dict())
+    assert restored == original
+
+
+# ---- InterestSet: load / save ----
+
+
+def test_interestset_load_missing_falls_back_to_defaults(tmp_path: Path):
+    missing = tmp_path / "nope.json"
+    loaded = InterestSet.load(missing, default_path=DEFAULT_INTERESTS_PATH)
+    assert loaded.interests == ()  # default is empty
+
+
+def test_interestset_load_corrupt_falls_back(tmp_path: Path):
+    bad = tmp_path / "interests.json"
+    bad.write_text("not valid{", encoding="utf-8")
+    loaded = InterestSet.load(bad, default_path=DEFAULT_INTERESTS_PATH)
+    assert loaded.interests == ()
+
+
+def test_interestset_load_valid_file(tmp_path: Path):
+    path = tmp_path / "interests.json"
+    path.write_text(json.dumps({"version": 1, "interests": [_sample_dict()]}), encoding="utf-8")
+    loaded = InterestSet.load(path, default_path=DEFAULT_INTERESTS_PATH)
+    assert len(loaded.interests) == 1
+    assert loaded.interests[0].topic == "Test topic"
+
+
+def test_interestset_save_atomic(tmp_path: Path):
+    path = tmp_path / "interests.json"
+    s = InterestSet(interests=(Interest.from_dict(_sample_dict()),))
+    s.save(path)
+    # File exists + valid JSON + .new tempfile cleaned up
+    assert path.exists()
+    assert not (path.with_suffix(path.suffix + ".new")).exists()
+    reloaded = InterestSet.load(path, default_path=DEFAULT_INTERESTS_PATH)
+    assert reloaded.interests[0].id == "abc-123"
+
+
+def test_interestset_load_bad_interest_skipped_good_kept(tmp_path: Path):
+    path = tmp_path / "interests.json"
+    payload = {
+        "version": 1,
+        "interests": [_sample_dict(), {"id": "broken"}],  # second missing required keys
+    }
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    loaded = InterestSet.load(path, default_path=DEFAULT_INTERESTS_PATH)
+    topics = {i.topic for i in loaded.interests}
+    assert "Test topic" in topics
+    assert len(loaded.interests) == 1
+
+
+# ---- InterestSet: helpers ----
+
+
+def test_interestset_find_by_topic():
+    s = InterestSet(interests=(Interest.from_dict(_sample_dict(topic="Rebecca")),))
+    assert s.find_by_topic("Rebecca") is not None
+    assert s.find_by_topic("rebecca") is not None  # case-insensitive
+    assert s.find_by_topic("Unknown") is None
+
+
+def test_interestset_bump_existing_topic():
+    now = datetime.now(UTC)
+    s = InterestSet(interests=(Interest.from_dict(_sample_dict(pull_score=6.0, feed_count=3)),))
+    new_s = s.bump("Test topic", amount=0.5, now=now)
+    bumped = new_s.find_by_topic("Test topic")
+    assert bumped is not None
+    assert bumped.pull_score == 6.5
+    assert bumped.feed_count == 4
+    assert bumped.last_fed == now
+
+
+def test_interestset_bump_unknown_topic_returns_unchanged():
+    s = InterestSet(interests=(Interest.from_dict(_sample_dict()),))
+    new_s = s.bump("Unknown", amount=1.0, now=datetime.now(UTC))
+    assert new_s == s
+
+
+def test_interestset_list_eligible_respects_pull_threshold():
+    now = datetime.now(UTC)
+    low = Interest.from_dict(_sample_dict(id="low", topic="A", pull_score=5.0))
+    high = Interest.from_dict(_sample_dict(id="high", topic="B", pull_score=7.0))
+    s = InterestSet(interests=(low, high))
+    eligible = s.list_eligible(pull_threshold=6.0, cooldown_hours=24.0, now=now)
+    assert [i.id for i in eligible] == ["high"]
+
+
+def test_interestset_list_eligible_respects_cooldown():
+    now = datetime.now(UTC)
+    recent = Interest.from_dict(
+        _sample_dict(
+            id="recent",
+            topic="A",
+            pull_score=7.0,
+            last_researched_at=(now - timedelta(hours=1)).isoformat().replace("+00:00", "Z"),
+        )
+    )
+    old = Interest.from_dict(
+        _sample_dict(
+            id="old",
+            topic="B",
+            pull_score=7.0,
+            last_researched_at=(now - timedelta(hours=30)).isoformat().replace("+00:00", "Z"),
+        )
+    )
+    never = Interest.from_dict(_sample_dict(id="never", topic="C", pull_score=7.0))
+    s = InterestSet(interests=(recent, old, never))
+    eligible = s.list_eligible(pull_threshold=6.0, cooldown_hours=24.0, now=now)
+    ids = [i.id for i in eligible]
+    assert "recent" not in ids
+    assert "old" in ids
+    assert "never" in ids
+
+
+def test_interestset_list_eligible_sorted_pull_desc_then_oldest_research():
+    now = datetime.now(UTC)
+    a = Interest.from_dict(
+        _sample_dict(
+            id="a",
+            topic="A",
+            pull_score=7.0,
+            last_researched_at=(now - timedelta(hours=50)).isoformat().replace("+00:00", "Z"),
+        )
+    )
+    b = Interest.from_dict(_sample_dict(id="b", topic="B", pull_score=8.0))
+    c = Interest.from_dict(
+        _sample_dict(
+            id="c",
+            topic="C",
+            pull_score=7.0,
+            last_researched_at=(now - timedelta(hours=100)).isoformat().replace("+00:00", "Z"),
+        )
+    )
+    s = InterestSet(interests=(a, b, c))
+    eligible = s.list_eligible(pull_threshold=6.0, cooldown_hours=24.0, now=now)
+    # b first (highest pull), then c (older research than a), then a
+    assert [i.id for i in eligible] == ["b", "c", "a"]

--- a/tests/unit/brain/engines/test_research.py
+++ b/tests/unit/brain/engines/test_research.py
@@ -2,18 +2,20 @@
 
 from __future__ import annotations
 
-from datetime import UTC, datetime
+import json
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 import pytest
 
 from brain.bridge.provider import FakeProvider
+from brain.engines._interests import InterestSet
 from brain.engines.research import (
     ResearchEngine,
     ResearchFire,
     ResearchResult,
 )
-from brain.memory.store import MemoryStore
+from brain.memory.store import Memory, MemoryStore
 from brain.search.base import NoopWebSearcher
 
 DEFAULT_INTERESTS_PATH = Path(__file__).parents[4] / "brain" / "engines" / "default_interests.json"
@@ -63,20 +65,327 @@ def test_research_engine_construction(tmp_path: Path):
         store.close()
 
 
-def test_run_tick_raises_not_implemented_yet(tmp_path: Path):
+# ---- run_tick ----
+
+
+def _build_engine(
+    tmp_path: Path, store: MemoryStore, provider=None, searcher=None
+) -> ResearchEngine:
+    return ResearchEngine(
+        store=store,
+        provider=provider or FakeProvider(),
+        searcher=searcher or NoopWebSearcher(),
+        persona_name="Nell",
+        persona_system_prompt="You are Nell.",
+        interests_path=tmp_path / "interests.json",
+        research_log_path=tmp_path / "research_log.json",
+        default_interests_path=DEFAULT_INTERESTS_PATH,
+    )
+
+
+def _write_interests(path: Path, interests: list[dict]) -> None:
+    path.write_text(json.dumps({"version": 1, "interests": interests}, indent=2), encoding="utf-8")
+
+
+def _seed_conversation_memory(
+    store: MemoryStore, content: str, emotions: dict[str, float] | None = None
+) -> str:
+    mem = Memory.create_new(
+        content=content,
+        memory_type="conversation",
+        domain="us",
+        emotions=emotions or {},
+    )
+    store.create(mem)
+    return mem.id
+
+
+def _interest_dict(**overrides) -> dict:
+    base = {
+        "id": "i1",
+        "topic": "marine bioluminescence",
+        "pull_score": 7.0,
+        "scope": "either",
+        "related_keywords": ["marine", "bioluminescence", "ocean"],
+        "notes": "",
+        "first_seen": "2026-04-01T10:00:00Z",
+        "last_fed": "2026-04-15T10:00:00Z",
+        "last_researched_at": None,
+        "feed_count": 3,
+        "source_types": ["manual"],
+    }
+    base.update(overrides)
+    return base
+
+
+def test_run_tick_no_interests_defined(tmp_path: Path):
+    _write_interests(tmp_path / "interests.json", [])
     store = MemoryStore(":memory:")
     try:
-        engine = ResearchEngine(
-            store=store,
-            provider=FakeProvider(),
-            searcher=NoopWebSearcher(),
-            persona_name="Nell",
-            persona_system_prompt="You are Nell.",
-            interests_path=tmp_path / "interests.json",
-            research_log_path=tmp_path / "research_log.json",
-            default_interests_path=DEFAULT_INTERESTS_PATH,
-        )
-        with pytest.raises(NotImplementedError):
-            engine.run_tick(trigger="manual", dry_run=False)
+        engine = _build_engine(tmp_path, store)
+        result = engine.run_tick(trigger="manual", dry_run=False, days_since_human_override=5.0)
+        assert result.fired is None
+        assert result.reason == "no_interests_defined"
     finally:
         store.close()
+
+
+def test_run_tick_not_due_returns_reason(tmp_path: Path):
+    _write_interests(tmp_path / "interests.json", [_interest_dict()])
+    store = MemoryStore(":memory:")
+    try:
+        engine = _build_engine(tmp_path, store)
+        # Low days + no emotion signal provided → not due
+        result = engine.run_tick(
+            trigger="manual",
+            dry_run=False,
+            days_since_human_override=0.0,
+            emotion_state_override=None,
+        )
+        assert result.fired is None
+        assert result.reason == "not_due"
+    finally:
+        store.close()
+
+
+def test_run_tick_days_since_human_triggers(tmp_path: Path):
+    _write_interests(tmp_path / "interests.json", [_interest_dict()])
+    store = MemoryStore(":memory:")
+    try:
+        engine = _build_engine(tmp_path, store)
+        result = engine.run_tick(
+            trigger="days_since_human", dry_run=False, days_since_human_override=5.0
+        )
+        # Now eligible + selected + fired
+        assert result.fired is not None
+        assert result.fired.topic == "marine bioluminescence"
+    finally:
+        store.close()
+
+
+def test_run_tick_emotion_high_triggers(tmp_path: Path):
+    from brain.emotion.state import EmotionalState
+
+    _write_interests(tmp_path / "interests.json", [_interest_dict()])
+    store = MemoryStore(":memory:")
+    try:
+        engine = _build_engine(tmp_path, store)
+        es = EmotionalState()
+        es.set("creative_hunger", 8.0)
+        result = engine.run_tick(
+            trigger="emotion_high",
+            dry_run=False,
+            days_since_human_override=0.0,
+            emotion_state_override=es,
+        )
+        assert result.fired is not None
+    finally:
+        store.close()
+
+
+def test_run_tick_pull_threshold_filters(tmp_path: Path):
+    _write_interests(
+        tmp_path / "interests.json", [_interest_dict(pull_score=5.0)]
+    )  # below threshold 6.0
+    store = MemoryStore(":memory:")
+    try:
+        engine = _build_engine(tmp_path, store)
+        result = engine.run_tick(days_since_human_override=5.0)
+        assert result.fired is None
+        assert result.reason == "no_eligible_interest"
+    finally:
+        store.close()
+
+
+def test_run_tick_cooldown_filters(tmp_path: Path):
+    now = datetime.now(UTC)
+    recent = (now - timedelta(hours=1)).isoformat().replace("+00:00", "Z")
+    _write_interests(tmp_path / "interests.json", [_interest_dict(last_researched_at=recent)])
+    store = MemoryStore(":memory:")
+    try:
+        engine = _build_engine(tmp_path, store)
+        result = engine.run_tick(days_since_human_override=5.0)
+        assert result.fired is None
+        assert result.reason == "no_eligible_interest"
+    finally:
+        store.close()
+
+
+def test_run_tick_ranks_highest_pull(tmp_path: Path):
+    _write_interests(
+        tmp_path / "interests.json",
+        [
+            _interest_dict(id="low", topic="Topic A", pull_score=6.5, related_keywords=["a"]),
+            _interest_dict(id="high", topic="Topic B", pull_score=8.0, related_keywords=["b"]),
+        ],
+    )
+    store = MemoryStore(":memory:")
+    try:
+        engine = _build_engine(tmp_path, store)
+        result = engine.run_tick(days_since_human_override=5.0)
+        assert result.fired is not None
+        assert result.fired.topic == "Topic B"
+    finally:
+        store.close()
+
+
+def test_run_tick_forced_interest_bypasses_gates(tmp_path: Path):
+    _write_interests(
+        tmp_path / "interests.json", [_interest_dict(pull_score=2.0)]
+    )  # way below threshold
+    store = MemoryStore(":memory:")
+    try:
+        engine = _build_engine(tmp_path, store)
+        result = engine.run_tick(
+            days_since_human_override=0.0,  # not-due gate would also block
+            forced_interest_topic="marine bioluminescence",
+        )
+        assert result.fired is not None
+        assert result.fired.topic == "marine bioluminescence"
+    finally:
+        store.close()
+
+
+def test_run_tick_forced_interest_not_found(tmp_path: Path):
+    _write_interests(tmp_path / "interests.json", [_interest_dict()])
+    store = MemoryStore(":memory:")
+    try:
+        engine = _build_engine(tmp_path, store)
+        result = engine.run_tick(
+            days_since_human_override=5.0,
+            forced_interest_topic="Unknown Topic",
+        )
+        assert result.fired is None
+        assert result.reason == "no_eligible_interest"
+    finally:
+        store.close()
+
+
+def test_run_tick_dry_run_reports_would_fire(tmp_path: Path):
+    _write_interests(tmp_path / "interests.json", [_interest_dict()])
+    store = MemoryStore(":memory:")
+    try:
+        engine = _build_engine(tmp_path, store)
+        result = engine.run_tick(dry_run=True, days_since_human_override=5.0)
+        assert result.dry_run is True
+        assert result.would_fire == "marine bioluminescence"
+        assert result.fired is None
+        # No memory written
+        assert store.count() == 0
+        # No log file
+        assert not (tmp_path / "research_log.json").exists()
+    finally:
+        store.close()
+
+
+def test_run_tick_fire_writes_research_memory(tmp_path: Path):
+    _write_interests(tmp_path / "interests.json", [_interest_dict()])
+    store = MemoryStore(":memory:")
+    try:
+        engine = _build_engine(tmp_path, store)
+        result = engine.run_tick(days_since_human_override=5.0)
+        assert result.fired is not None
+        mem = store.get(result.fired.output_memory_id)
+        assert mem is not None
+        assert mem.memory_type == "research"
+        assert mem.metadata["interest_topic"] == "marine bioluminescence"
+        assert mem.metadata["web_used"] is False  # Noop searcher returns []
+    finally:
+        store.close()
+
+
+def test_run_tick_fire_updates_interest_last_researched_at(tmp_path: Path):
+    _write_interests(tmp_path / "interests.json", [_interest_dict()])
+    store = MemoryStore(":memory:")
+    try:
+        engine = _build_engine(tmp_path, store)
+        engine.run_tick(days_since_human_override=5.0)
+        # Reload interests and verify last_researched_at was updated
+        reloaded = InterestSet.load(
+            tmp_path / "interests.json", default_path=DEFAULT_INTERESTS_PATH
+        )
+        assert reloaded.interests[0].last_researched_at is not None
+    finally:
+        store.close()
+
+
+def test_run_tick_fire_appends_to_log(tmp_path: Path):
+    _write_interests(tmp_path / "interests.json", [_interest_dict()])
+    store = MemoryStore(":memory:")
+    try:
+        engine = _build_engine(tmp_path, store)
+        engine.run_tick(days_since_human_override=5.0)
+        log_data = json.loads((tmp_path / "research_log.json").read_text(encoding="utf-8"))
+        assert len(log_data["fires"]) == 1
+        assert log_data["fires"][0]["topic"] == "marine bioluminescence"
+    finally:
+        store.close()
+
+
+def test_run_tick_internal_scope_skips_searcher(tmp_path: Path):
+    _write_interests(tmp_path / "interests.json", [_interest_dict(scope="internal")])
+    store = MemoryStore(":memory:")
+
+    class TrackingSearcher(NoopWebSearcher):
+        calls = 0
+
+        def search(self, query: str, *, limit: int = 5):
+            TrackingSearcher.calls += 1
+            return []
+
+    ts = TrackingSearcher()
+    try:
+        engine = _build_engine(tmp_path, store, searcher=ts)
+        result = engine.run_tick(days_since_human_override=5.0)
+        assert result.fired is not None
+        assert TrackingSearcher.calls == 0
+        assert result.fired.web_used is False
+    finally:
+        store.close()
+
+
+def test_run_tick_llm_failure_does_not_touch_files(tmp_path: Path):
+    _write_interests(tmp_path / "interests.json", [_interest_dict()])
+    store = MemoryStore(":memory:")
+
+    class FailingProvider(FakeProvider):
+        def generate(self, prompt, *, system=None):
+            raise RuntimeError("simulated LLM failure")
+
+    try:
+        engine = _build_engine(tmp_path, store, provider=FailingProvider())
+        with pytest.raises(RuntimeError):
+            engine.run_tick(days_since_human_override=5.0)
+        # No memory, no log
+        assert store.count() == 0
+        assert not (tmp_path / "research_log.json").exists()
+        # last_researched_at still None
+        reloaded = InterestSet.load(
+            tmp_path / "interests.json", default_path=DEFAULT_INTERESTS_PATH
+        )
+        assert reloaded.interests[0].last_researched_at is None
+    finally:
+        store.close()
+
+
+def test_run_tick_renders_prompt_with_context(tmp_path: Path):
+    _write_interests(tmp_path / "interests.json", [_interest_dict()])
+    store = MemoryStore(":memory:")
+    _seed_conversation_memory(store, "I love how deep-sea creatures make their own light.")
+
+    captured = {}
+
+    class CapturingProvider(FakeProvider):
+        def generate(self, prompt, *, system=None):
+            captured["prompt"] = prompt
+            captured["system"] = system
+            return "I spent some time today exploring marine bioluminescence..."
+
+    try:
+        engine = _build_engine(tmp_path, store, provider=CapturingProvider())
+        engine.run_tick(days_since_human_override=5.0)
+    finally:
+        store.close()
+
+    assert "marine bioluminescence" in captured["prompt"]
+    assert "Nell" in (captured["system"] or "")

--- a/tests/unit/brain/engines/test_research.py
+++ b/tests/unit/brain/engines/test_research.py
@@ -1,0 +1,82 @@
+"""Unit tests for brain.engines.research — scaffold + types."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+from brain.bridge.provider import FakeProvider
+from brain.engines.research import (
+    ResearchEngine,
+    ResearchFire,
+    ResearchResult,
+)
+from brain.memory.store import MemoryStore
+from brain.search.base import NoopWebSearcher
+
+DEFAULT_INTERESTS_PATH = Path(__file__).parents[4] / "brain" / "engines" / "default_interests.json"
+
+
+def test_research_fire_construction():
+    fire = ResearchFire(
+        interest_id="abc",
+        topic="Test",
+        fired_at=datetime.now(UTC),
+        trigger="manual",
+        web_used=False,
+        web_result_count=0,
+        output_memory_id="mem_xyz",
+    )
+    assert fire.topic == "Test"
+    assert fire.web_used is False
+
+
+def test_research_result_construction():
+    r = ResearchResult(
+        fired=None,
+        would_fire=None,
+        reason="not_due",
+        dry_run=False,
+        evaluated_at=datetime.now(UTC),
+    )
+    assert r.fired is None
+    assert r.reason == "not_due"
+
+
+def test_research_engine_construction(tmp_path: Path):
+    store = MemoryStore(":memory:")
+    try:
+        engine = ResearchEngine(
+            store=store,
+            provider=FakeProvider(),
+            searcher=NoopWebSearcher(),
+            persona_name="Nell",
+            persona_system_prompt="You are Nell.",
+            interests_path=tmp_path / "interests.json",
+            research_log_path=tmp_path / "research_log.json",
+            default_interests_path=DEFAULT_INTERESTS_PATH,
+        )
+        assert engine.persona_name == "Nell"
+    finally:
+        store.close()
+
+
+def test_run_tick_raises_not_implemented_yet(tmp_path: Path):
+    store = MemoryStore(":memory:")
+    try:
+        engine = ResearchEngine(
+            store=store,
+            provider=FakeProvider(),
+            searcher=NoopWebSearcher(),
+            persona_name="Nell",
+            persona_system_prompt="You are Nell.",
+            interests_path=tmp_path / "interests.json",
+            research_log_path=tmp_path / "research_log.json",
+            default_interests_path=DEFAULT_INTERESTS_PATH,
+        )
+        with pytest.raises(NotImplementedError):
+            engine.run_tick(trigger="manual", dry_run=False)
+    finally:
+        store.close()

--- a/tests/unit/brain/migrator/test_cli.py
+++ b/tests/unit/brain/migrator/test_cli.py
@@ -216,3 +216,52 @@ def test_migrate_writes_reflex_arcs(
     assert data["arcs"][0]["output_memory_type"] == "reflex_gift"
     assert report.reflex_arcs_migrated == 1
     assert report.reflex_arcs_skipped_reason is None
+
+
+def test_migrate_writes_interests(
+    og_dir: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Regression: migrator writes interests.json from OG nell_interests.json."""
+    interests_data = {
+        "version": "1.0",
+        "interests": [
+            {
+                "id": "test-id",
+                "topic": "Lispector diagonal syntax",
+                "pull_score": 7.2,
+                "first_seen": "2026-03-29T16:42:33.435028+00:00",
+                "last_fed": "2026-03-31T11:37:13.729750+00:00",
+                "feed_count": 5,
+                "source_types": ["dream"],
+                "related_keywords": ["lispector", "syntax"],
+                "notes": "sideways through meaning",
+            }
+        ],
+    }
+    # og_dir is tmp_path/og_data — nell_interests.json candidate paths include
+    # args.input_dir / "nell_interests.json" which resolves to og_dir directly.
+    (og_dir / "nell_interests.json").write_text(json.dumps(interests_data), encoding="utf-8")
+
+    persona_root = tmp_path / "persona_root"
+    persona_root.mkdir()
+    monkeypatch.setenv("NELLBRAIN_HOME", str(persona_root))
+
+    args = MigrateArgs(
+        input_dir=og_dir,
+        output_dir=None,
+        install_as="testpersona",
+        force=False,
+    )
+    report = run_migrate(args)
+
+    from brain.paths import get_persona_dir
+
+    target = get_persona_dir("testpersona") / "interests.json"
+    assert target.exists()
+    data = json.loads(target.read_text(encoding="utf-8"))
+    assert len(data["interests"]) == 1
+    assert data["interests"][0]["topic"] == "Lispector diagonal syntax"
+    assert data["interests"][0]["scope"] == "either"  # no soul match
+    assert data["interests"][0]["last_researched_at"] is None
+    assert report.interests_migrated == 1
+    assert report.interests_skipped_reason is None

--- a/tests/unit/brain/migrator/test_og_interests.py
+++ b/tests/unit/brain/migrator/test_og_interests.py
@@ -1,0 +1,69 @@
+"""Tests for brain.migrator.og_interests."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from brain.migrator.og_interests import extract_interests_from_og
+
+
+def _write_og_interests(path: Path, interests: list[dict]) -> None:
+    path.write_text(json.dumps({"version": "1.0", "interests": interests}), encoding="utf-8")
+
+
+def _og_interest(**overrides) -> dict:
+    base = {
+        "id": "abc-123",
+        "topic": "Lispector diagonal syntax",
+        "pull_score": 7.2,
+        "first_seen": "2026-03-29T16:42:33.435028+00:00",
+        "last_fed": "2026-03-31T11:37:13.729750+00:00",
+        "feed_count": 5,
+        "source_types": ["dream", "heartbeat"],
+        "related_keywords": ["lispector", "syntax", "language", "clarice"],
+        "notes": "sideways through meaning",
+    }
+    base.update(overrides)
+    return base
+
+
+def test_extract_interests_simple(tmp_path: Path):
+    path = tmp_path / "nell_interests.json"
+    _write_og_interests(path, [_og_interest()])
+    out = extract_interests_from_og(path, soul_names=set())
+    assert len(out) == 1
+    item = out[0]
+    assert item["topic"] == "Lispector diagonal syntax"
+    assert item["scope"] == "either"  # no soul match → default
+    assert item["last_researched_at"] is None
+    assert item["pull_score"] == 7.2
+
+
+def test_extract_interests_scope_classification_from_soul(tmp_path: Path):
+    path = tmp_path / "nell_interests.json"
+    _write_og_interests(
+        path,
+        [
+            _og_interest(id="a", topic="Lispector diagonal syntax"),
+            _og_interest(id="b", topic="Hana"),
+        ],
+    )
+    out = extract_interests_from_og(path, soul_names={"hana"})
+    scopes = {i["topic"]: i["scope"] for i in out}
+    assert scopes["Hana"] == "internal"
+    assert scopes["Lispector diagonal syntax"] == "either"
+
+
+def test_extract_interests_missing_file_raises(tmp_path: Path):
+    with pytest.raises(FileNotFoundError):
+        extract_interests_from_og(tmp_path / "missing.json", soul_names=set())
+
+
+def test_extract_interests_corrupt_json_raises(tmp_path: Path):
+    path = tmp_path / "bad.json"
+    path.write_text("{not json", encoding="utf-8")
+    with pytest.raises(ValueError):
+        extract_interests_from_og(path, soul_names=set())

--- a/tests/unit/brain/search/test_ddgs.py
+++ b/tests/unit/brain/search/test_ddgs.py
@@ -1,0 +1,56 @@
+"""Tests for brain.search.ddgs_searcher.DdgsWebSearcher."""
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import MagicMock, patch
+
+from brain.search.base import SearchResult
+from brain.search.ddgs_searcher import DdgsWebSearcher
+
+
+def test_ddgs_happy_path():
+    fake_ctx = MagicMock()
+    fake_ctx.__enter__.return_value = fake_ctx
+    fake_ctx.__exit__.return_value = None
+    fake_ctx.text.return_value = [
+        {"title": "T1", "href": "https://example.com/1", "body": "s1"},
+        {"title": "T2", "href": "https://example.com/2", "body": "s2"},
+    ]
+
+    with patch("brain.search.ddgs_searcher.DDGS", return_value=fake_ctx):
+        out = DdgsWebSearcher().search("quantum mechanics", limit=2)
+
+    assert len(out) == 2
+    assert out[0] == SearchResult(title="T1", url="https://example.com/1", snippet="s1")
+    assert out[1].url == "https://example.com/2"
+
+
+def test_ddgs_uses_href_or_url_field():
+    fake_ctx = MagicMock()
+    fake_ctx.__enter__.return_value = fake_ctx
+    fake_ctx.__exit__.return_value = None
+    fake_ctx.text.return_value = [{"title": "T", "url": "https://x.com", "body": "s"}]
+
+    with patch("brain.search.ddgs_searcher.DDGS", return_value=fake_ctx):
+        out = DdgsWebSearcher().search("q", limit=1)
+
+    assert out[0].url == "https://x.com"
+
+
+def test_ddgs_transient_failure_returns_empty(caplog):
+    fake_ctx = MagicMock()
+    fake_ctx.__enter__.return_value = fake_ctx
+    fake_ctx.__exit__.return_value = None
+    fake_ctx.text.side_effect = RuntimeError("network down")
+
+    with patch("brain.search.ddgs_searcher.DDGS", return_value=fake_ctx):
+        with caplog.at_level(logging.WARNING, logger="brain.search.ddgs_searcher"):
+            out = DdgsWebSearcher().search("q")
+
+    assert out == []
+    assert any("ddgs search failed" in r.message for r in caplog.records)
+
+
+def test_ddgs_name():
+    assert DdgsWebSearcher().name() == "ddgs"

--- a/tests/unit/brain/search/test_noop.py
+++ b/tests/unit/brain/search/test_noop.py
@@ -1,0 +1,19 @@
+"""Tests for brain.search.base.NoopWebSearcher."""
+
+from __future__ import annotations
+
+from brain.search.base import NoopWebSearcher
+
+
+def test_noop_returns_empty_list():
+    s = NoopWebSearcher()
+    assert s.search("any query") == []
+
+
+def test_noop_returns_empty_with_limit_arg():
+    s = NoopWebSearcher()
+    assert s.search("any query", limit=10) == []
+
+
+def test_noop_name():
+    assert NoopWebSearcher().name() == "noop"

--- a/uv.lock
+++ b/uv.lock
@@ -3,6 +3,18 @@ revision = 3
 requires-python = ">=3.12"
 
 [[package]]
+name = "click"
+version = "8.3.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bb/63/f9e1ea081ce35720d8b92acde70daaedace594dc93b693c869e0d5910718/click-8.3.3.tar.gz", hash = "sha256:398329ad4837b2ff7cbe1dd166a4c0f8900c3ca3a218de04466f38f6497f18a2", size = 328061, upload-time = "2026-04-22T15:11:27.506Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ae/44/c1221527f6a71a01ec6fbad7fa78f1d50dfa02217385cf0fa3eec7087d59/click-8.3.3-py3-none-any.whl", hash = "sha256:a2bf429bb3033c89fa4936ffb35d5cb471e3719e1f3c8a7c3fff0b8314305613", size = 110502, upload-time = "2026-04-22T15:11:25.044Z" },
+]
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
@@ -16,6 +28,7 @@ name = "companion-emergence"
 version = "0.0.1"
 source = { editable = "." }
 dependencies = [
+    { name = "ddgs" },
     { name = "numpy" },
     { name = "platformdirs" },
 ]
@@ -29,6 +42,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "ddgs", specifier = ">=6.0" },
     { name = "numpy", specifier = ">=1.26" },
     { name = "platformdirs", specifier = ">=4.2" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
@@ -122,12 +136,106 @@ wheels = [
 ]
 
 [[package]]
+name = "ddgs"
+version = "9.14.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "lxml" },
+    { name = "primp" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c9/f2/aa1f5af106ea0ef0351d11a2fe05d28618463160137326eeb3073b7d788b/ddgs-9.14.1.tar.gz", hash = "sha256:85b878225a622ba145aff33c0f2f0dceb90d6cfaa291af253021d10cb261a8bb", size = 57157, upload-time = "2026-04-20T12:09:21.313Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4f/a0/c0b568acd6ec819ec94ecfd4eebd00edc855efab06e589ad17d0412ff4ce/ddgs-9.14.1-py3-none-any.whl", hash = "sha256:e6b853be092532add9c0d611c4b121f0b27092de66756401057c2100f6b1ab44", size = 67019, upload-time = "2026-04-20T12:09:19.867Z" },
+]
+
+[[package]]
 name = "iniconfig"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "lxml"
+version = "6.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/28/30/9abc9e34c657c33834eaf6cd02124c61bdf5944d802aa48e69be8da3585d/lxml-6.1.0.tar.gz", hash = "sha256:bfd57d8008c4965709a919c3e9a98f76c2c7cb319086b3d26858250620023b13", size = 4197006, upload-time = "2026-04-18T04:32:51.613Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/d4/9326838b59dc36dfae42eec9656b97520f9997eee1de47b8316aaeed169c/lxml-6.1.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:d2f17a16cd8751e8eb233a7e41aecdf8e511712e00088bf9be455f604cd0d28d", size = 8570663, upload-time = "2026-04-18T04:27:48.253Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/a4/053745ce1f8303ccbb788b86c0db3a91b973675cefc42566a188637b7c40/lxml-6.1.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:f0cea5b1d3e6e77d71bd2b9972eb2446221a69dc52bb0b9c3c6f6e5700592d93", size = 4624024, upload-time = "2026-04-18T04:27:52.594Z" },
+    { url = "https://files.pythonhosted.org/packages/90/97/a517944b20f8fd0932ad2109482bee4e29fe721416387a363306667941f6/lxml-6.1.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:fc46da94826188ed45cb53bd8e3fc076ae22675aea2087843d4735627f867c6d", size = 4930895, upload-time = "2026-04-18T04:32:56.29Z" },
+    { url = "https://files.pythonhosted.org/packages/94/7c/e08a970727d556caa040a44773c7b7e3ad0f0d73dedc863543e9a8b931f2/lxml-6.1.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:9147d8e386ec3b82c3b15d88927f734f565b0aaadef7def562b853adca45784a", size = 5093820, upload-time = "2026-04-18T04:32:58.94Z" },
+    { url = "https://files.pythonhosted.org/packages/88/ee/2a5c2aa2c32016a226ca25d3e1056a8102ea6e1fe308bf50213586635400/lxml-6.1.0-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5715e0e28736a070f3f34a7ccc09e2fdcba0e3060abbcf61a1a5718ff6d6b105", size = 5005790, upload-time = "2026-04-18T04:33:01.272Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/38/a0db9be8f38ad6043ab9429487c128dd1d30f07956ef43040402f8da49e8/lxml-6.1.0-cp312-cp312-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:4937460dc5df0cdd2f06a86c285c28afda06aefa3af949f9477d3e8df430c485", size = 5630827, upload-time = "2026-04-18T04:33:04.036Z" },
+    { url = "https://files.pythonhosted.org/packages/31/ba/3c13d3fc24b7cacf675f808a3a1baabf43a30d0cd24c98f94548e9aa58eb/lxml-6.1.0-cp312-cp312-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bc783ee3147e60a25aa0445ea82b3e8aabb83b240f2b95d32cb75587ff781814", size = 5240445, upload-time = "2026-04-18T04:33:06.87Z" },
+    { url = "https://files.pythonhosted.org/packages/55/ba/eeef4ccba09b2212fe239f46c1692a98db1878e0872ae320756488878a94/lxml-6.1.0-cp312-cp312-manylinux_2_28_i686.whl", hash = "sha256:40d9189f80075f2e1f88db21ef815a2b17b28adf8e50aaf5c789bfe737027f32", size = 5350121, upload-time = "2026-04-18T04:33:09.365Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/01/1da87c7b587c38d0cbe77a01aae3b9c1c49ed47d76918ef3db8fc151b1ca/lxml-6.1.0-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:05b9b8787e35bec69e68daf4952b2e6dfcfb0db7ecf1a06f8cdfbbac4eb71aad", size = 4694949, upload-time = "2026-04-18T04:33:11.628Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/88/7db0fe66d5aaf128443ee1623dec3db1576f3e4c17751ec0ef5866468590/lxml-6.1.0-cp312-cp312-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:0f0f08beb0182e3e9a86fae124b3c47a7b41b7b69b225e1377db983802404e54", size = 5243901, upload-time = "2026-04-18T04:33:13.95Z" },
+    { url = "https://files.pythonhosted.org/packages/00/a8/1346726af7d1f6fca1f11223ba34001462b0a3660416986d37641708d57c/lxml-6.1.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:73becf6d8c81d4c76b1014dbd3584cb26d904492dcf73ca85dc8bff08dcd6d2d", size = 5048054, upload-time = "2026-04-18T04:33:16.965Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/b7/85057012f035d1a0c87e02f8c723ca3c3e6e0728bcf4cb62080b21b1c1e3/lxml-6.1.0-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:1ae225f66e5938f4fa29d37e009a3bb3b13032ac57eb4eb42afa44f6e4054e69", size = 4777324, upload-time = "2026-04-18T04:33:19.832Z" },
+    { url = "https://files.pythonhosted.org/packages/75/6c/ad2f94a91073ef570f33718040e8e160d5fb93331cf1ab3ca1323f939e2d/lxml-6.1.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:690022c7fae793b0489aa68a658822cea83e0d5933781811cabbf5ea3bcfe73d", size = 5645702, upload-time = "2026-04-18T04:33:22.436Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/89/0bb6c0bd549c19004c60eea9dc554dd78fd647b72314ef25d460e0d208c6/lxml-6.1.0-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:63aeafc26aac0be8aff14af7871249e87ea1319be92090bfd632ec68e03b16a5", size = 5232901, upload-time = "2026-04-18T04:33:26.21Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/d9/d609a11fb567da9399f525193e2b49847b5a409cdebe737f06a8b7126bdc/lxml-6.1.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:264c605ab9c0e4aa1a679636f4582c4d3313700009fac3ec9c3412ed0d8f3e1d", size = 5261333, upload-time = "2026-04-18T04:33:28.984Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/3a/ac3f99ec8ac93089e7dd556f279e0d14c24de0a74a507e143a2e4b496e7c/lxml-6.1.0-cp312-cp312-win32.whl", hash = "sha256:56971379bc5ee8037c5a0f09fa88f66cdb7d37c3e38af3e45cf539f41131ac1f", size = 3596289, upload-time = "2026-04-18T04:27:42.819Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/a7/0a915557538593cb1bbeedcd40e13c7a261822c26fecbbdb71dad0c2f540/lxml-6.1.0-cp312-cp312-win_amd64.whl", hash = "sha256:bba078de0031c219e5dd06cf3e6bf8fb8e6e64a77819b358f53bb132e3e03366", size = 3997059, upload-time = "2026-04-18T04:27:46.764Z" },
+    { url = "https://files.pythonhosted.org/packages/92/96/a5dc078cf0126fbfbc35611d77ecd5da80054b5893e28fb213a5613b9e1d/lxml-6.1.0-cp312-cp312-win_arm64.whl", hash = "sha256:c3592631e652afa34999a088f98ba7dfc7d6aff0d535c410bea77a71743f3819", size = 3659552, upload-time = "2026-04-18T04:27:51.133Z" },
+    { url = "https://files.pythonhosted.org/packages/08/03/69347590f1cf4a6d5a4944bb6099e6d37f334784f16062234e1f892fdb1d/lxml-6.1.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:a0092f2b107b69601adf562a57c956fbb596e05e3e6651cabd3054113b007e45", size = 8559689, upload-time = "2026-04-18T04:31:57.785Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/58/25e00bb40b185c974cfe156c110474d9a8a8390d5f7c92a4e328189bb60e/lxml-6.1.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:fc7140d7a7386e6b545d41b7358f4d02b656d4053f5fa6859f92f4b9c2572c4d", size = 4617892, upload-time = "2026-04-18T04:32:01.78Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/54/92ad98a94ac318dc4f97aaac22ff8d1b94212b2ae8af5b6e9b354bf825f7/lxml-6.1.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:419c58fc92cc3a2c3fa5f78c63dbf5da70c1fa9c1b25f25727ecee89a96c7de2", size = 4923489, upload-time = "2026-04-18T04:33:31.401Z" },
+    { url = "https://files.pythonhosted.org/packages/15/3b/a20aecfab42bdf4f9b390590d345857ad3ffd7c51988d1c89c53a0c73faf/lxml-6.1.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:37fabd1452852636cf38ecdcc9dd5ca4bba7a35d6c53fa09725deeb894a87491", size = 5082162, upload-time = "2026-04-18T04:33:34.262Z" },
+    { url = "https://files.pythonhosted.org/packages/45/26/2cdb3d281ac1bd175603e290cbe4bad6eff127c0f8de90bafd6f8548f0fd/lxml-6.1.0-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a2853c8b2170cc6cd54a6b4d50d2c1a8a7aeca201f23804b4898525c7a152cfc", size = 4993247, upload-time = "2026-04-18T04:33:36.674Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/05/d735aef963740022a08185c84821f689fc903acb3d50326e6b1e9886cc22/lxml-6.1.0-cp313-cp313-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:8e369cbd690e788c8d15e56222d91a09c6a417f49cbc543040cba0fe2e25a79e", size = 5613042, upload-time = "2026-04-18T04:33:39.205Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/b8/ead7c10efff731738c72e59ed6eb5791854879fbed7ae98781a12006263a/lxml-6.1.0-cp313-cp313-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e69aa6805905807186eb00e66c6d97a935c928275182eb02ee40ba00da9623b2", size = 5228304, upload-time = "2026-04-18T04:33:41.647Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/10/e9842d2ec322ea65f0a7270aa0315a53abed06058b88ef1b027f620e7a5f/lxml-6.1.0-cp313-cp313-manylinux_2_28_i686.whl", hash = "sha256:4bd1bdb8a9e0e2dd229de19b5f8aebac80e916921b4b2c6ef8a52bc131d0c1f9", size = 5341578, upload-time = "2026-04-18T04:33:44.596Z" },
+    { url = "https://files.pythonhosted.org/packages/89/54/40d9403d7c2775fa7301d3ddd3464689bfe9ba71acc17dfff777071b4fdc/lxml-6.1.0-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:cbd7b79cdcb4986ad78a2662625882747f09db5e4cd7b2ae178a88c9c51b3dfe", size = 4700209, upload-time = "2026-04-18T04:33:47.552Z" },
+    { url = "https://files.pythonhosted.org/packages/85/b2/bbdcc2cf45dfc7dfffef4fd97e5c47b15919b6a365247d95d6f684ef5e82/lxml-6.1.0-cp313-cp313-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:43e4d297f11080ec9d64a4b1ad7ac02b4484c9f0e2179d9c4ef78e886e747b88", size = 5232365, upload-time = "2026-04-18T04:33:50.249Z" },
+    { url = "https://files.pythonhosted.org/packages/48/5a/b06875665e53aaba7127611a7bed3b7b9658e20b22bc2dd217a0b7ab0091/lxml-6.1.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:cc16682cc987a3da00aa56a3aa3075b08edb10d9b1e476938cfdbee8f3b67181", size = 5043654, upload-time = "2026-04-18T04:33:52.71Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/9c/e71a069d09641c1a7abeb30e693f828c7c90a41cbe3d650b2d734d876f85/lxml-6.1.0-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:d6d8efe71429635f0559579092bb5e60560d7b9115ee38c4adbea35632e7fa24", size = 4769326, upload-time = "2026-04-18T04:33:55.244Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/06/7a9cd84b3d4ed79adf35f874750abb697dec0b4a81a836037b36e47c091a/lxml-6.1.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:7e39ab3a28af7784e206d8606ec0e4bcad0190f63a492bca95e94e5a4aef7f6e", size = 5635879, upload-time = "2026-04-18T04:33:58.509Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/f0/9d57916befc1e54c451712c7ee48e9e74e80ae4d03bdce49914e0aee42cd/lxml-6.1.0-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:9eb667bf50856c4a58145f8ca2d5e5be160191e79eb9e30855a476191b3c3495", size = 5224048, upload-time = "2026-04-18T04:34:00.943Z" },
+    { url = "https://files.pythonhosted.org/packages/99/75/90c4eefda0c08c92221fe0753db2d6699a4c628f76ff4465ec20dea84cc1/lxml-6.1.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:7f4a77d6f7edf9230cee3e1f7f6764722a41604ee5681844f18db9a81ea0ec33", size = 5250241, upload-time = "2026-04-18T04:34:03.365Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/73/16596f7e4e38fa33084b9ccbccc22a15f82a290a055126f2c1541236d2ff/lxml-6.1.0-cp313-cp313-win32.whl", hash = "sha256:28902146ffbe5222df411c5d19e5352490122e14447e98cd118907ee3fd6ee62", size = 3596938, upload-time = "2026-04-18T04:31:56.206Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/63/981401c5680c1eb30893f00a19641ac80db5d1e7086c62cb4b13ed813038/lxml-6.1.0-cp313-cp313-win_amd64.whl", hash = "sha256:4a1503c56e4e2b38dc76f2f2da7bae69670c0f1933e27cfa34b2fa5876410b16", size = 3995728, upload-time = "2026-04-18T04:31:58.763Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/e8/c358a38ac3e541d16a1b527e4e9cb78c0419b0506a070ace11777e5e8404/lxml-6.1.0-cp313-cp313-win_arm64.whl", hash = "sha256:e0af85773850417d994d019741239b901b22c6680206f46a34766926e466141d", size = 3658372, upload-time = "2026-04-18T04:32:03.629Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/45/cee4cf203ef0bab5c52afc118da61d6b460c928f2893d40023cfa27e0b80/lxml-6.1.0-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:ab863fd37458fed6456525f297d21239d987800c46e67da5ef04fc6b3dd93ac8", size = 8576713, upload-time = "2026-04-18T04:32:06.831Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/a7/eda05babeb7e046839204eaf254cd4d7c9130ce2bbf0d9e90ea41af5654d/lxml-6.1.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:6fd8b1df8254ff4fd93fd31da1fc15770bde23ac045be9bb1f87425702f61cc9", size = 4623874, upload-time = "2026-04-18T04:32:10.755Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/e9/db5846de9b436b91890a62f29d80cd849ea17948a49bf532d5278ee69a9e/lxml-6.1.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:47024feaae386a92a146af0d2aeed65229bf6fff738e6a11dda6b0015fb8fd03", size = 4949535, upload-time = "2026-04-18T04:34:06.657Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/ba/0d3593373dcae1d68f40dc3c41a5a92f2544e68115eb2f62319a4c2a6500/lxml-6.1.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3f00972f84450204cd5d93a5395965e348956aaceaadec693a22ec743f8ae3eb", size = 5086881, upload-time = "2026-04-18T04:34:09.556Z" },
+    { url = "https://files.pythonhosted.org/packages/43/76/759a7484539ad1af0d125a9afe9c3fb5f82a8779fd1f5f56319d9e4ea2fd/lxml-6.1.0-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:97faa0860e13b05b15a51fb4986421ef7a30f0b3334061c416e0981e9450ca4c", size = 5031305, upload-time = "2026-04-18T04:34:12.336Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/b9/c1f0daf981a11e47636126901fd4ab82429e18c57aeb0fc3ad2940b42d8b/lxml-6.1.0-cp314-cp314-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:972a6451204798675407beaad97b868d0c733d9a74dafefc63120b81b8c2de28", size = 5647522, upload-time = "2026-04-18T04:34:14.89Z" },
+    { url = "https://files.pythonhosted.org/packages/31/e6/1f533dcd205275363d9ba3511bcec52fa2df86abf8abe6a5f2c599f0dc31/lxml-6.1.0-cp314-cp314-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fe022f20bc4569ec66b63b3fb275a3d628d9d32da6326b2982584104db6d3086", size = 5239310, upload-time = "2026-04-18T04:34:17.652Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/8c/4175fb709c78a6e315ed814ed33be3defd8b8721067e70419a6cf6f971da/lxml-6.1.0-cp314-cp314-manylinux_2_28_i686.whl", hash = "sha256:75c4c7c619a744f972f4451bf5adf6d0fb00992a1ffc9fd78e13b0bc817cc99f", size = 5350799, upload-time = "2026-04-18T04:34:20.529Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/77/6ffdebc5994975f0dde4acb59761902bd9d9bb84422b9a0bd239a7da9ca8/lxml-6.1.0-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:3648f20d25102a22b6061c688beb3a805099ea4beb0a01ce62975d926944d292", size = 4697693, upload-time = "2026-04-18T04:34:23.541Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/f1/565f36bd5c73294602d48e04d23f81ff4c8736be6ba5e1d1ec670ac9be80/lxml-6.1.0-cp314-cp314-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:77b9f99b17cbf14026d1e618035077060fc7195dd940d025149f3e2e830fbfcb", size = 5250708, upload-time = "2026-04-18T04:34:26.001Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/11/a68ab9dd18c5c499404deb4005f4bc4e0e88e5b72cd755ad96efec81d18d/lxml-6.1.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:32662519149fd7a9db354175aa5e417d83485a8039b8aaa62f873ceee7ea4cad", size = 5084737, upload-time = "2026-04-18T04:34:28.32Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/78/e8f41e2c74f4af564e6a0348aea69fb6daaefa64bc071ef469823d22cc18/lxml-6.1.0-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:73d658216fc173cf2c939e90e07b941c5e12736b0bf6a99e7af95459cfe8eabb", size = 4737817, upload-time = "2026-04-18T04:34:30.784Z" },
+    { url = "https://files.pythonhosted.org/packages/06/2d/aa4e117aa2ce2f3b35d9ff246be74a2f8e853baba5d2a92c64744474603a/lxml-6.1.0-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:ac4db068889f8772a4a698c5980ec302771bb545e10c4b095d4c8be26749616f", size = 5670753, upload-time = "2026-04-18T04:34:33.675Z" },
+    { url = "https://files.pythonhosted.org/packages/08/f5/dd745d50c0409031dbfcc4881740542a01e54d6f0110bd420fa7782110b8/lxml-6.1.0-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:45e9dfbd1b661eb64ba0d4dbe762bd210c42d86dd1e5bd2bdf89d634231beb43", size = 5238071, upload-time = "2026-04-18T04:34:36.12Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/74/ad424f36d0340a904665867dab310a3f1f4c96ff4039698de83b77f44c1f/lxml-6.1.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:89e8d73d09ac696a5ba42ec69787913d53284f12092f651506779314f10ba585", size = 5264319, upload-time = "2026-04-18T04:34:39.035Z" },
+    { url = "https://files.pythonhosted.org/packages/53/36/a15d8b3514ec889bfd6aa3609107fcb6c9189f8dc347f1c0b81eded8d87c/lxml-6.1.0-cp314-cp314-win32.whl", hash = "sha256:ebe33f4ec1b2de38ceb225a1749a2965855bffeef435ba93cd2d5d540783bf2f", size = 3657139, upload-time = "2026-04-18T04:32:20.006Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/a4/263ebb0710851a3c6c937180a9a86df1206fdfe53cc43005aa2237fd7736/lxml-6.1.0-cp314-cp314-win_amd64.whl", hash = "sha256:398443df51c538bd578529aa7e5f7afc6c292644174b47961f3bf87fe5741120", size = 4064195, upload-time = "2026-04-18T04:32:23.876Z" },
+    { url = "https://files.pythonhosted.org/packages/80/68/2000f29d323b6c286de077ad20b429fc52272e44eae6d295467043e56012/lxml-6.1.0-cp314-cp314-win_arm64.whl", hash = "sha256:8c8984e1d8c4b3949e419158fda14d921ff703a9ed8a47236c6eb7a2b6cb4946", size = 3741870, upload-time = "2026-04-18T04:32:27.922Z" },
+    { url = "https://files.pythonhosted.org/packages/30/e9/21383c7c8d43799f0da90224c0d7c921870d476ec9b3e01e1b2c0b8237c5/lxml-6.1.0-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:1081dd10bc6fa437db2500e13993abf7cc30716d0a2f40e65abb935f02ec559c", size = 8827548, upload-time = "2026-04-18T04:32:15.094Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/01/c6bc11cd587030dd4f719f65c5657960649fe3e19196c844c75bf32cd0d6/lxml-6.1.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:dabecc48db5f42ba348d1f5d5afdc54c6c4cc758e676926c7cd327045749517d", size = 4735866, upload-time = "2026-04-18T04:32:18.924Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/01/757132fff5f4acf25463b5298f1a46099f3a94480b806547b29ce5e385de/lxml-6.1.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:e3dd5fe19c9e0ac818a9c7f132a5e43c1339ec1cbbfecb1a938bd3a47875b7c9", size = 4969476, upload-time = "2026-04-18T04:34:41.889Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/fb/1bc8b9d27ed64be7c8903db6c89e74dc8c2cd9ec630a7462e4654316dc5b/lxml-6.1.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:9e7b0a4ca6dcc007a4cef00a761bba2dea959de4bd2df98f926b33c92ca5dfb9", size = 5103719, upload-time = "2026-04-18T04:34:44.797Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/e7/5bf82fa28133536a54601aae633b14988e89ed61d4c1eb6b899b023233aa/lxml-6.1.0-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5d27bbe326c6b539c64b42638b18bc6003a8d88f76213a97ac9ed4f885efeab7", size = 5027890, upload-time = "2026-04-18T04:34:47.634Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/20/e048db5d4b4ea0366648aa595f26bb764b2670903fc585b87436d0a5032c/lxml-6.1.0-cp314-cp314t-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c4e425db0c5445ef0ad56b0eec54f89b88b2d884656e536a90b2f52aecb4ca86", size = 5596008, upload-time = "2026-04-18T04:34:51.503Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/c2/d10807bc8da4824b39e5bd01b5d05c077b6fd01bd91584167edf6b269d22/lxml-6.1.0-cp314-cp314t-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4b89b098105b8599dc57adac95d1813409ac476d3c948a498775d3d0c6124bfb", size = 5224451, upload-time = "2026-04-18T04:34:54.263Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/15/2ebea45bea427e7f0057e9ce7b2d62c5aba20c6b001cca89ed0aadb3ad41/lxml-6.1.0-cp314-cp314t-manylinux_2_28_i686.whl", hash = "sha256:c4a699432846df86cc3de502ee85f445ebad748a1c6021d445f3e514d2cd4b1c", size = 5312135, upload-time = "2026-04-18T04:34:56.818Z" },
+    { url = "https://files.pythonhosted.org/packages/31/e2/87eeae151b0be2a308d49a7ec444ff3eb192b14251e62addb29d0bf3778f/lxml-6.1.0-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:30e7b2ed63b6c8e97cca8af048589a788ab5c9c905f36d9cf1c2bb549f450d2f", size = 4639126, upload-time = "2026-04-18T04:34:59.704Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/51/8a3f6a20902ad604dd746ec7b4000311b240d389dac5e9d95adefd349e0c/lxml-6.1.0-cp314-cp314t-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:022981127642fe19866d2907d76241bb07ed21749601f727d5d5dd1ce5d1b773", size = 5232579, upload-time = "2026-04-18T04:35:02.658Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/d2/650d619bdbe048d2c3f2c31edb00e35670a5e2d65b4fe3b61bce37b19121/lxml-6.1.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:23cad0cc86046d4222f7f418910e46b89971c5a45d3c8abfad0f64b7b05e4a9b", size = 5084206, upload-time = "2026-04-18T04:35:05.175Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/8a/672ca1a3cbeabd1f511ca275a916c0514b747f4b85bdaae103b8fa92f307/lxml-6.1.0-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:21c3302068f50d1e8728c67c87ba92aa87043abee517aa2576cca1855326b405", size = 4758906, upload-time = "2026-04-18T04:35:08.098Z" },
+    { url = "https://files.pythonhosted.org/packages/be/f1/ef4b691da85c916cb2feb1eec7414f678162798ac85e042fa164419ac05c/lxml-6.1.0-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:be10838781cb3be19251e276910cd508fe127e27c3242e50521521a0f3781690", size = 5620553, upload-time = "2026-04-18T04:35:11.23Z" },
+    { url = "https://files.pythonhosted.org/packages/59/17/94e81def74107809755ac2782fdad4404420f1c92ca83433d117a6d5acf0/lxml-6.1.0-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:2173a7bffe97667bbf0767f8a99e587740a8c56fdf3befac4b09cb29a80276fd", size = 5229458, upload-time = "2026-04-18T04:35:14.254Z" },
+    { url = "https://files.pythonhosted.org/packages/21/55/c4be91b0f830a871fc1b0d730943d56013b683d4671d5198260e2eae722b/lxml-6.1.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:c6854e9cf99c84beb004eecd7d3a3868ef1109bf2b1df92d7bc11e96a36c2180", size = 5247861, upload-time = "2026-04-18T04:35:17.006Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/ca/77123e4d77df3cb1e968ade7b1f808f5d3a5c1c96b18a33895397de292c1/lxml-6.1.0-cp314-cp314t-win32.whl", hash = "sha256:00750d63ef0031a05331b9223463b1c7c02b9004cef2346a5b2877f0f9494dd2", size = 3897377, upload-time = "2026-04-18T04:32:07.656Z" },
+    { url = "https://files.pythonhosted.org/packages/64/ce/3554833989d074267c063209bae8b09815e5656456a2d332b947806b05ff/lxml-6.1.0-cp314-cp314t-win_amd64.whl", hash = "sha256:80410c3a7e3c617af04de17caa9f9f20adaa817093293d69eae7d7d0522836f5", size = 4392701, upload-time = "2026-04-18T04:32:12.113Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/a0/9b916c68c0e57752c07f8f64b30138d9d4059dbeb27b90274dedbea128ff/lxml-6.1.0-cp314-cp314t-win_arm64.whl", hash = "sha256:26dd9f57ee3bd41e7d35b4c98a2ffd89ed11591649f421f0ec19f67d50ec67ac", size = 3817120, upload-time = "2026-04-18T04:32:15.803Z" },
 ]
 
 [[package]]
@@ -216,6 +324,44 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "primp"
+version = "1.2.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/ca/383bdf0df3dc87b60bf73c55da526ac743d42c5155a84a9014775b895e96/primp-1.2.3.tar.gz", hash = "sha256:a531b01f57cb59e3e7a3a2b526bb151b61dc7b2e15d2f6961615a553632e2889", size = 1342866, upload-time = "2026-04-20T08:34:09.018Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b6/b1/05bb7e00bd17a439aae7ed49b0c0834508e3ce50624dfa43c6dcb8b71bd0/primp-1.2.3-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:e96d6ab40fba41039947dad0fcc42b0b56b67180883e526715720bb2d90f3bfc", size = 4360352, upload-time = "2026-04-20T08:33:52.785Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/db/8bb1e4b6bb715f606b53793831e7910aebeb40169e439138e9124686820a/primp-1.2.3-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:42f28679916ce080e643e7464786abeb659c8062c0f74bb411918c7f07e5b806", size = 4035926, upload-time = "2026-04-20T08:34:06.348Z" },
+    { url = "https://files.pythonhosted.org/packages/45/91/52b5e6d840be4d5a8f689d9ba82dd616c67e29e3e1d13baf6a4c9be3f4b3/primp-1.2.3-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:643d47cf24962331ad2b049d6bb4329dce6b18a0914490dbf09541cb38596d39", size = 4309649, upload-time = "2026-04-20T08:34:01.369Z" },
+    { url = "https://files.pythonhosted.org/packages/40/85/d98e20104429bb8393939396c2317ec6163a83d856b1fe555bf5f021e97a/primp-1.2.3-cp310-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:898a12b44af9aed20c10fd4b497314731e9f6dcab20f4aa64cf118f79df17fa0", size = 3910331, upload-time = "2026-04-20T08:33:37.294Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/c7/53f11e2e2fe758830f6f208cef5bd3d0ecc6f538c0a2ca8e15a1fa502bd1/primp-1.2.3-cp310-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d4bdf2b164c2908f7bdc845215dd21ebded1f2f43e9e9ae2d9a961ea56e5cb87", size = 4152054, upload-time = "2026-04-20T08:33:56.193Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/5a/48e8f985daeeb58c7f1789bb6748d9aba250ea3541d787bcbcb1243abfd3/primp-1.2.3-cp310-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:036884d4c6c866c93a88e591e49f67ed160f6a9d98c779fc652cce63de62996a", size = 4443286, upload-time = "2026-04-20T08:34:07.782Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/81/42b32337bd8c7b7b8184a1fcd79fd51d4773427553a8d2036eb0a93a137d/primp-1.2.3-cp310-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:bfc695c20f5c6e345abc3262bef3c246a571986db5cea73bdc41db6b166066c8", size = 4323757, upload-time = "2026-04-20T08:33:43.807Z" },
+    { url = "https://files.pythonhosted.org/packages/37/43/9ee78c283cbca7fcd635c2a9bb5633aa6568b1925958017e1a979fffe56c/primp-1.2.3-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:13255b0826c60681478c787fbe29cfc773caf6242390fee047dac0f23f6e8c11", size = 4525772, upload-time = "2026-04-20T08:33:45.427Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/41/f10164485d84145a1ea18c7966d1ee098d1790b2088b7f122570463b7d5c/primp-1.2.3-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:9bc40f94c8e58444befaf7e78b8aadd96e94e32789dadbe4a03785db772aa4dc", size = 4471705, upload-time = "2026-04-20T08:33:54.317Z" },
+    { url = "https://files.pythonhosted.org/packages/18/a2/5328d66dd8f63bacfc9ef0e1e5fde66b2bb43103108fe8f01dcb2d2f0e50/primp-1.2.3-cp310-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:2e0e8e245113ab3c9fd4b36014b3a04869cf08f72e8e7f36c4f5ef46d26da090", size = 4148309, upload-time = "2026-04-20T08:33:31.609Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/86/4d000d3ee341e5f1e73d81fb2c84e985f23b343a1aa4234c40987ec6eae7/primp-1.2.3-cp310-abi3-musllinux_1_2_i686.whl", hash = "sha256:3bb50934b5e209e7da4876d3419ebc23d1425fe6f089c0cd95382d21bd8a39bd", size = 4276881, upload-time = "2026-04-20T08:33:34.414Z" },
+    { url = "https://files.pythonhosted.org/packages/22/f5/50acc3e349d22044abf4ed7c2abaaba11a01b9ccb6a7d66a3fbc2275c590/primp-1.2.3-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:b293f13078afee9d41b74c77d05a5eaeb57dfab5110648dd24bc3fb3c750a05c", size = 4775229, upload-time = "2026-04-20T08:34:10.241Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/d6/2c482973211666fdf2c4365babf343a88ea30f753ef650121cebd4ad7ece/primp-1.2.3-cp310-abi3-win32.whl", hash = "sha256:c600dd83e9c978bf494aab072cd5bbfdd59b131f3afc353850c53373a86992e5", size = 3504032, upload-time = "2026-04-20T08:33:28.344Z" },
+    { url = "https://files.pythonhosted.org/packages/70/89/3d2032a8f5e986fcc03bc86ac98705ce2bd35ed0e182d4949c159214da6a/primp-1.2.3-cp310-abi3-win_amd64.whl", hash = "sha256:3cbbe52a6eb51a4831d3dd35055f13b28ff5b9be2487c14ffe66922bf8028b49", size = 3872596, upload-time = "2026-04-20T08:33:46.927Z" },
+    { url = "https://files.pythonhosted.org/packages/79/00/f726d54ff00213641069a66ee2fadf17f01f77a2f1ba92de229830056419/primp-1.2.3-cp310-abi3-win_arm64.whl", hash = "sha256:03c668481b2cf34552880f4b6ebabfa913fdaeb2921ce982e42c428f451b630c", size = 3875239, upload-time = "2026-04-20T08:33:32.981Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/e6/1fe1bcaf7566d7e6c9b39748f0d6ded857c80cf3252acf6aa3c6b7b8dbb0/primp-1.2.3-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:0148fd5c0502bb88a26217b606ebb254de44a666dac52657ff97f727577bc7ce", size = 4348055, upload-time = "2026-04-20T08:33:48.193Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/46/cae79466969a31d885409ce716eb5a4af66f66d1121e63ee3ddd7d666b9e/primp-1.2.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:13bfc39172a083cc5520d9045a99988d7f8502458be139d6b1926de4d57e30e9", size = 4034114, upload-time = "2026-04-20T08:33:26.888Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/c3/e8b24ff42ef6bf71f8b4277fd6d83a139d9b9ad14b0ffb4c76a8e9225a15/primp-1.2.3-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:283e751671e78cbac9f1ff72e89225d74bcd9ea08886910160f485cd78a55f2b", size = 4303794, upload-time = "2026-04-20T08:34:04.947Z" },
+    { url = "https://files.pythonhosted.org/packages/72/b4/9c59197fee68abdc53683b65b6b0e5ea6e0f098cc2527af29edd05b22ed4/primp-1.2.3-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ec5d94244f24c61b350791112c1687c97d144f400a7ea5d8476dbd2fad6de9af", size = 3908577, upload-time = "2026-04-20T08:33:59.567Z" },
+    { url = "https://files.pythonhosted.org/packages/71/b2/25c7cfcfe33f2fa82ab8cc72f4082fc12c8f803ceb2624c787fa72c73e12/primp-1.2.3-cp314-cp314t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:48d459dda86bfddce3a14b514694e0c8028f20cc461dd52e105aba400c622513", size = 4153501, upload-time = "2026-04-20T08:34:03.22Z" },
+    { url = "https://files.pythonhosted.org/packages/04/9b/83e61b32b9049478f63c1956ff3244619691c3edf6e96b19254047756b36/primp-1.2.3-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d0d8441f07c948a54ff21bfc4094cd2967b5fb6f8a9ef0c9562a1eb35da0127e", size = 4440289, upload-time = "2026-04-20T08:33:24.734Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/3f/48c351f601f204c52d5a477d7a19efcd8b7deb6478c57195fbe8bf9c3632/primp-1.2.3-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:728b6f63552f1bc729e0490ee69a3a9fbd39698c1578b0e6313f3779de469a8c", size = 4306848, upload-time = "2026-04-20T08:33:40.482Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/9a/683b2fbb8c2df3b3d2b351e86eec0a873479b95bb804e5d882939057366b/primp-1.2.3-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9952509dcd8aa8750f4cdfc86b24cdcec96f9342a6525003bc3446ba466d5512", size = 4521679, upload-time = "2026-04-20T08:33:38.699Z" },
+    { url = "https://files.pythonhosted.org/packages/80/eb/bbbbc79cf4132f2beeb0a0f99f41837dd66c158d0439f59df75a2d592d0a/primp-1.2.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e74a6aa83aa65d02665ad5d0e53d7877ea8abce6f3d50ed92495f9c4c9d10e2e", size = 4469041, upload-time = "2026-04-20T08:33:51.161Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/5c/208fe1c6e9d3a28c6eae530378ac9c60fe8ae389f68a4707ef7986d5b133/primp-1.2.3-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:1dfc4dd5bf7e4f9a45f9c7ae1256f957cc7ca8d5344f82d335129a13e1d7ffea", size = 4144925, upload-time = "2026-04-20T08:33:35.94Z" },
+    { url = "https://files.pythonhosted.org/packages/da/06/ce175b54edecf22b750da67bc095bea53f2d87d191c4461b30122c7ddd1e/primp-1.2.3-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:97c37df6fc7eb989f324b326e0547b23757a82f9d8b334075d4b0bd29e310723", size = 4276929, upload-time = "2026-04-20T08:33:49.521Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/12/a913ab53ad61fe51d44ef0f8fee6b63a897d2b9c8a4b43299d7f5decc003/primp-1.2.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ead9c8b660fa0ebb193317b85d61dd1bd840a3e97e882b33b896dc9e37ed6d63", size = 4772684, upload-time = "2026-04-20T08:33:42.456Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/2f/2c3aafb2814703979bf5a216575f4478bcf6070bc6ec143056cf3b56c134/primp-1.2.3-cp314-cp314t-win32.whl", hash = "sha256:cb52db4d54105097773c0df4e2ef0ce7b42461d9d4d3ec28a0622ca2d22945bb", size = 3499126, upload-time = "2026-04-20T08:33:29.953Z" },
+    { url = "https://files.pythonhosted.org/packages/54/f0/bad9c739a35f4cf69e2f39c01f664c9a5969e753c4cfcdc33e113cc984af/primp-1.2.3-cp314-cp314t-win_amd64.whl", hash = "sha256:d85a44585df27038e18298f7e35335c4961926e7401edd1a1bf4f7f967b3f107", size = 3870129, upload-time = "2026-04-20T08:34:11.666Z" },
+    { url = "https://files.pythonhosted.org/packages/67/78/882563dc554c5f710b4e47c58978586c2528703435800a7a84e81b339d90/primp-1.2.3-cp314-cp314t-win_arm64.whl", hash = "sha256:6513dcb55e6b511c1ae383a3a0e887929b09d8d6b2c70e2b188b425c51471a02", size = 3874087, upload-time = "2026-04-20T08:33:58.109Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Fourth and final Week 4 cognitive engine. **Research** — autonomous exploration of developed interests via DuckDuckGo web search (default) + memory sweep, synthesized into first-person memories in the persona's voice.

After this merges, Week 4 is complete: dream + heartbeat + reflex + research. Ready to tag `week-4`.

**Key architectural decisions:**
- **Framework-agnostic web search.** New `brain/search/` package with `WebSearcher` ABC + `DdgsWebSearcher` (default, free, no API key, works with any LLM backend) + `NoopWebSearcher` (tests) + stub `ClaudeToolWebSearcher`. Clean split from LLM provider.
- **Additive memory.** Research outputs are `memory_type="research"` in `MemoryStore` — first-class memories that decay, participate in Hebbian connections, can be dreamed about later. The brain grows.
- **Per-persona interests** with `scope` field (`internal` / `external` / `either`). Migration auto-classifies: topics mentioning soul crystallizations (Hana, Jordan) → `internal` (memory-only). Lispector → `either`.
- **Heartbeat-orchestrated** between dream gate and heartbeat-memory. Interest ingestion hook runs after Hebbian decay (zero LLM, keyword-match bumps pull_scores). Reflex-wins-tie prevents two-long-outputs-in-one-breath.
- **Fault isolated.** Research LLM failures log warning + return empty — heartbeat tick continues with decay/state save intact.

**Phase 2 deferred:** automatic discovery of brand-new interests (currently manual via `nell interest add`).

**Spec:** `docs/superpowers/specs/2026-04-24-week-4-research-engine-design.md`
**Plan:** `docs/superpowers/plans/2026-04-24-week-4-research-engine.md`

## Commits (7 tasks)

| Task | Commit |
|------|--------|
| T0 web search layer (brain/search/ + ddgs dep) | `033a9c3` |
| T1 Interest + InterestSet | `02b8a70` |
| T2 ResearchEngine scaffold + types | `f676d5f` |
| T3 ResearchEngine.run_tick body | `32e47d3` |
| T4 nell research + nell interest CLI | `9fc68f2` |
| T5 heartbeat integration | `1584428` |
| T6 Nell OG interest migration | `82f9822` |

## Test plan

- [x] Full suite 431/431 passing (was 376 pre-branch → +55 new tests)
- [x] `rg 'import anthropic' brain/` → 0 matches (hard rule intact)
- [x] `rg 'import anthropic' brain/search/` → 0 matches (search layer has no LLM SDK imports)
- [x] ruff check + format clean
- [x] Nell's sandbox re-migrated: 2 OG interests migrate with correct scope classification
  - Lispector diagonal syntax (pull=7.2) → scope=either
  - Hana (pull=4.8) → scope=internal (soul-name auto-detected)
- [x] `nell interest list --persona nell.sandbox` shows migrated interests cleanly
- [x] `nell research --persona nell.sandbox --searcher noop --interest "Lispector diagonal syntax"` fires and writes research memory with correct metadata
- [x] `nell heartbeat --persona nell.sandbox --searcher noop --trigger manual` runs with full orchestration:
  - Second tick: decayed 877 memories, dream gated (24h), **reflex fired `gratitude_reflection`**, **research gated: reflex_won_tie**
  - reflex-wins-tie rule proven against Nell's real aggregated emotional state

## After merge

Week 4 is complete. Next session: tag `week-4` covering all four cognitive engines (dream + heartbeat + reflex + research). Then the brain has a full cognitive substrate — consolidation (dream), rhythm (heartbeat), expression (reflex), curiosity (research).

🤖 Generated with [Claude Code](https://claude.com/claude-code)