### PR TITLE
Post-audit nit cleanup — 5 small fixes

### DIFF
--- a/brain/bridge/provider.py
+++ b/brain/bridge/provider.py
@@ -88,13 +88,23 @@ class ClaudeCliProvider(LLMProvider):
 class OllamaProvider(LLMProvider):
     """Placeholder for local Ollama integration.
 
-    Stub until Hana's local Ollama stack is back up. Fill in by:
+    Stub — fill in when Ollama integration lands. Fill in by:
     1. Replacing raise with an httpx POST to {host}/api/generate
     2. Parsing the streamed/non-streamed response
     3. Adding the httpx dep to pyproject
+
+    Default model: huihui_ai/qwen2.5-abliterated:7b — uncensored Qwen2.5
+    abliterated variant. Same base architecture as Nell's nell-dpo
+    fine-tune, light enough for most local hardware (~4.7GB), works
+    well with the brain's emotional + creative tone. Users can override
+    via `OllamaProvider(model="...")`.
     """
 
-    def __init__(self, model: str = "nell-dpo", host: str = "http://localhost:11434") -> None:
+    def __init__(
+        self,
+        model: str = "huihui_ai/qwen2.5-abliterated:7b",
+        host: str = "http://localhost:11434",
+    ) -> None:
         self._model = model
         self._host = host
 

--- a/brain/engines/heartbeat.py
+++ b/brain/engines/heartbeat.py
@@ -14,7 +14,7 @@ import os
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Literal
+from typing import Literal, get_args
 
 from brain.bridge.provider import LLMProvider
 from brain.memory.hebbian import HebbianMatrix
@@ -25,7 +25,9 @@ from brain.utils.time import iso_utc, parse_iso_utc
 logger = logging.getLogger(__name__)
 
 EmitMemoryMode = Literal["always", "conditional", "never"]
-_VALID_EMIT_MODES: tuple[str, ...] = ("always", "conditional", "never")
+# Single source of truth — derived from the Literal so a new mode added
+# above only needs to land in one place.
+_VALID_EMIT_MODES: tuple[str, ...] = get_args(EmitMemoryMode)
 
 
 @dataclass

--- a/brain/paths.py
+++ b/brain/paths.py
@@ -42,13 +42,15 @@ def get_persona_dir(name: str) -> Path:
     """Return the directory for a specific persona's private data.
 
     Raises ValueError if `name` could escape the personas/ root via path
-    traversal (contains '/', '\\', or equals '.' / '..').
+    traversal ('/' or '\\') or break str.format_map prompt rendering
+    (literal '{' or '}'), or equals '.' / '..'.
     """
     if not name:
         raise ValueError("Persona name cannot be empty.")
-    if "/" in name or "\\" in name or name in (".", ".."):
+    if "/" in name or "\\" in name or "{" in name or "}" in name or name in (".", ".."):
         raise ValueError(
-            f"Invalid persona name: {name!r} (must not contain '/' or '\\\\', or be '.' / '..')."
+            f"Invalid persona name: {name!r} "
+            "(must not contain '/', '\\\\', '{', '}', or be '.' / '..')."
         )
     return get_home() / "personas" / name
 

--- a/tests/unit/brain/engines/test_reflex.py
+++ b/tests/unit/brain/engines/test_reflex.py
@@ -197,8 +197,6 @@ def test_reflex_log_last_fire_for_arc_returns_most_recent(tmp_path: Path):
 
 
 def test_reflex_engine_construction(tmp_path: Path):
-    from brain.bridge.provider import FakeProvider
-
     store = MemoryStore(":memory:")
     try:
         engine = ReflexEngine(

--- a/tests/unit/brain/test_paths.py
+++ b/tests/unit/brain/test_paths.py
@@ -79,6 +79,15 @@ def test_get_persona_dir_rejects_dot_name() -> None:
         paths.get_persona_dir("..")
 
 
+def test_get_persona_dir_rejects_brace_chars() -> None:
+    """Persona name with literal '{' or '}' would break str.format_map
+    prompt rendering used by reflex/research engines."""
+    with pytest.raises(ValueError):
+        paths.get_persona_dir("evil{persona_name}")
+    with pytest.raises(ValueError):
+        paths.get_persona_dir("evil}persona{")
+
+
 def test_get_persona_dir_rejects_empty() -> None:
     with pytest.raises(ValueError):
         paths.get_persona_dir("")


### PR DESCRIPTION
## Summary

Bundle of 5 nits triaged with Hana from the Week 4 audit findings. Each was flagged "author's call" — these were the ones we agreed warranted fixing now. Three nits were skipped (factory-guarded, structurally fine) and one (vocabulary split) is being elevated into proper feature work with its own brainstorm/spec.

## Fixes

| # | Fix | Impact |
|---|---|---|
| 1 | `_VALID_EMIT_MODES` → `get_args(EmitMemoryMode)` | Single source of truth; prevents drift when a fourth emit mode lands |
| 2 | OllamaProvider default model: `nell-dpo` → `huihui_ai/qwen2.5-abliterated:7b` | Same Qwen2.5-7B base as Nell's DPO, uncensored by default (matches framework's fiction-friendly philosophy), ~4.7GB so most users can run it |
| 3 | `get_persona_dir` also rejects literal `{`/`}` | Persona names couldn't break `str.format_map` template rendering in reflex/research |
| 4 | Removed redundant local `FakeProvider` import in `test_reflex.py` | Cosmetic |
| 5 | Updated `OllamaProvider` docstring | No longer references Hana personally |

Plus 1 new regression test (`test_get_persona_dir_rejects_brace_chars`).

## Test plan

- [x] Full suite: **450/450 passing** (449 → 450 with new brace test)
- [x] `rg 'import anthropic' brain/` → 0
- [x] ruff clean
- [x] `OllamaProvider().name()` → `"ollama:huihui_ai/qwen2.5-abliterated:7b"`
- [x] `get_persona_dir("evil{x}")` → ValueError

## Deferred (separate feature work)

**Vocabulary split** — Nell's 5 `nell_specific` emotions (`body_grief`, `emergence`, `anchor_pull`, `creative_hunger`, `freedom_ache`) currently live in framework `_BASELINE`. Should be moved to per-persona vocabulary that loads on engine startup (parallel to reflex arcs and interests). New brains start with generic baseline; Nell's migration writes her 5 to `{persona_dir}/emotion_vocabulary.json`. Phase 2 (deferred): emotions emerge over time through a crystallizer.

This is real design work, not a nit. Will get its own brainstorm → spec → plan arc in a future session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)