### PR TITLE
hardening: surface silent failures in growth log + vocab read

### DIFF
--- a/brain/growth/log.py
+++ b/brain/growth/log.py
@@ -68,14 +68,23 @@ def read_growth_log(path: Path, *, limit: int | None = None) -> list[GrowthLogEv
     if not path.exists():
         return []
     events: list[GrowthLogEvent] = []
-    for raw in path.read_text(encoding="utf-8").splitlines():
+    for line_index, raw in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
         if not raw.strip():
             continue
         try:
             data = json.loads(raw)
             events.append(_event_from_dict(data))
         except (json.JSONDecodeError, KeyError, TypeError, ValueError) as exc:
-            logger.warning("skipping malformed growth log line: %.200s", exc)
+            # Include line number + truncated content so a forensic grep can
+            # find and fix (or quarantine) the bad line. The exception alone
+            # doesn't tell you WHERE in the log the corruption is.
+            logger.warning(
+                "skipping malformed growth log line %d in %s: %.200s | content: %r",
+                line_index,
+                path,
+                exc,
+                raw[:200],
+            )
             continue
     if limit is not None:
         events = events[-limit:]

--- a/brain/growth/scheduler.py
+++ b/brain/growth/scheduler.py
@@ -110,13 +110,34 @@ def run_growth_tick(
 
 
 def _read_current_vocabulary_names(vocab_path: Path) -> set[str]:
+    """Return the set of emotion names currently in the persona's vocabulary file.
+
+    Distinguishes three load outcomes:
+      - Missing file → return empty set silently (fresh persona; expected).
+      - Corrupt JSON or wrong schema → return empty set BUT log a WARNING
+        with the file path. A silent fallback would mask the corruption,
+        and the scheduler would then think "no emotions exist" and might
+        re-add framework baselines on the next growth tick.
+      - Well-formed → return the set of names.
+    """
     if not vocab_path.exists():
         return set()
     try:
         data = json.loads(vocab_path.read_text(encoding="utf-8"))
-    except json.JSONDecodeError:
+    except json.JSONDecodeError as exc:
+        logger.warning(
+            "growth scheduler: emotion_vocabulary at %s is corrupt JSON (%.200s); "
+            "treating as empty for this tick — fix or quarantine the file",
+            vocab_path,
+            exc,
+        )
         return set()
     if not isinstance(data, dict) or not isinstance(data.get("emotions"), list):
+        logger.warning(
+            "growth scheduler: emotion_vocabulary at %s has invalid schema "
+            "(missing 'emotions' list); treating as empty for this tick",
+            vocab_path,
+        )
         return set()
     return {e["name"] for e in data["emotions"] if isinstance(e, dict) and "name" in e}
 

--- a/tests/unit/brain/engines/test_heartbeat.py
+++ b/tests/unit/brain/engines/test_heartbeat.py
@@ -1423,6 +1423,16 @@ def test_heartbeat_growth_disabled_skips_growth_tick(tmp_path: Path) -> None:
 
         result = engine.run_tick(trigger="manual")
         assert result.growth_emotions_added == 0
+
+        # Hardening: audit log must record growth.enabled=False so a forensic
+        # reader can distinguish "disabled" from "not due" from "no persona dir".
+        audit_lines = (
+            (persona_dir / "heartbeats.log.jsonl").read_text(encoding="utf-8").splitlines()
+        )
+        last_audit = json.loads(audit_lines[-1])
+        assert last_audit["growth"]["enabled"] is False
+        assert last_audit["growth"]["ran"] is False
+        assert last_audit["growth"]["emotions_added"] == 0
     finally:
         store.close()
         hebbian.close()

--- a/tests/unit/brain/growth/test_log.py
+++ b/tests/unit/brain/growth/test_log.py
@@ -111,6 +111,9 @@ def test_read_growth_log_with_limit_returns_most_recent(tmp_path: Path) -> None:
 
 def test_read_growth_log_skips_corrupt_lines(tmp_path: Path, caplog) -> None:
     """A partial-write or hand-edited bad line is skipped, others still parse."""
+    import logging
+
+    caplog.set_level(logging.WARNING)
     log_path = tmp_path / "growth.log.jsonl"
     append_growth_event(log_path, _event(name="good"))
     # Append a corrupt line manually
@@ -120,6 +123,14 @@ def test_read_growth_log_skips_corrupt_lines(tmp_path: Path, caplog) -> None:
     events = read_growth_log(log_path)
     assert len(events) == 2
     assert {e.name for e in events} == {"good", "also_good"}
+
+    # Hardening: warning includes line number + content preview so a forensic
+    # grep of the logs can find and quarantine the bad line.
+    bad_warnings = [r for r in caplog.records if "malformed growth log line" in r.message]
+    assert len(bad_warnings) == 1
+    msg = bad_warnings[0].getMessage()
+    assert "line 2" in msg  # corrupt line is the 2nd line in the file
+    assert "{not valid json" in msg  # content preview present
 
 
 def test_read_growth_log_round_trips_all_fields(tmp_path: Path) -> None:

--- a/tests/unit/brain/growth/test_scheduler.py
+++ b/tests/unit/brain/growth/test_scheduler.py
@@ -177,3 +177,75 @@ def test_run_growth_tick_handles_multiple_proposals(persona_dir: Path, store: Me
     assert result.emotions_added == 3
     log_path = persona_dir / "emotion_growth.log.jsonl"
     assert len(log_path.read_text(encoding="utf-8").splitlines()) == 3
+
+
+# ---- Hardening: corrupt-vocab detection ----
+
+
+def test_run_growth_tick_corrupt_vocabulary_logs_warning(
+    persona_dir: Path, store: MemoryStore, caplog
+) -> None:
+    """A corrupt emotion_vocabulary.json is detected and surfaces a WARNING.
+
+    Prior to hardening, the JSONDecodeError was silently swallowed, so a
+    corrupt vocab file looked indistinguishable from "no emotions yet" to
+    the scheduler. The scheduler still proceeds (returns empty set + tick
+    continues) but the warning gives the user / forensic-grep a thread to
+    pull on rather than silent degradation.
+    """
+    import logging
+
+    caplog.set_level(logging.WARNING)
+
+    # Write corrupt JSON to the vocab path.
+    (persona_dir / "emotion_vocabulary.json").write_text("{not valid json", encoding="utf-8")
+
+    result = run_growth_tick(persona_dir, store, datetime.now(UTC))
+
+    # Tick still completes (no proposals from stub anyway).
+    assert result.emotions_added == 0
+
+    # Warning surfaces both the path and the corruption.
+    corrupt_warnings = [r for r in caplog.records if "corrupt JSON" in r.getMessage()]
+    assert len(corrupt_warnings) == 1
+    assert "emotion_vocabulary.json" in corrupt_warnings[0].getMessage()
+
+
+def test_run_growth_tick_invalid_vocabulary_schema_logs_warning(
+    persona_dir: Path, store: MemoryStore, caplog
+) -> None:
+    """A vocab file with the wrong shape (missing 'emotions' list) surfaces a WARNING."""
+    import logging
+
+    caplog.set_level(logging.WARNING)
+
+    (persona_dir / "emotion_vocabulary.json").write_text(
+        json.dumps({"version": 1, "wrong_field": []}), encoding="utf-8"
+    )
+
+    result = run_growth_tick(persona_dir, store, datetime.now(UTC))
+    assert result.emotions_added == 0
+
+    schema_warnings = [r for r in caplog.records if "invalid schema" in r.getMessage()]
+    assert len(schema_warnings) == 1
+
+
+def test_run_growth_tick_missing_vocabulary_no_warning(
+    persona_dir: Path, store: MemoryStore, caplog
+) -> None:
+    """A missing vocab file is the expected fresh-persona case — no warning."""
+    import logging
+
+    caplog.set_level(logging.WARNING)
+
+    # Don't seed the vocab file at all.
+    result = run_growth_tick(persona_dir, store, datetime.now(UTC))
+    assert result.emotions_added == 0
+
+    # Crucially: no warning. Missing != corrupt.
+    bad_warnings = [
+        r
+        for r in caplog.records
+        if "corrupt JSON" in r.getMessage() or "invalid schema" in r.getMessage()
+    ]
+    assert bad_warnings == []


### PR DESCRIPTION
## Summary

Three reviewer-flagged silent-failure fixes from the Phase 2a final-pass review. The principle: **a healthy brain heals from injuries AND records having healed.** Silent degradation hides real problems behind a working heartbeat.

This PR addresses the immediate, low-risk wins. The bigger self-healing surface (`brain/health/` module with quarantine + auto-restore) is the Phase 2a-extension after this lands.

## Changes

**1. `read_growth_log` warning carries line number + content preview**

Previously: `\"skipping malformed growth log line: <exception text>\"` — useless for forensic grep.

Now: `\"skipping malformed growth log line N in <path>: <exception> | content: '<first 200 chars>'\"` — a reader can locate and quarantine the bad line by hand.

**2. `_read_current_vocabulary_names` distinguishes missing from corrupt**

Previously: corrupt JSON silently returned `set()`, indistinguishable from \"no emotions yet.\" A real disk corruption could hide indefinitely while the scheduler thought the vocabulary was empty.

Now: three distinct outcomes
- Missing file → return empty set silently (fresh persona; expected)
- Corrupt JSON → return empty set + log WARNING with the file path
- Wrong schema (no \`emotions\` list) → return empty set + log WARNING

**3. New heartbeat-integration test for `growth_enabled=False` audit-log short-circuit**

Verifies the audit log entry records `growth.enabled=False` so a forensic reader can distinguish three different reasons to see `growth_emotions_added=0`: disabled, not-due, no-persona-dir.

## Test plan

- [x] 3 new tests added: corrupt-vocab warning, invalid-schema warning, missing-vocab no-warning
- [x] Existing `test_read_growth_log_skips_corrupt_lines` extended to verify line number + content preview in the warning
- [x] Existing `test_heartbeat_growth_disabled_skips_growth_tick` extended to assert audit log fields
- [x] **534 tests passing** (was 531, +3 net)
- [x] `ruff check && ruff format --check` clean

## Follow-up

The proper self-healing surface lands as a separate Phase 2a-extension PR with its own brainstorm → spec → plan cycle. Scope:
- `brain/health/` module with `HealthCheck` + `BrainAnomaly` dataclasses
- Quarantine pattern: corrupt files moved to `<file>.corrupt-<ts>` then defaults rewritten
- Heartbeat audit log gains `anomalies: [...]` array
- New `nell health check --persona X` CLI for proactive scan
- Compact CLI heartbeat output mentions \"the brain self-healed N file(s) today\"