### PR TITLE
Brain Health PR-1: core helpers + SQLite integrity check

### DIFF
--- a/brain/health/__init__.py
+++ b/brain/health/__init__.py
@@ -1,0 +1,4 @@
+"""brain.health — self-healing architecture.
+
+Per docs/superpowers/specs/2026-04-25-brain-health-module-design.md.
+"""

--- a/brain/health/adaptive.py
+++ b/brain/health/adaptive.py
@@ -1,0 +1,45 @@
+"""Adaptive treatment — backup depth + verify-after-write computed from audit log."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+from brain.health.jsonl_reader import read_jsonl_skipping_corrupt
+from brain.utils.time import parse_iso_utc
+
+WINDOW_DAYS = 7
+BUMP_THRESHOLD = 3
+ELEVATED_BACKUP_COUNT = 6
+DEFAULT_BACKUP_COUNT = 3
+
+
+@dataclass(frozen=True)
+class FileTreatment:
+    backup_count: int
+    verify_after_write: bool
+
+
+def compute_treatment(persona_dir: Path, file: str) -> FileTreatment:
+    """Read audit log; if `file` saw ≥3 anomalies in last 7 days, return elevated treatment."""
+    audit_path = persona_dir / "heartbeats.log.jsonl"
+    cutoff = datetime.now(UTC) - timedelta(days=WINDOW_DAYS)
+
+    count = 0
+    for entry in read_jsonl_skipping_corrupt(audit_path):
+        for a in entry.get("anomalies") or []:
+            if not isinstance(a, dict):
+                continue
+            if a.get("file") != file:
+                continue
+            try:
+                ts = parse_iso_utc(a["timestamp"])
+            except (KeyError, ValueError, TypeError):
+                continue
+            if ts >= cutoff:
+                count += 1
+
+    if count >= BUMP_THRESHOLD:
+        return FileTreatment(backup_count=ELEVATED_BACKUP_COUNT, verify_after_write=True)
+    return FileTreatment(backup_count=DEFAULT_BACKUP_COUNT, verify_after_write=False)

--- a/brain/health/alarm.py
+++ b/brain/health/alarm.py
@@ -1,0 +1,86 @@
+"""Pending-alarm computation — derived from audit log; no separate state file."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+from brain.health.anomaly import AlarmEntry
+from brain.health.jsonl_reader import read_jsonl_skipping_corrupt
+from brain.utils.time import parse_iso_utc
+
+_IDENTITY_FILES = frozenset({
+    "emotion_vocabulary.json",
+    "interests.json",
+    "reflex_arcs.json",
+    # future: "soul.json"
+})
+
+WINDOW_DAYS = 7
+
+
+def compute_pending_alarms(persona_dir: Path) -> list[AlarmEntry]:
+    """Walk recent audit log; return alarms not yet acknowledged."""
+    audit_path = persona_dir / "heartbeats.log.jsonl"
+    cutoff = datetime.now(UTC) - timedelta(days=WINDOW_DAYS)
+
+    # First pass: collect all anomalies + acknowledgments in window.
+    anomalies: list[dict] = []
+    acknowledged_files: set[str] = set()
+
+    for entry in read_jsonl_skipping_corrupt(audit_path):
+        try:
+            ts = parse_iso_utc(entry["timestamp"])
+        except (KeyError, ValueError, TypeError):
+            continue
+        if ts < cutoff:
+            continue
+
+        ack = entry.get("user_acknowledged") or []
+        if isinstance(ack, list):
+            for f in ack:
+                if isinstance(f, str):
+                    acknowledged_files.add(f)
+
+        for a in entry.get("anomalies") or []:
+            if isinstance(a, dict):
+                anomalies.append(a)
+
+    # Second pass: count per file + classify alarmable.
+    by_file: dict[str, list[dict]] = {}
+    for a in anomalies:
+        f = a.get("file")
+        if not isinstance(f, str):
+            continue
+        by_file.setdefault(f, []).append(a)
+
+    alarms: list[AlarmEntry] = []
+    for f, anoms in by_file.items():
+        if f in acknowledged_files:
+            continue
+
+        is_alarm = False
+        for a in anoms:
+            if a.get("action") == "reset_to_default" and f in _IDENTITY_FILES:
+                is_alarm = True
+                break
+            if a.get("kind") == "sqlite_integrity_fail":
+                is_alarm = True
+                break
+        # ≥6 anomalies in window = recurring-after-adaptation
+        if len(anoms) >= 6:
+            is_alarm = True
+
+        if is_alarm:
+            first_seen = min(parse_iso_utc(a["timestamp"]) for a in anoms)
+            kind = anoms[-1].get("kind", "json_parse_error")
+            alarms.append(
+                AlarmEntry(
+                    file=f,
+                    kind=kind,
+                    first_seen_at=first_seen,
+                    occurrences_in_window=len(anoms),
+                )
+            )
+
+    return alarms

--- a/brain/health/alarm.py
+++ b/brain/health/alarm.py
@@ -9,12 +9,14 @@ from brain.health.anomaly import AlarmEntry
 from brain.health.jsonl_reader import read_jsonl_skipping_corrupt
 from brain.utils.time import parse_iso_utc
 
-_IDENTITY_FILES = frozenset({
-    "emotion_vocabulary.json",
-    "interests.json",
-    "reflex_arcs.json",
-    # future: "soul.json"
-})
+_IDENTITY_FILES = frozenset(
+    {
+        "emotion_vocabulary.json",
+        "interests.json",
+        "reflex_arcs.json",
+        # future: "soul.json"
+    }
+)
 
 WINDOW_DAYS = 7
 

--- a/brain/health/anomaly.py
+++ b/brain/health/anomaly.py
@@ -1,0 +1,76 @@
+"""BrainAnomaly + AlarmEntry — structured records of detection events."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Literal
+
+from brain.utils.time import iso_utc, parse_iso_utc
+
+AnomalyKind = Literal["json_parse_error", "schema_mismatch", "sqlite_integrity_fail"]
+AnomalyAction = Literal[
+    "restored_from_bak1",
+    "restored_from_bak2",
+    "restored_from_bak3",
+    "reset_to_default",
+    "reconstructed_from_memories",
+    "alarmed_unrecoverable",
+    "verify_after_write_failed",
+]
+LikelyCause = Literal["user_edit", "disk", "unknown"]
+
+
+@dataclass(frozen=True)
+class BrainAnomaly:
+    timestamp: datetime
+    file: str
+    kind: AnomalyKind
+    action: AnomalyAction
+    quarantine_path: str | None
+    likely_cause: LikelyCause
+    detail: str
+
+    def to_dict(self) -> dict:
+        return {
+            "timestamp": iso_utc(self.timestamp),
+            "file": self.file,
+            "kind": self.kind,
+            "action": self.action,
+            "quarantine_path": self.quarantine_path,
+            "likely_cause": self.likely_cause,
+            "detail": self.detail,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> BrainAnomaly:
+        return cls(
+            timestamp=parse_iso_utc(data["timestamp"]),
+            file=str(data["file"]),
+            kind=data["kind"],
+            action=data["action"],
+            quarantine_path=data.get("quarantine_path"),
+            likely_cause=data.get("likely_cause", "unknown"),
+            detail=str(data.get("detail", "")),
+        )
+
+
+@dataclass(frozen=True)
+class AlarmEntry:
+    file: str
+    kind: str
+    first_seen_at: datetime
+    occurrences_in_window: int
+
+
+class BrainIntegrityError(Exception):
+    """Raised when a SQLite database fails PRAGMA integrity_check.
+
+    The brain's memory or hebbian graph is unrecoverable from this state
+    in v1 — surfaces as a Layer 3 alarm in the audit log.
+    """
+
+    def __init__(self, db_path: str, detail: str) -> None:
+        super().__init__(f"integrity check failed for {db_path}: {detail}")
+        self.db_path = db_path
+        self.detail = detail

--- a/brain/health/attempt_heal.py
+++ b/brain/health/attempt_heal.py
@@ -59,7 +59,9 @@ def _heal_from_baks(
     quarantine = path.with_name(f"{path.name}.corrupt-{iso_utc(now)}")
     os.replace(path, quarantine)
 
-    kind = "json_parse_error" if isinstance(original_exc, json.JSONDecodeError) else "schema_mismatch"
+    kind = (
+        "json_parse_error" if isinstance(original_exc, json.JSONDecodeError) else "schema_mismatch"
+    )
 
     for bak_index in (1, 2, 3):
         bak = path.with_name(f"{path.name}.bak{bak_index}")
@@ -75,27 +77,33 @@ def _heal_from_baks(
 
         # Found a valid bak — restore.
         os.replace(bak, path)
-        return data, BrainAnomaly(
-            timestamp=now,
-            file=path.name,
-            kind=kind,  # type: ignore[arg-type]
-            action=f"restored_from_bak{bak_index}",  # type: ignore[arg-type]
-            quarantine_path=quarantine.name,
-            likely_cause=likely_cause,
-            detail=str(original_exc)[:500],
+        return (
+            data,
+            BrainAnomaly(
+                timestamp=now,
+                file=path.name,
+                kind=kind,  # type: ignore[arg-type]
+                action=f"restored_from_bak{bak_index}",  # type: ignore[arg-type]
+                quarantine_path=quarantine.name,
+                likely_cause=likely_cause,
+                detail=str(original_exc)[:500],
+            ),
         )
 
     # All baks corrupt or missing — reset to default.
     default_data = default_factory()
     path.write_text(json.dumps(default_data, indent=2) + "\n", encoding="utf-8")
-    return default_data, BrainAnomaly(
-        timestamp=now,
-        file=path.name,
-        kind=kind,  # type: ignore[arg-type]
-        action="reset_to_default",
-        quarantine_path=quarantine.name,
-        likely_cause=likely_cause,
-        detail=str(original_exc)[:500],
+    return (
+        default_data,
+        BrainAnomaly(
+            timestamp=now,
+            file=path.name,
+            kind=kind,  # type: ignore[arg-type]
+            action="reset_to_default",
+            quarantine_path=quarantine.name,
+            likely_cause=likely_cause,
+            detail=str(original_exc)[:500],
+        ),
     )
 
 

--- a/brain/health/attempt_heal.py
+++ b/brain/health/attempt_heal.py
@@ -1,0 +1,144 @@
+"""Core heal + save helpers — atomic .bak rotation + corruption recovery."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import time
+from collections.abc import Callable
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from brain.health.anomaly import BrainAnomaly
+from brain.utils.time import iso_utc
+
+logger = logging.getLogger(__name__)
+
+
+def attempt_heal(
+    path: Path,
+    default_factory: Callable[[], Any],
+    schema_validator: Callable[[Any], None] | None = None,
+) -> tuple[Any, BrainAnomaly | None]:
+    """Load `path`, healing from .bak rotation if corrupt.
+
+    Returns (data, anomaly_or_None).
+      - Missing file → (default_factory(), None)
+      - Healthy file → (parsed_data, None)
+      - Corrupt file → quarantine, walk .bak1/.bak2/.bak3, restore freshest
+        valid backup; if all corrupt, write default_factory() output.
+        Returns (data, BrainAnomaly).
+    """
+    if not path.exists():
+        return default_factory(), None
+
+    try:
+        data = _load_and_validate(path, schema_validator)
+        return data, None
+    except (json.JSONDecodeError, ValueError, TypeError) as exc:
+        return _heal_from_baks(path, default_factory, schema_validator, exc)
+
+
+def _load_and_validate(path: Path, validator: Callable[[Any], None] | None) -> Any:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if validator is not None:
+        validator(data)
+    return data
+
+
+def _heal_from_baks(
+    path: Path,
+    default_factory: Callable[[], Any],
+    schema_validator: Callable[[Any], None] | None,
+    original_exc: Exception,
+) -> tuple[Any, BrainAnomaly]:
+    now = datetime.now(UTC)
+    likely_cause = _classify_cause(path)
+    quarantine = path.with_name(f"{path.name}.corrupt-{iso_utc(now)}")
+    os.replace(path, quarantine)
+
+    kind = "json_parse_error" if isinstance(original_exc, json.JSONDecodeError) else "schema_mismatch"
+
+    for bak_index in (1, 2, 3):
+        bak = path.with_name(f"{path.name}.bak{bak_index}")
+        if not bak.exists():
+            continue
+        try:
+            data = _load_and_validate(bak, schema_validator)
+        except (json.JSONDecodeError, ValueError, TypeError):
+            # This bak is also corrupt — quarantine it too.
+            bak_quarantine = path.with_name(f"{path.name}.bak{bak_index}.corrupt-{iso_utc(now)}")
+            os.replace(bak, bak_quarantine)
+            continue
+
+        # Found a valid bak — restore.
+        os.replace(bak, path)
+        return data, BrainAnomaly(
+            timestamp=now,
+            file=path.name,
+            kind=kind,  # type: ignore[arg-type]
+            action=f"restored_from_bak{bak_index}",  # type: ignore[arg-type]
+            quarantine_path=quarantine.name,
+            likely_cause=likely_cause,
+            detail=str(original_exc)[:500],
+        )
+
+    # All baks corrupt or missing — reset to default.
+    default_data = default_factory()
+    path.write_text(json.dumps(default_data, indent=2) + "\n", encoding="utf-8")
+    return default_data, BrainAnomaly(
+        timestamp=now,
+        file=path.name,
+        kind=kind,  # type: ignore[arg-type]
+        action="reset_to_default",
+        quarantine_path=quarantine.name,
+        likely_cause=likely_cause,
+        detail=str(original_exc)[:500],
+    )
+
+
+def _classify_cause(path: Path) -> str:
+    """Heuristic: hand-edit vs disk vs unknown.
+
+    user_edit: mtime within 60s, size < 100KB, content starts with { or [.
+    Otherwise unknown. (No specific disk-error heuristic in v1.)
+    """
+    try:
+        st = path.stat()
+        if time.time() - st.st_mtime < 60 and st.st_size < 100_000:
+            head = path.read_bytes()[:1]
+            if head and head[:1] in (b"{", b"["):
+                return "user_edit"
+    except OSError:
+        pass
+    return "unknown"
+
+
+def save_with_backup(path: Path, data: Any, backup_count: int = 3) -> None:
+    """Atomic save with .bak rotation.
+
+    Writes <path>.new, rotates existing <path> → <path>.bak1 → ... → <path>.bak{N},
+    drops oldest, then atomically replaces <path>. Stale <path>.new from a prior
+    crash is unlinked before the new write begins.
+    """
+    new_path = path.with_name(path.name + ".new")
+    if new_path.exists():
+        new_path.unlink()  # stale from prior crash; always incomplete
+
+    new_path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+
+    # Rotate: drop oldest first, then walk down toward live.
+    oldest = path.with_name(f"{path.name}.bak{backup_count}")
+    if oldest.exists():
+        oldest.unlink()
+    for i in range(backup_count - 1, 0, -1):
+        src = path.with_name(f"{path.name}.bak{i}")
+        dst = path.with_name(f"{path.name}.bak{i + 1}")
+        if src.exists():
+            os.replace(src, dst)
+    if path.exists():
+        os.replace(path, path.with_name(f"{path.name}.bak1"))
+
+    os.replace(new_path, path)

--- a/brain/health/attempt_heal.py
+++ b/brain/health/attempt_heal.py
@@ -17,6 +17,16 @@ from brain.utils.time import iso_utc
 logger = logging.getLogger(__name__)
 
 
+def _filename_safe_timestamp(now: datetime) -> str:
+    """Build an ISO-like timestamp safe for filenames on every platform.
+
+    `iso_utc(now)` produces strings with `:` (e.g. `2026-04-25T18:30:00.123456Z`),
+    which Windows rejects in filenames. We swap colons for hyphens so the
+    quarantine filename round-trips on POSIX + Windows.
+    """
+    return iso_utc(now).replace(":", "-")
+
+
 def attempt_heal(
     path: Path,
     default_factory: Callable[[], Any],
@@ -56,7 +66,7 @@ def _heal_from_baks(
 ) -> tuple[Any, BrainAnomaly]:
     now = datetime.now(UTC)
     likely_cause = _classify_cause(path)
-    quarantine = path.with_name(f"{path.name}.corrupt-{iso_utc(now)}")
+    quarantine = path.with_name(f"{path.name}.corrupt-{_filename_safe_timestamp(now)}")
     os.replace(path, quarantine)
 
     kind = (
@@ -71,7 +81,7 @@ def _heal_from_baks(
             data = _load_and_validate(bak, schema_validator)
         except (json.JSONDecodeError, ValueError, TypeError):
             # This bak is also corrupt — quarantine it too.
-            bak_quarantine = path.with_name(f"{path.name}.bak{bak_index}.corrupt-{iso_utc(now)}")
+            bak_quarantine = path.with_name(f"{path.name}.bak{bak_index}.corrupt-{_filename_safe_timestamp(now)}")
             os.replace(bak, bak_quarantine)
             continue
 

--- a/brain/health/jsonl_reader.py
+++ b/brain/health/jsonl_reader.py
@@ -1,0 +1,44 @@
+"""Append-only JSONL log reader with per-line corruption skip.
+
+Generalises the pattern shipped in the Phase 2a hardening PR for the growth log.
+Used by every *.log.jsonl reader in the brain — heartbeats, dreams, reflex,
+research, growth.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+def read_jsonl_skipping_corrupt(path: Path) -> list[dict]:
+    """Return parsed lines from `path`, skipping malformed lines with a WARNING.
+
+    Per-line resilience: a single corrupt line never invalidates the lines
+    around it. Each skipped line emits a warning that includes the line
+    number, the file path, the parse exception, and a 200-char preview of
+    the bad content — enough for a human to find and quarantine the line.
+    """
+    if not path.exists():
+        return []
+    out: list[dict] = []
+    for line_index, raw in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+        if not raw.strip():
+            continue
+        try:
+            data = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            logger.warning(
+                "skipping malformed jsonl line %d in %s: %s | content: %r",
+                line_index,
+                path,
+                exc,
+                raw[:201],
+            )
+            continue
+        if isinstance(data, dict):
+            out.append(data)
+    return out

--- a/brain/health/reconstruct.py
+++ b/brain/health/reconstruct.py
@@ -1,0 +1,51 @@
+"""Identity reconstruction — rebuild vocabulary from memory references.
+
+When all backups of emotion_vocabulary.json are corrupt and reset would
+otherwise fire, the brain re-learns its own vocabulary from how it has
+been operating: scan memories.db for distinct emotion names, register
+framework baseline + persona-extensions for any unknown names found.
+"""
+
+from __future__ import annotations
+
+from brain.emotion import vocabulary as _vocabulary
+from brain.memory.store import MemoryStore
+
+PLACEHOLDER_DESCRIPTION = "(reconstructed from memory)"
+PLACEHOLDER_DECAY_DAYS = 1.0  # conservative — fast decay until user re-tunes
+
+
+def reconstruct_vocabulary_from_memories(store: MemoryStore) -> dict:
+    """Build emotion_vocabulary.json content: baseline + extensions found in memories."""
+    baseline_names: set[str] = {e.name for e in _vocabulary._BASELINE}
+    seen_names: set[str] = set()
+    for mem in store.search_text("", active_only=True, limit=None):
+        for name in mem.emotions:
+            seen_names.add(name)
+
+    entries: list[dict] = []
+    # Framework baseline always — these are immutable identity.
+    for e in _vocabulary._BASELINE:
+        entries.append(
+            {
+                "name": e.name,
+                "description": e.description,
+                "category": e.category,
+                "decay_half_life_days": e.decay_half_life_days,
+                "intensity_clamp": e.intensity_clamp,
+            }
+        )
+
+    # Persona extensions: any emotion name in memories not in baseline.
+    for name in sorted(seen_names - baseline_names):
+        entries.append(
+            {
+                "name": name,
+                "description": PLACEHOLDER_DESCRIPTION,
+                "category": "persona_extension",
+                "decay_half_life_days": PLACEHOLDER_DECAY_DAYS,
+                "intensity_clamp": 10.0,
+            }
+        )
+
+    return {"version": 1, "emotions": entries}

--- a/brain/health/walker.py
+++ b/brain/health/walker.py
@@ -1,0 +1,69 @@
+"""Proactive walk over every persona file — used by `nell health check`
+and triggered automatically when a heartbeat tick produces >=2 anomalies."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+from brain.health.anomaly import BrainAnomaly, BrainIntegrityError
+from brain.health.attempt_heal import attempt_heal
+
+# Atomic-rewrite files this walker checks. Each entry: filename -> default dict.
+_DEFAULTS: dict[str, dict] = {
+    "user_preferences.json": {"dream_every_hours": 24.0},
+    "persona_config.json": {"provider": "claude-cli", "searcher": "ddgs"},
+    "heartbeat_config.json": {},  # all-default HeartbeatConfig
+    "heartbeat_state.json": {},  # triggers fresh-init via load fallback
+    "interests.json": {"version": 1, "interests": []},
+    "reflex_arcs.json": {"version": 1, "arcs": []},
+    "emotion_vocabulary.json": {"version": 1, "emotions": []},
+}
+
+
+def walk_persona(persona_dir: Path) -> list[BrainAnomaly]:
+    """Check every persona file. Heal what's healable; report anomalies.
+
+    Iterates atomic-rewrite files via attempt_heal (captures corruption +
+    repairs in one shot) then opens each SQLite store so the constructor's
+    PRAGMA integrity_check runs. Returns an empty list when everything is
+    healthy.
+    """
+    anomalies: list[BrainAnomaly] = []
+
+    # Atomic-rewrite file scan — d=default captures the dict at iteration time
+    # to avoid Python's late-binding closure gotcha.
+    for name, default in _DEFAULTS.items():
+        path = persona_dir / name
+        _, anomaly = attempt_heal(path, default_factory=lambda d=default: d)
+        if anomaly is not None:
+            anomalies.append(anomaly)
+
+    # SQLite integrity — constructor runs PRAGMA integrity_check; catch failures.
+    for db_name in ("memories.db", "hebbian.db"):
+        db_path = persona_dir / db_name
+        if not db_path.exists():
+            continue
+        try:
+            if db_name == "memories.db":
+                from brain.memory.store import MemoryStore
+
+                MemoryStore(db_path=db_path).close()
+            else:
+                from brain.memory.hebbian import HebbianMatrix
+
+                HebbianMatrix(db_path=db_path).close()
+        except BrainIntegrityError as exc:
+            anomalies.append(
+                BrainAnomaly(
+                    timestamp=datetime.now(UTC),
+                    file=db_name,
+                    kind="sqlite_integrity_fail",
+                    action="alarmed_unrecoverable",
+                    quarantine_path=None,
+                    likely_cause="disk",
+                    detail=exc.detail[:500],
+                )
+            )
+
+    return anomalies

--- a/brain/memory/hebbian.py
+++ b/brain/memory/hebbian.py
@@ -39,6 +39,19 @@ class HebbianMatrix:
 
     def __init__(self, db_path: str | Path) -> None:
         self._conn = sqlite3.connect(str(db_path))
+        try:
+            result = self._conn.execute("PRAGMA integrity_check").fetchall()
+        except sqlite3.DatabaseError as exc:
+            self._conn.close()
+            from brain.health.anomaly import BrainIntegrityError
+
+            raise BrainIntegrityError(str(db_path), str(exc)) from exc
+        if result != [("ok",)]:
+            detail = "; ".join(str(row[0]) for row in result)
+            self._conn.close()
+            from brain.health.anomaly import BrainIntegrityError
+
+            raise BrainIntegrityError(str(db_path), detail)
         self._conn.executescript(self._SCHEMA)
         self._conn.commit()
 

--- a/brain/memory/store.py
+++ b/brain/memory/store.py
@@ -204,6 +204,21 @@ class MemoryStore:
 
     def __init__(self, db_path: str | Path) -> None:
         self._conn = sqlite3.connect(str(db_path))
+        # Run integrity check BEFORE setting row_factory so result rows are
+        # plain tuples — the comparison [("ok",)] is unambiguous.
+        try:
+            result = self._conn.execute("PRAGMA integrity_check").fetchall()
+        except sqlite3.DatabaseError as exc:
+            self._conn.close()
+            from brain.health.anomaly import BrainIntegrityError
+
+            raise BrainIntegrityError(str(db_path), str(exc)) from exc
+        if result != [("ok",)]:
+            detail = "; ".join(str(row[0]) for row in result)
+            self._conn.close()
+            from brain.health.anomaly import BrainIntegrityError
+
+            raise BrainIntegrityError(str(db_path), detail)
         self._conn.row_factory = sqlite3.Row
         self._conn.executescript(_SCHEMA)
         self._conn.commit()

--- a/tests/unit/brain/health/test_adaptive.py
+++ b/tests/unit/brain/health/test_adaptive.py
@@ -1,0 +1,85 @@
+"""Tests for brain.health.adaptive — backup-depth + verify-after-write driven by audit log."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+from brain.health.adaptive import FileTreatment, compute_treatment
+
+
+def _audit_entry(file: str, when: datetime, kind: str = "json_parse_error") -> dict:
+    return {
+        "timestamp": when.isoformat().replace("+00:00", "Z"),
+        "anomalies": [
+            {
+                "timestamp": when.isoformat().replace("+00:00", "Z"),
+                "file": file,
+                "kind": kind,
+                "action": "restored_from_bak1",
+                "quarantine_path": None,
+                "likely_cause": "unknown",
+                "detail": "test",
+            }
+        ],
+    }
+
+
+def _seed_audit(persona_dir: Path, entries: list[dict]) -> None:
+    persona_dir.mkdir(parents=True, exist_ok=True)
+    p = persona_dir / "heartbeats.log.jsonl"
+    p.write_text("\n".join(json.dumps(e) for e in entries) + "\n", encoding="utf-8")
+
+
+def test_no_audit_log_returns_default(tmp_path: Path) -> None:
+    t = compute_treatment(tmp_path, "x.json")
+    assert t == FileTreatment(backup_count=3, verify_after_write=False)
+
+
+def test_one_anomaly_within_window_returns_default(tmp_path: Path) -> None:
+    _seed_audit(tmp_path, [_audit_entry("x.json", datetime.now(UTC) - timedelta(days=2))])
+    t = compute_treatment(tmp_path, "x.json")
+    assert t == FileTreatment(backup_count=3, verify_after_write=False)
+
+
+def test_three_anomalies_within_window_bumps_treatment(tmp_path: Path) -> None:
+    now = datetime.now(UTC)
+    _seed_audit(
+        tmp_path,
+        [
+            _audit_entry("x.json", now - timedelta(days=1)),
+            _audit_entry("x.json", now - timedelta(days=3)),
+            _audit_entry("x.json", now - timedelta(days=5)),
+        ],
+    )
+    t = compute_treatment(tmp_path, "x.json")
+    assert t == FileTreatment(backup_count=6, verify_after_write=True)
+
+
+def test_anomalies_for_other_file_not_counted(tmp_path: Path) -> None:
+    now = datetime.now(UTC)
+    _seed_audit(
+        tmp_path,
+        [
+            _audit_entry("y.json", now - timedelta(days=1)),
+            _audit_entry("y.json", now - timedelta(days=2)),
+            _audit_entry("y.json", now - timedelta(days=3)),
+        ],
+    )
+    t = compute_treatment(tmp_path, "x.json")
+    assert t == FileTreatment(backup_count=3, verify_after_write=False)
+
+
+def test_anomalies_outside_window_not_counted(tmp_path: Path) -> None:
+    now = datetime.now(UTC)
+    _seed_audit(
+        tmp_path,
+        [
+            _audit_entry("x.json", now - timedelta(days=10)),
+            _audit_entry("x.json", now - timedelta(days=12)),
+            _audit_entry("x.json", now - timedelta(days=15)),
+        ],
+    )
+    t = compute_treatment(tmp_path, "x.json")
+    assert t == FileTreatment(backup_count=3, verify_after_write=False)

--- a/tests/unit/brain/health/test_alarm.py
+++ b/tests/unit/brain/health/test_alarm.py
@@ -1,0 +1,65 @@
+"""Tests for brain.health.alarm."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+from brain.health.alarm import compute_pending_alarms
+
+
+def _audit_entry(file: str, when: datetime, action: str = "restored_from_bak1", kind: str = "json_parse_error") -> dict:
+    return {
+        "timestamp": when.isoformat().replace("+00:00", "Z"),
+        "anomalies": [
+            {
+                "timestamp": when.isoformat().replace("+00:00", "Z"),
+                "file": file,
+                "kind": kind,
+                "action": action,
+                "quarantine_path": None,
+                "likely_cause": "unknown",
+                "detail": "",
+            }
+        ],
+    }
+
+
+def _seed(persona_dir: Path, entries: list[dict]) -> None:
+    persona_dir.mkdir(parents=True, exist_ok=True)
+    p = persona_dir / "heartbeats.log.jsonl"
+    p.write_text("\n".join(json.dumps(e) for e in entries) + "\n", encoding="utf-8")
+
+
+def test_no_anomalies_no_alarms(tmp_path: Path) -> None:
+    assert compute_pending_alarms(tmp_path) == []
+
+
+def test_reset_to_default_on_identity_file_alarms(tmp_path: Path) -> None:
+    _seed(tmp_path, [_audit_entry("emotion_vocabulary.json", datetime.now(UTC), action="reset_to_default")])
+    alarms = compute_pending_alarms(tmp_path)
+    assert len(alarms) == 1
+    assert alarms[0].file == "emotion_vocabulary.json"
+
+
+def test_sqlite_integrity_fail_alarms(tmp_path: Path) -> None:
+    _seed(tmp_path, [_audit_entry("memories.db", datetime.now(UTC), kind="sqlite_integrity_fail", action="alarmed_unrecoverable")])
+    alarms = compute_pending_alarms(tmp_path)
+    assert len(alarms) == 1
+    assert alarms[0].kind == "sqlite_integrity_fail"
+
+
+def test_acknowledged_alarm_suppressed(tmp_path: Path) -> None:
+    when = datetime.now(UTC)
+    entries = [
+        _audit_entry("emotion_vocabulary.json", when, action="reset_to_default"),
+        # User acknowledged after the reset
+        {
+            "timestamp": (when + timedelta(minutes=5)).isoformat().replace("+00:00", "Z"),
+            "user_acknowledged": ["emotion_vocabulary.json"],
+        },
+    ]
+    _seed(tmp_path, entries)
+    alarms = compute_pending_alarms(tmp_path)
+    assert alarms == []

--- a/tests/unit/brain/health/test_alarm.py
+++ b/tests/unit/brain/health/test_alarm.py
@@ -9,7 +9,9 @@ from pathlib import Path
 from brain.health.alarm import compute_pending_alarms
 
 
-def _audit_entry(file: str, when: datetime, action: str = "restored_from_bak1", kind: str = "json_parse_error") -> dict:
+def _audit_entry(
+    file: str, when: datetime, action: str = "restored_from_bak1", kind: str = "json_parse_error"
+) -> dict:
     return {
         "timestamp": when.isoformat().replace("+00:00", "Z"),
         "anomalies": [
@@ -37,14 +39,27 @@ def test_no_anomalies_no_alarms(tmp_path: Path) -> None:
 
 
 def test_reset_to_default_on_identity_file_alarms(tmp_path: Path) -> None:
-    _seed(tmp_path, [_audit_entry("emotion_vocabulary.json", datetime.now(UTC), action="reset_to_default")])
+    _seed(
+        tmp_path,
+        [_audit_entry("emotion_vocabulary.json", datetime.now(UTC), action="reset_to_default")],
+    )
     alarms = compute_pending_alarms(tmp_path)
     assert len(alarms) == 1
     assert alarms[0].file == "emotion_vocabulary.json"
 
 
 def test_sqlite_integrity_fail_alarms(tmp_path: Path) -> None:
-    _seed(tmp_path, [_audit_entry("memories.db", datetime.now(UTC), kind="sqlite_integrity_fail", action="alarmed_unrecoverable")])
+    _seed(
+        tmp_path,
+        [
+            _audit_entry(
+                "memories.db",
+                datetime.now(UTC),
+                kind="sqlite_integrity_fail",
+                action="alarmed_unrecoverable",
+            )
+        ],
+    )
     alarms = compute_pending_alarms(tmp_path)
     assert len(alarms) == 1
     assert alarms[0].kind == "sqlite_integrity_fail"

--- a/tests/unit/brain/health/test_anomaly.py
+++ b/tests/unit/brain/health/test_anomaly.py
@@ -1,0 +1,66 @@
+"""Tests for brain.health.anomaly — BrainAnomaly + AlarmEntry frozen dataclasses."""
+
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError
+from datetime import UTC, datetime
+
+import pytest
+
+from brain.health.anomaly import AlarmEntry, BrainAnomaly
+
+
+def test_brain_anomaly_construction() -> None:
+    a = BrainAnomaly(
+        timestamp=datetime(2026, 4, 25, 18, 30, tzinfo=UTC),
+        file="emotion_vocabulary.json",
+        kind="json_parse_error",
+        action="restored_from_bak1",
+        quarantine_path="emotion_vocabulary.json.corrupt-2026-04-25T18:30:00Z",
+        likely_cause="user_edit",
+        detail="Expecting ',' delimiter: line 12 column 5",
+    )
+    assert a.file == "emotion_vocabulary.json"
+    assert a.kind == "json_parse_error"
+    assert a.likely_cause == "user_edit"
+
+
+def test_brain_anomaly_is_frozen() -> None:
+    a = BrainAnomaly(
+        timestamp=datetime.now(UTC),
+        file="x.json",
+        kind="json_parse_error",
+        action="reset_to_default",
+        quarantine_path=None,
+        likely_cause="unknown",
+        detail="",
+    )
+    with pytest.raises(FrozenInstanceError):
+        a.file = "mutated"  # type: ignore[misc]
+
+
+def test_brain_anomaly_to_dict_serialises_iso_utc() -> None:
+    a = BrainAnomaly(
+        timestamp=datetime(2026, 4, 25, 18, 30, tzinfo=UTC),
+        file="x.json",
+        kind="schema_mismatch",
+        action="reset_to_default",
+        quarantine_path=None,
+        likely_cause="unknown",
+        detail="missing 'emotions' key",
+    )
+    d = a.to_dict()
+    assert d["timestamp"].endswith("Z")
+    assert d["file"] == "x.json"
+    assert d["quarantine_path"] is None
+
+
+def test_alarm_entry_is_frozen() -> None:
+    e = AlarmEntry(
+        file="memories.db",
+        kind="sqlite_integrity_fail",
+        first_seen_at=datetime.now(UTC),
+        occurrences_in_window=1,
+    )
+    with pytest.raises(FrozenInstanceError):
+        e.file = "x"  # type: ignore[misc]

--- a/tests/unit/brain/health/test_attempt_heal.py
+++ b/tests/unit/brain/health/test_attempt_heal.py
@@ -86,8 +86,12 @@ def test_attempt_heal_walks_to_bak2_when_bak1_corrupt(tmp_path: Path) -> None:
 
 def test_attempt_heal_schema_validator_failure_treated_as_corrupt(tmp_path: Path) -> None:
     p = tmp_path / "vocab.json"
-    p.write_text(json.dumps({"version": 1, "wrong_field": []}), encoding="utf-8")  # parses but invalid
-    data, anomaly = attempt_heal(p, lambda: {"version": 1, "emotions": []}, schema_validator=_vocab_validator)
+    p.write_text(
+        json.dumps({"version": 1, "wrong_field": []}), encoding="utf-8"
+    )  # parses but invalid
+    data, anomaly = attempt_heal(
+        p, lambda: {"version": 1, "emotions": []}, schema_validator=_vocab_validator
+    )
     assert anomaly is not None
     assert anomaly.kind == "schema_mismatch"
     assert anomaly.action == "reset_to_default"

--- a/tests/unit/brain/health/test_attempt_heal.py
+++ b/tests/unit/brain/health/test_attempt_heal.py
@@ -158,3 +158,22 @@ def test_save_with_backup_higher_count_keeps_more(tmp_path: Path) -> None:
     for k, expected in zip(range(1, 7), [6, 5, 4, 3, 2, 1], strict=True):
         bak = tmp_path / f"x.json.bak{k}"
         assert json.loads(bak.read_text(encoding="utf-8")) == {"a": expected}
+
+
+def test_quarantine_filename_has_no_colons(tmp_path: Path) -> None:
+    """Quarantine filenames must use Windows-safe characters.
+
+    `os.replace` with a filename containing `:` raises WinError 123 on Windows.
+    The quarantine timestamp swaps colons for hyphens to round-trip across
+    POSIX + Windows.
+    """
+    p = tmp_path / "x.json"
+    p.write_text("{not json", encoding="utf-8")
+    _, anomaly = attempt_heal(p, _default)
+    assert anomaly is not None
+    assert ":" not in anomaly.quarantine_path
+    # Verify the quarantine file actually exists on disk (would have failed
+    # to create on Windows if the filename were illegal).
+    quarantines = list(tmp_path.glob("x.json.corrupt-*"))
+    assert len(quarantines) == 1
+    assert ":" not in quarantines[0].name

--- a/tests/unit/brain/health/test_attempt_heal.py
+++ b/tests/unit/brain/health/test_attempt_heal.py
@@ -1,0 +1,156 @@
+"""Tests for brain.health.attempt_heal — core heal + save helpers."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from brain.health.attempt_heal import attempt_heal, save_with_backup
+
+
+def _default() -> dict:
+    return {"version": 1, "value": "default"}
+
+
+def _vocab_validator(data: object) -> None:
+    if not isinstance(data, dict) or not isinstance(data.get("emotions"), list):
+        raise ValueError("missing 'emotions' list")
+
+
+# ---- Healthy paths ----
+
+
+def test_attempt_heal_missing_file_returns_default(tmp_path: Path) -> None:
+    data, anomaly = attempt_heal(tmp_path / "x.json", _default)
+    assert data == {"version": 1, "value": "default"}
+    assert anomaly is None
+
+
+def test_attempt_heal_well_formed_returns_data(tmp_path: Path) -> None:
+    p = tmp_path / "x.json"
+    p.write_text(json.dumps({"version": 1, "value": "stored"}), encoding="utf-8")
+    data, anomaly = attempt_heal(p, _default)
+    assert data == {"version": 1, "value": "stored"}
+    assert anomaly is None
+
+
+def test_attempt_heal_validator_passes_well_formed(tmp_path: Path) -> None:
+    p = tmp_path / "vocab.json"
+    p.write_text(json.dumps({"version": 1, "emotions": []}), encoding="utf-8")
+    data, anomaly = attempt_heal(p, _default, schema_validator=_vocab_validator)
+    assert anomaly is None
+
+
+# ---- Corrupt paths ----
+
+
+def test_attempt_heal_corrupt_json_no_baks_resets_to_default(tmp_path: Path) -> None:
+    p = tmp_path / "x.json"
+    p.write_text("{not json", encoding="utf-8")
+    data, anomaly = attempt_heal(p, _default)
+    assert data == {"version": 1, "value": "default"}
+    assert anomaly is not None
+    assert anomaly.action == "reset_to_default"
+    assert anomaly.kind == "json_parse_error"
+    # Quarantine present
+    quarantines = list(tmp_path.glob("x.json.corrupt-*"))
+    assert len(quarantines) == 1
+    # Live file rewritten with default
+    assert json.loads(p.read_text(encoding="utf-8")) == {"version": 1, "value": "default"}
+
+
+def test_attempt_heal_restores_from_bak1(tmp_path: Path) -> None:
+    p = tmp_path / "x.json"
+    bak1 = tmp_path / "x.json.bak1"
+    bak1.write_text(json.dumps({"version": 1, "value": "good"}), encoding="utf-8")
+    p.write_text("{not json", encoding="utf-8")
+    data, anomaly = attempt_heal(p, _default)
+    assert data == {"version": 1, "value": "good"}
+    assert anomaly.action == "restored_from_bak1"
+    # bak1 is now the live file (was renamed in)
+    assert json.loads(p.read_text(encoding="utf-8"))["value"] == "good"
+    assert not bak1.exists()  # consumed
+
+
+def test_attempt_heal_walks_to_bak2_when_bak1_corrupt(tmp_path: Path) -> None:
+    p = tmp_path / "x.json"
+    p.write_text("{not json", encoding="utf-8")
+    (tmp_path / "x.json.bak1").write_text("{also not json", encoding="utf-8")
+    (tmp_path / "x.json.bak2").write_text(
+        json.dumps({"version": 1, "value": "older_good"}), encoding="utf-8"
+    )
+    data, anomaly = attempt_heal(p, _default)
+    assert data == {"version": 1, "value": "older_good"}
+    assert anomaly.action == "restored_from_bak2"
+
+
+def test_attempt_heal_schema_validator_failure_treated_as_corrupt(tmp_path: Path) -> None:
+    p = tmp_path / "vocab.json"
+    p.write_text(json.dumps({"version": 1, "wrong_field": []}), encoding="utf-8")  # parses but invalid
+    data, anomaly = attempt_heal(p, lambda: {"version": 1, "emotions": []}, schema_validator=_vocab_validator)
+    assert anomaly is not None
+    assert anomaly.kind == "schema_mismatch"
+    assert anomaly.action == "reset_to_default"
+
+
+def test_attempt_heal_user_edit_heuristic(tmp_path: Path) -> None:
+    p = tmp_path / "user_preferences.json"
+    p.write_text("{not json", encoding="utf-8")
+    # mtime is now (recently edited), small file, content starts with {
+    data, anomaly = attempt_heal(p, _default)
+    assert anomaly is not None
+    assert anomaly.likely_cause == "user_edit"
+
+
+# ---- Save flow ----
+
+
+def test_save_with_backup_first_save_no_bak(tmp_path: Path) -> None:
+    p = tmp_path / "x.json"
+    save_with_backup(p, {"a": 1})
+    assert json.loads(p.read_text(encoding="utf-8")) == {"a": 1}
+    assert not (tmp_path / "x.json.bak1").exists()
+    assert not (tmp_path / "x.json.new").exists()
+
+
+def test_save_with_backup_rotates_3_levels(tmp_path: Path) -> None:
+    p = tmp_path / "x.json"
+    save_with_backup(p, {"a": 1})  # live=1
+    save_with_backup(p, {"a": 2})  # live=2, bak1=1
+    save_with_backup(p, {"a": 3})  # live=3, bak1=2, bak2=1
+    save_with_backup(p, {"a": 4})  # live=4, bak1=3, bak2=2, bak3=1
+    assert json.loads(p.read_text(encoding="utf-8")) == {"a": 4}
+    assert json.loads((tmp_path / "x.json.bak1").read_text(encoding="utf-8")) == {"a": 3}
+    assert json.loads((tmp_path / "x.json.bak2").read_text(encoding="utf-8")) == {"a": 2}
+    assert json.loads((tmp_path / "x.json.bak3").read_text(encoding="utf-8")) == {"a": 1}
+
+
+def test_save_with_backup_caps_at_3_drops_oldest(tmp_path: Path) -> None:
+    p = tmp_path / "x.json"
+    for i in range(1, 6):
+        save_with_backup(p, {"a": i})
+    # live=5, bak1=4, bak2=3, bak3=2, oldest dropped
+    assert json.loads(p.read_text(encoding="utf-8")) == {"a": 5}
+    assert json.loads((tmp_path / "x.json.bak3").read_text(encoding="utf-8")) == {"a": 2}
+    assert not (tmp_path / "x.json.bak4").exists()
+
+
+def test_save_with_backup_unlinks_stale_new(tmp_path: Path) -> None:
+    """If .new exists from a prior crash, save unlinks it before writing."""
+    p = tmp_path / "x.json"
+    (tmp_path / "x.json.new").write_text("stale partial content", encoding="utf-8")
+    save_with_backup(p, {"a": 1})
+    # Stale .new is gone; live file is correct
+    assert not (tmp_path / "x.json.new").exists()
+    assert json.loads(p.read_text(encoding="utf-8")) == {"a": 1}
+
+
+def test_save_with_backup_higher_count_keeps_more(tmp_path: Path) -> None:
+    """When backup_count=6, six backups are retained."""
+    p = tmp_path / "x.json"
+    for i in range(1, 8):
+        save_with_backup(p, {"a": i}, backup_count=6)
+    # live=7; bak1..bak6 = 6,5,4,3,2,1
+    for k, expected in zip(range(1, 7), [6, 5, 4, 3, 2, 1], strict=True):
+        bak = tmp_path / f"x.json.bak{k}"
+        assert json.loads(bak.read_text(encoding="utf-8")) == {"a": expected}

--- a/tests/unit/brain/health/test_jsonl_reader.py
+++ b/tests/unit/brain/health/test_jsonl_reader.py
@@ -15,9 +15,7 @@ def test_missing_file_returns_empty(tmp_path: Path) -> None:
 
 def test_well_formed_lines_round_trip(tmp_path: Path) -> None:
     p = tmp_path / "log.jsonl"
-    p.write_text(
-        json.dumps({"a": 1}) + "\n" + json.dumps({"a": 2}) + "\n", encoding="utf-8"
-    )
+    p.write_text(json.dumps({"a": 1}) + "\n" + json.dumps({"a": 2}) + "\n", encoding="utf-8")
     out = read_jsonl_skipping_corrupt(p)
     assert out == [{"a": 1}, {"a": 2}]
 

--- a/tests/unit/brain/health/test_jsonl_reader.py
+++ b/tests/unit/brain/health/test_jsonl_reader.py
@@ -1,0 +1,57 @@
+"""Tests for brain.health.jsonl_reader."""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+
+from brain.health.jsonl_reader import read_jsonl_skipping_corrupt
+
+
+def test_missing_file_returns_empty(tmp_path: Path) -> None:
+    assert read_jsonl_skipping_corrupt(tmp_path / "missing.jsonl") == []
+
+
+def test_well_formed_lines_round_trip(tmp_path: Path) -> None:
+    p = tmp_path / "log.jsonl"
+    p.write_text(
+        json.dumps({"a": 1}) + "\n" + json.dumps({"a": 2}) + "\n", encoding="utf-8"
+    )
+    out = read_jsonl_skipping_corrupt(p)
+    assert out == [{"a": 1}, {"a": 2}]
+
+
+def test_skips_blank_lines(tmp_path: Path) -> None:
+    p = tmp_path / "log.jsonl"
+    p.write_text(json.dumps({"a": 1}) + "\n\n\n" + json.dumps({"a": 2}) + "\n", encoding="utf-8")
+    assert read_jsonl_skipping_corrupt(p) == [{"a": 1}, {"a": 2}]
+
+
+def test_skips_corrupt_lines_and_warns(tmp_path: Path, caplog) -> None:
+    caplog.set_level(logging.WARNING)
+    p = tmp_path / "log.jsonl"
+    p.write_text(
+        json.dumps({"good": 1}) + "\n{not valid\n" + json.dumps({"good": 2}) + "\n",
+        encoding="utf-8",
+    )
+    out = read_jsonl_skipping_corrupt(p)
+    assert out == [{"good": 1}, {"good": 2}]
+
+    bad = [r for r in caplog.records if "malformed jsonl line" in r.getMessage()]
+    assert len(bad) == 1
+    msg = bad[0].getMessage()
+    assert "line 2" in msg
+    assert "{not valid" in msg
+
+
+def test_warning_includes_path_and_truncates_long_content(tmp_path: Path, caplog) -> None:
+    caplog.set_level(logging.WARNING)
+    p = tmp_path / "log.jsonl"
+    long_corrupt = "{" + ("x" * 500)
+    p.write_text(long_corrupt + "\n", encoding="utf-8")
+    read_jsonl_skipping_corrupt(p)
+    msg = next(r.getMessage() for r in caplog.records if "malformed jsonl line" in r.getMessage())
+    assert str(p) in msg
+    assert "x" * 200 in msg  # 200-char preview
+    assert "x" * 500 not in msg  # truncated

--- a/tests/unit/brain/health/test_reconstruct.py
+++ b/tests/unit/brain/health/test_reconstruct.py
@@ -28,13 +28,17 @@ def test_reconstructs_persona_extensions_from_memories() -> None:
         # Seed memories that reference custom emotions not in baseline.
         store.create(
             Memory.create_new(
-                content="x", memory_type="conversation", domain="us",
+                content="x",
+                memory_type="conversation",
+                domain="us",
                 emotions={"body_grief": 8.0, "love": 9.0},
             )
         )
         store.create(
             Memory.create_new(
-                content="y", memory_type="conversation", domain="us",
+                content="y",
+                memory_type="conversation",
+                domain="us",
                 emotions={"creative_hunger": 7.0},
             )
         )
@@ -61,7 +65,10 @@ def test_baseline_names_in_memories_not_duplicated() -> None:
     try:
         store.create(
             Memory.create_new(
-                content="x", memory_type="conversation", domain="us", emotions={"love": 9.0},
+                content="x",
+                memory_type="conversation",
+                domain="us",
+                emotions={"love": 9.0},
             )
         )
         result = reconstruct_vocabulary_from_memories(store)
@@ -78,7 +85,10 @@ def test_returned_shape_matches_persona_loader_expectation() -> None:
     try:
         store.create(
             Memory.create_new(
-                content="x", memory_type="conversation", domain="us", emotions={"x_emotion": 5.0},
+                content="x",
+                memory_type="conversation",
+                domain="us",
+                emotions={"x_emotion": 5.0},
             )
         )
         result = reconstruct_vocabulary_from_memories(store)

--- a/tests/unit/brain/health/test_reconstruct.py
+++ b/tests/unit/brain/health/test_reconstruct.py
@@ -1,0 +1,93 @@
+"""Tests for brain.health.reconstruct — vocabulary reconstruction from memories."""
+
+from __future__ import annotations
+
+from brain.health.reconstruct import reconstruct_vocabulary_from_memories
+from brain.memory.store import Memory, MemoryStore
+
+
+def test_empty_store_returns_baseline_only() -> None:
+    store = MemoryStore(":memory:")
+    try:
+        result = reconstruct_vocabulary_from_memories(store)
+        names = {e["name"] for e in result["emotions"]}
+        # 21 framework baseline emotions
+        assert "love" in names
+        assert "joy" in names
+        assert "belonging" in names
+        # No persona extensions
+        for e in result["emotions"]:
+            assert e["category"] == "core" or e["category"] == "complex"
+    finally:
+        store.close()
+
+
+def test_reconstructs_persona_extensions_from_memories() -> None:
+    store = MemoryStore(":memory:")
+    try:
+        # Seed memories that reference custom emotions not in baseline.
+        store.create(
+            Memory.create_new(
+                content="x", memory_type="conversation", domain="us",
+                emotions={"body_grief": 8.0, "love": 9.0},
+            )
+        )
+        store.create(
+            Memory.create_new(
+                content="y", memory_type="conversation", domain="us",
+                emotions={"creative_hunger": 7.0},
+            )
+        )
+
+        result = reconstruct_vocabulary_from_memories(store)
+        names = {e["name"] for e in result["emotions"]}
+        assert "body_grief" in names
+        assert "creative_hunger" in names
+        # love is baseline, should also be present
+        assert "love" in names
+
+        # Extensions have placeholder description + conservative decay
+        body_grief = next(e for e in result["emotions"] if e["name"] == "body_grief")
+        assert "reconstructed from memory" in body_grief["description"]
+        assert body_grief["category"] == "persona_extension"
+        assert body_grief["decay_half_life_days"] == 1.0
+    finally:
+        store.close()
+
+
+def test_baseline_names_in_memories_not_duplicated() -> None:
+    """If a baseline emotion name appears in memories, it doesn't get duplicated as extension."""
+    store = MemoryStore(":memory:")
+    try:
+        store.create(
+            Memory.create_new(
+                content="x", memory_type="conversation", domain="us", emotions={"love": 9.0},
+            )
+        )
+        result = reconstruct_vocabulary_from_memories(store)
+        love_entries = [e for e in result["emotions"] if e["name"] == "love"]
+        assert len(love_entries) == 1
+        assert love_entries[0]["category"] == "core"  # baseline, not extension
+    finally:
+        store.close()
+
+
+def test_returned_shape_matches_persona_loader_expectation() -> None:
+    """Output is loadable by load_persona_vocabulary."""
+    store = MemoryStore(":memory:")
+    try:
+        store.create(
+            Memory.create_new(
+                content="x", memory_type="conversation", domain="us", emotions={"x_emotion": 5.0},
+            )
+        )
+        result = reconstruct_vocabulary_from_memories(store)
+        assert "version" in result
+        assert isinstance(result["emotions"], list)
+        for e in result["emotions"]:
+            assert "name" in e
+            assert "description" in e
+            assert "category" in e
+            assert "decay_half_life_days" in e
+    finally:
+        store.close()

--- a/tests/unit/brain/health/test_walker.py
+++ b/tests/unit/brain/health/test_walker.py
@@ -1,0 +1,53 @@
+"""Tests for brain.health.walker."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from brain.health.walker import walk_persona
+from brain.memory.hebbian import HebbianMatrix
+from brain.memory.store import MemoryStore
+
+
+def _setup_persona(tmp_path: Path) -> Path:
+    persona = tmp_path / "persona"
+    persona.mkdir()
+    MemoryStore(db_path=persona / "memories.db").close()
+    HebbianMatrix(db_path=persona / "hebbian.db").close()
+    return persona
+
+
+def test_walk_clean_persona_no_anomalies(tmp_path: Path) -> None:
+    persona = _setup_persona(tmp_path)
+    anomalies = walk_persona(persona)
+    assert anomalies == []
+
+
+def test_walk_detects_corrupt_atomic_rewrite_file(tmp_path: Path) -> None:
+    persona = _setup_persona(tmp_path)
+    (persona / "user_preferences.json").write_text("{not json", encoding="utf-8")
+    anomalies = walk_persona(persona)
+    assert len(anomalies) == 1
+    assert anomalies[0].file == "user_preferences.json"
+    # File is healed (reset to default since no .bak)
+    assert (persona / "user_preferences.json").exists()
+
+
+def test_walk_detects_sqlite_corruption(tmp_path: Path) -> None:
+    persona = tmp_path / "persona"
+    persona.mkdir()
+    (persona / "memories.db").write_bytes(b"not sqlite")
+    HebbianMatrix(db_path=persona / "hebbian.db").close()  # clean
+    anomalies = walk_persona(persona)
+    assert any(a.kind == "sqlite_integrity_fail" for a in anomalies)
+
+
+def test_walk_returns_multiple_anomalies(tmp_path: Path) -> None:
+    persona = _setup_persona(tmp_path)
+    (persona / "user_preferences.json").write_text("{not json", encoding="utf-8")
+    (persona / "persona_config.json").write_text("{also not json", encoding="utf-8")
+    anomalies = walk_persona(persona)
+    assert len(anomalies) >= 2
+    files = {a.file for a in anomalies}
+    assert "user_preferences.json" in files
+    assert "persona_config.json" in files

--- a/tests/unit/brain/memory/test_store_integrity.py
+++ b/tests/unit/brain/memory/test_store_integrity.py
@@ -1,0 +1,42 @@
+"""Tests for SQLite integrity check on store + hebbian open."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from brain.health.anomaly import BrainIntegrityError
+from brain.memory.hebbian import HebbianMatrix
+from brain.memory.store import MemoryStore
+
+
+def test_memory_store_clean_db_passes_integrity_check(tmp_path: Path) -> None:
+    """A clean store opens without raising."""
+    store = MemoryStore(db_path=tmp_path / "memories.db")
+    store.close()
+    # Re-open — integrity check runs again on fresh open
+    store2 = MemoryStore(db_path=tmp_path / "memories.db")
+    store2.close()
+
+
+def test_memory_store_corrupt_db_raises_integrity_error(tmp_path: Path) -> None:
+    """A file with bad SQLite header → BrainIntegrityError on open."""
+    db = tmp_path / "memories.db"
+    db.write_bytes(b"this is not a SQLite database")
+    with pytest.raises(BrainIntegrityError):
+        MemoryStore(db_path=db)
+
+
+def test_hebbian_matrix_clean_db_passes(tmp_path: Path) -> None:
+    h = HebbianMatrix(db_path=tmp_path / "hebbian.db")
+    h.close()
+    h2 = HebbianMatrix(db_path=tmp_path / "hebbian.db")
+    h2.close()
+
+
+def test_hebbian_matrix_corrupt_db_raises(tmp_path: Path) -> None:
+    db = tmp_path / "hebbian.db"
+    db.write_bytes(b"not sqlite")
+    with pytest.raises(BrainIntegrityError):
+        HebbianMatrix(db_path=db)


### PR DESCRIPTION
## Summary

Implements **PR-1 (Tasks 1-8)** of the brain-health module per:
- **Spec:** [docs/superpowers/specs/2026-04-25-brain-health-module-design.md](docs/superpowers/specs/2026-04-25-brain-health-module-design.md)
- **Plan:** [docs/superpowers/plans/2026-04-25-brain-health-module-plan.md](docs/superpowers/plans/2026-04-25-brain-health-module-plan.md)

This PR ships the entire `brain/health/` package internals + SQLite integrity check on `MemoryStore` / `HebbianMatrix`. **No wiring into other modules yet** — that's PR-2. PR-1 is self-contained and reviewable independently.

The brain doesn't auto-heal anything yet because nothing calls these helpers. PR-2 will wire them into every load/save path; this PR proves the helpers work in isolation.

## Components shipped

**`brain/health/` package:**
- `anomaly.py` — `BrainAnomaly` + `AlarmEntry` frozen dataclasses + `BrainIntegrityError`. `to_dict`/`from_dict` round-trip.
- `jsonl_reader.py` — `read_jsonl_skipping_corrupt(path)` generalises the Phase 2a hardening pattern (line-index + 200-char content preview in warnings).
- `attempt_heal.py` — `attempt_heal(path, default_factory, schema_validator=None) -> tuple[Any, BrainAnomaly | None]` + `save_with_backup(path, data, backup_count=3)`. Heal flow: quarantine corrupt → walk `.bak1`/`.bak2`/`.bak3` for freshest valid backup → restore via `os.replace`; if all corrupt, write `default_factory()` output. Save flow: stale `.new` cleanup, atomic rotation, atomic replace.
- `adaptive.py` — `compute_treatment(persona_dir, file)` reads audit log; ≥3 corruptions in 7 days → returns `FileTreatment(backup_count=6, verify_after_write=True)`.
- `reconstruct.py` — `reconstruct_vocabulary_from_memories(store)` rebuilds `emotion_vocabulary.json` from observed emotion names in memories.db. Framework baseline (21 entries) + persona-extension entries with placeholder description and conservative decay (1.0 days).
- `walker.py` — `walk_persona(persona_dir) -> list[BrainAnomaly]` proactive scan over every persona file.
- `alarm.py` — `compute_pending_alarms(persona_dir) -> list[AlarmEntry]` derived from audit log + acknowledgments.

**SQLite integrity:**
- `MemoryStore.__init__` and `HebbianMatrix.__init__` run `PRAGMA integrity_check` before any other init logic. Raise `BrainIntegrityError` on failure or non-`ok` result.

## Per-task review

Each task went through implementer → spec compliance ✅ (T1-T3 explicit, T4-T8 inline-checked) → code quality ✅ where the surface warranted.

T3 (the meatiest task — heal flow + atomic save rotation) had three nits flagged:
1. Quarantine timestamp collision on sub-second corruption (rare, low priority — corruption already lost)
2. Validator exception types narrow (acceptable — validators are trusted code)
3. Stale `.new` cleanup uses `if exists: unlink()` (defensible; could use `unlink(missing_ok=True)` for race safety)

All non-blocking. Captured for follow-up if real-world evidence ever shows them.

T6 caught a real bug pre-emptively: `sqlite3.Row` row factory makes `result != [("ok",)]` always True. Implementer reordered: integrity check runs *before* `row_factory` is set on `MemoryStore`.

## Test plan

- [x] **577 tests passing** (was 534, +43 new across T1-T8: 4 + 5 + 13 + 5 + 4 + 4 + 4 + 4)
- [x] `ruff check && ruff format --check` clean
- [x] `rg 'import anthropic' brain/health/` returns zero
- [x] All helpers tested in isolation; no integration tests yet (PR-2 territory)

## Follow-up (PR-2)

Tasks T9-T14:
- Wire `attempt_heal` + `save_with_backup` into every atomic-rewrite load/save (`PersonaConfig`, `UserPreferences`, `HeartbeatConfig`, `HeartbeatState`, `InterestSet`, reflex arcs, `load_persona_vocabulary`, growth scheduler vocabulary writes)
- Wire `read_jsonl_skipping_corrupt` into all log readers
- Heartbeat tick aggregates anomalies, runs cross-file walk on ≥2, surfaces `pending_alarms_count`, adds compact CLI banner / 🩹 line
- `nell health show / check / acknowledge` CLI subcommands
- Sandbox smoke + acceptance verification