### PR TITLE
Brain Health PR-2: wire helpers + heartbeat anomaly aggregation + nell health CLI

### DIFF
--- a/brain/cli.py
+++ b/brain/cli.py
@@ -20,12 +20,16 @@ from brain.engines.dream import DreamEngine
 from brain.engines.heartbeat import HeartbeatEngine
 from brain.engines.reflex import ReflexEngine
 from brain.engines.research import ResearchEngine
+from brain.health.alarm import compute_pending_alarms
+from brain.health.jsonl_reader import read_jsonl_skipping_corrupt
+from brain.health.walker import walk_persona
 from brain.memory.hebbian import HebbianMatrix
 from brain.memory.store import MemoryStore
 from brain.migrator.cli import build_parser as _build_migrate_parser
 from brain.paths import get_persona_dir
 from brain.persona_config import PersonaConfig
 from brain.search.factory import get_searcher
+from brain.utils.time import iso_utc
 
 
 def _resolve_routing(persona_dir: Path, args: argparse.Namespace) -> tuple[str, str]:
@@ -420,6 +424,160 @@ def _growth_log_handler(args: argparse.Namespace) -> int:
     return 0
 
 
+def _health_show_handler(args: argparse.Namespace) -> int:
+    """Dispatch `nell health show` — pending alarms + recent self-treatments (read-only)."""
+    persona_dir = get_persona_dir(args.persona)
+    if not persona_dir.exists():
+        raise FileNotFoundError(
+            f"No persona directory at {persona_dir}. Persona {args.persona!r} does not exist."
+        )
+
+    from datetime import UTC, datetime, timedelta
+
+    audit_path = persona_dir / "heartbeats.log.jsonl"
+    cutoff = datetime.now(UTC) - timedelta(days=7)
+
+    # Collect recent anomaly records from the audit log.
+    recent_treatments: list[dict] = []
+    for entry in read_jsonl_skipping_corrupt(audit_path):
+        try:
+            from brain.utils.time import parse_iso_utc
+
+            ts = parse_iso_utc(entry["timestamp"])
+        except (KeyError, ValueError, TypeError):
+            continue
+        if ts < cutoff:
+            continue
+        for a in entry.get("anomalies") or []:
+            if isinstance(a, dict):
+                recent_treatments.append(a)
+
+    alarms = compute_pending_alarms(persona_dir)
+
+    print(f"Health for persona {args.persona!r}:\n")
+
+    print(f"  Pending alarms: {len(alarms)}")
+    for alarm in alarms:
+        date_str = alarm.first_seen_at.strftime("%Y-%m-%d")
+        print(
+            f"    {alarm.file}: {alarm.kind} {date_str} "
+            f"({alarm.occurrences_in_window} occurrences in window)"
+        )
+
+    print(f"  Recent self-treatments (last 7 days): {len(recent_treatments)}")
+    for t in recent_treatments:
+        try:
+            from brain.utils.time import parse_iso_utc
+
+            ts = parse_iso_utc(t["timestamp"])
+            ts_str = iso_utc(ts)
+        except (KeyError, ValueError, TypeError):
+            ts_str = "unknown"
+        f = t.get("file", "?")
+        action = t.get("action", "?")
+        cause = t.get("likely_cause", "unknown")
+        qpath = t.get("quarantine_path")
+        print(f"    {ts_str}  {f}  {action}  (cause: {cause})")
+        if qpath:
+            print(f"             forensic: {qpath}")
+
+    return 0
+
+
+def _health_check_handler(args: argparse.Namespace) -> int:
+    """Dispatch `nell health check` — run walk_persona, print per-file status."""
+    persona_dir = get_persona_dir(args.persona)
+    if not persona_dir.exists():
+        raise FileNotFoundError(
+            f"No persona directory at {persona_dir}. Persona {args.persona!r} does not exist."
+        )
+
+    anomalies = walk_persona(persona_dir)
+
+    # Classify anomalies: unhealable vs self-treated.
+    unhealable = [a for a in anomalies if a.action == "alarmed_unrecoverable"]
+    healed = [a for a in anomalies if a.action != "alarmed_unrecoverable"]
+
+    # Gather all checked file names (from anomalies only — healthy files print OK below).
+    anomaly_files = {a.file for a in anomalies}
+
+    # Print per-file status for anomalies.
+    for a in healed:
+        print(f"⚠️  {a.file}: {a.action} ({a.kind})")
+    for a in unhealable:
+        print(f"❌  {a.file}: {a.kind} — unrecoverable")
+
+    # Healthy files: any JSON file in the walker's default set not in anomalies.
+    walker_files = [
+        "user_preferences.json",
+        "persona_config.json",
+        "heartbeat_config.json",
+        "heartbeat_state.json",
+        "interests.json",
+        "reflex_arcs.json",
+        "emotion_vocabulary.json",
+        "memories.db",
+        "hebbian.db",
+    ]
+    for fname in walker_files:
+        if fname not in anomaly_files and (persona_dir / fname).exists():
+            print(f"✅  {fname}: OK")
+
+    n_healed = len(healed)
+    n_unhealable = len(unhealable)
+    is_alarming = n_unhealable > 0
+    state = "alarming" if is_alarming else "healthy"
+    print(f"\n{n_healed} file(s) healed, {n_unhealable} unhealable. Brain is {state}.")
+
+    return 2 if is_alarming else 0
+
+
+def _health_acknowledge_handler(args: argparse.Namespace) -> int:
+    """Dispatch `nell health acknowledge` — append user_acknowledged entry to audit log."""
+    from datetime import UTC, datetime
+
+    persona_dir = get_persona_dir(args.persona)
+    if not persona_dir.exists():
+        raise FileNotFoundError(
+            f"No persona directory at {persona_dir}. Persona {args.persona!r} does not exist."
+        )
+
+    # Validate: at most one of --file / --all may be set. Default to --all.
+    has_file = getattr(args, "ack_file", None) is not None
+    has_all = getattr(args, "ack_all", False)
+
+    if has_file and has_all:
+        print("Error: --file and --all are mutually exclusive.", file=sys.stderr)
+        return 1
+
+    if has_file:
+        files_to_ack = [args.ack_file]
+    else:
+        # Default: --all — acknowledge every pending alarm.
+        alarms = compute_pending_alarms(persona_dir)
+        files_to_ack = [alarm.file for alarm in alarms]
+
+    import json
+
+    entry = {
+        "timestamp": iso_utc(datetime.now(UTC)),
+        "user_acknowledged": files_to_ack,
+    }
+    audit_path = persona_dir / "heartbeats.log.jsonl"
+    with audit_path.open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps(entry) + "\n")
+
+    n = len(files_to_ack)
+    if n == 0:
+        print("No pending alarms to acknowledge.")
+    else:
+        desc = ", ".join(files_to_ack[:3])
+        if n > 3:
+            desc += f", ... ({n} total)"
+        print(f"Acknowledged {n} alarm(s): {desc}")
+    return 0
+
+
 def _build_parser() -> argparse.ArgumentParser:
     """Construct the top-level argparse parser with all stub subcommands."""
     parser = argparse.ArgumentParser(
@@ -628,6 +786,44 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Filter by event type (e.g. 'emotion_added').",
     )
     g_log.set_defaults(func=_growth_log_handler)
+
+    # nell health show/check/acknowledge — read-only inspection + append-only audit.
+    # Per Task 13: no restore/add/delete/approve/reject actions are wired.
+    h_sub = subparsers.add_parser(
+        "health",
+        help="Inspect and acknowledge brain health alarms (read-only + audit-append).",
+    )
+    h_actions = h_sub.add_subparsers(dest="action", required=True)
+
+    h_show = h_actions.add_parser("show", help="Print pending alarms + recent self-treatments.")
+    h_show.add_argument("--persona", required=True, help="Persona name (required).")
+    h_show.set_defaults(func=_health_show_handler)
+
+    h_check = h_actions.add_parser(
+        "check", help="Run a full file integrity walk; exit 2 if unhealable alarms exist."
+    )
+    h_check.add_argument("--persona", required=True, help="Persona name (required).")
+    h_check.set_defaults(func=_health_check_handler)
+
+    h_ack = h_actions.add_parser(
+        "acknowledge",
+        help="Acknowledge pending alarms (appends to audit log; no destructive changes).",
+    )
+    h_ack.add_argument("--persona", required=True, help="Persona name (required).")
+    h_ack.add_argument(
+        "--file",
+        dest="ack_file",
+        default=None,
+        help="Acknowledge a specific file. Mutually exclusive with --all.",
+    )
+    h_ack.add_argument(
+        "--all",
+        dest="ack_all",
+        action="store_true",
+        default=False,
+        help="Acknowledge all pending alarms (default if neither --file nor --all is given).",
+    )
+    h_ack.set_defaults(func=_health_acknowledge_handler)
 
     return parser
 

--- a/brain/cli.py
+++ b/brain/cli.py
@@ -185,6 +185,15 @@ def _heartbeat_handler(args: argparse.Namespace) -> int:
         )
     else:
         verbose = getattr(args, "verbose", False)
+
+        # Health banner — printed BEFORE engine status lines so it's visible
+        # at the top. Only shown when there are unacknowledged alarms.
+        if result.pending_alarms_count > 0:
+            print(
+                f"⚠️  Brain alarm — needs your attention. "
+                f"Run `nell health show --persona {args.persona}` for details."
+            )
+
         print(f"Heartbeat tick complete ({args.trigger}).")
         print(f"  elapsed: {result.elapsed_seconds / 3600:.2f}h")
         print(f"  decayed: {result.memories_decayed} memories, pruned {result.edges_pruned} edges")
@@ -216,6 +225,21 @@ def _heartbeat_handler(args: argparse.Namespace) -> int:
             print(f"  interests bumped: {result.interests_bumped}")
         elif verbose:
             print("  interests bumped: 0")
+
+        # Self-treatment line — shown when anomalies were healed but no pending alarms.
+        # Appears after engine status, before the trailing newline.
+        if result.anomalies and result.pending_alarms_count == 0:
+            distinct_files = list(dict.fromkeys(a.file for a in result.anomalies))
+            count = len(distinct_files)
+            if count <= 2:
+                files_desc = ", ".join(distinct_files)
+            else:
+                files_desc = ", ".join(distinct_files[:2]) + ", ..."
+            print(
+                f"  \U0001fa79 brain self-treated {count} file"
+                f"{'s' if count != 1 else ''} ({files_desc})"
+                f" — see `nell health show` for details"
+            )
     return 0
 
 

--- a/brain/emotion/persona_loader.py
+++ b/brain/emotion/persona_loader.py
@@ -9,15 +9,69 @@ Spec: docs/superpowers/specs/2026-04-25-vocabulary-split-design.md
 
 from __future__ import annotations
 
-import json
 import logging
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from brain.emotion import vocabulary
 from brain.emotion.vocabulary import Emotion
 from brain.memory.store import MemoryStore
 
+if TYPE_CHECKING:
+    from brain.health.anomaly import BrainAnomaly
+
 logger = logging.getLogger(__name__)
+
+_DEFAULT_VOCAB: dict = {"version": 1, "emotions": []}
+
+
+def _default_vocab_factory() -> dict:
+    return {"version": 1, "emotions": []}
+
+
+def _vocab_schema_validator(data: object) -> None:
+    if not isinstance(data, dict) or not isinstance(data.get("emotions"), list):
+        raise ValueError("emotion_vocabulary schema invalid: missing 'emotions' list")
+
+
+def load_persona_vocabulary_with_anomaly(
+    path: Path,
+    *,
+    store: MemoryStore | None = None,
+) -> tuple[int, BrainAnomaly | None]:
+    """Load persona vocabulary with self-healing from .bak rotation if corrupt.
+
+    Returns (registered_count, anomaly_or_None).
+      - Missing file → 0, no anomaly.
+      - Corrupt file → quarantine, restore from .bak1/.bak2/.bak3 or reset to
+        empty default. Anomaly set.
+      - Healthy file → counts of newly registered emotions, no anomaly.
+    """
+    from brain.health.attempt_heal import attempt_heal
+
+    if not path.exists():
+        if store is not None:
+            _warn_on_referenced_but_unregistered(store)
+        return 0, None
+
+    data, anomaly = attempt_heal(
+        path, _default_vocab_factory, schema_validator=_vocab_schema_validator
+    )
+
+    if anomaly is not None:
+        logger.warning(
+            "emotion_vocabulary anomaly detected: %s action=%s file=%s",
+            anomaly.kind,
+            anomaly.action,
+            anomaly.file,
+        )
+
+    registered = _register_from_data(data)
+
+    if store is not None:
+        _warn_on_referenced_but_unregistered(store)
+
+    return registered, anomaly
 
 
 def load_persona_vocabulary(
@@ -32,7 +86,7 @@ def load_persona_vocabulary(
     this twice for the same persona returns 0 the second time.
 
     Missing `path` → returns 0 silently. Fresh personas don't need a file.
-    Corrupt JSON → returns 0, logs a warning.
+    Corrupt JSON → quarantine + heal from .bak, log a warning.
     Per-entry validation failure → that entry skipped + warning,
     other entries proceed.
 
@@ -40,26 +94,14 @@ def load_persona_vocabulary(
     for emotion names not in the registry and logs a one-time warning
     per missing name pointing the user at `nell migrate --force`.
     """
-    if not path.exists():
-        if store is not None:
-            _warn_on_referenced_but_unregistered(store)
-        return 0
+    count, _anomaly = load_persona_vocabulary_with_anomaly(path, store=store)
+    return count
 
-    try:
-        data = json.loads(path.read_text(encoding="utf-8"))
-    except json.JSONDecodeError as exc:
-        logger.warning("emotion_vocabulary at %s could not be parsed: %.200s", path, exc)
-        return 0
 
-    if not isinstance(data, dict) or not isinstance(data.get("emotions"), list):
-        logger.warning(
-            "emotion_vocabulary at %s has invalid schema (missing 'emotions' list)",
-            path,
-        )
-        return 0
-
+def _register_from_data(data: dict) -> int:
+    """Register emotions from a parsed vocab dict; return count of newly registered."""
     registered = 0
-    for entry in data["emotions"]:
+    for entry in data.get("emotions", []):
         try:
             emotion = _entry_to_emotion(entry)
         except (KeyError, ValueError, TypeError) as exc:
@@ -75,10 +117,6 @@ def load_persona_vocabulary(
 
         vocabulary.register(emotion)
         registered += 1
-
-    if store is not None:
-        _warn_on_referenced_but_unregistered(store)
-
     return registered
 
 

--- a/brain/engines/_interests.py
+++ b/brain/engines/_interests.py
@@ -9,13 +9,15 @@ from __future__ import annotations
 
 import json
 import logging
-import os
 from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
-from typing import Literal
+from typing import TYPE_CHECKING, Literal
 
 from brain.utils.time import iso_utc, parse_iso_utc
+
+if TYPE_CHECKING:
+    from brain.health.anomaly import BrainAnomaly
 
 logger = logging.getLogger(__name__)
 
@@ -105,36 +107,74 @@ class InterestSet:
     interests: tuple[Interest, ...] = field(default_factory=tuple)
 
     @classmethod
-    def load(cls, path: Path, *, default_path: Path) -> InterestSet:
-        source_path = path if path.exists() else default_path
-        if source_path != path:
-            logger.warning("interests file %s not found, using defaults", path)
+    def load_with_anomaly(
+        cls, path: Path, *, default_path: Path
+    ) -> tuple[InterestSet, BrainAnomaly | None]:
+        """Load with self-healing from .bak rotation if corrupt.
 
-        try:
-            data = json.loads(source_path.read_text(encoding="utf-8"))
-        except (json.JSONDecodeError, OSError) as exc:
-            logger.warning("interests load failed (%s), falling back to defaults", exc)
-            data = json.loads(default_path.read_text(encoding="utf-8"))
+        Returns (instance, anomaly_or_None).
+          - Missing file → load from default_path, no anomaly.
+          - Corrupt file → quarantine, restore from .bak1/.bak2/.bak3 or write
+            default; parse the result with existing per-entry coercion.
+        """
+        from brain.health.attempt_heal import attempt_heal
 
-        if not isinstance(data, dict) or not isinstance(data.get("interests"), list):
-            logger.warning("interests schema invalid at %s, falling back to defaults", source_path)
-            data = json.loads(default_path.read_text(encoding="utf-8"))
+        def _default_factory() -> dict:
+            return json.loads(default_path.read_text(encoding="utf-8"))
+
+        def _schema_validator(data: object) -> None:
+            if not isinstance(data, dict) or not isinstance(data.get("interests"), list):
+                raise ValueError("interests schema invalid: missing 'interests' list")
+
+        if not path.exists():
+            data = _default_factory()
+            anomaly = None
+        else:
+            data, anomaly = attempt_heal(path, _default_factory, schema_validator=_schema_validator)
 
         out: list[Interest] = []
-        for raw in data["interests"]:
+        for raw in data.get("interests", []):
             try:
                 out.append(Interest.from_dict(raw))
             except (KeyError, ValueError, TypeError) as exc:
                 logger.warning("interest %r failed to load: %s", raw.get("topic"), exc)
                 continue
-        return cls(interests=tuple(out))
+        return cls(interests=tuple(out)), anomaly
+
+    @classmethod
+    def load(cls, path: Path, *, default_path: Path) -> InterestSet:
+        """Load interests; on corrupt file, quarantine + heal, log WARNING."""
+        source_path = path if path.exists() else default_path
+        if source_path != path:
+            logger.warning("interests file %s not found, using defaults", path)
+            data = json.loads(default_path.read_text(encoding="utf-8"))
+            out: list[Interest] = []
+            for raw in data.get("interests", []):
+                try:
+                    out.append(Interest.from_dict(raw))
+                except (KeyError, ValueError, TypeError) as exc:
+                    logger.warning("interest %r failed to load: %s", raw.get("topic"), exc)
+                    continue
+            return cls(interests=tuple(out))
+
+        instance, anomaly = cls.load_with_anomaly(path, default_path=default_path)
+        if anomaly is not None:
+            logger.warning(
+                "InterestSet anomaly detected: %s action=%s file=%s",
+                anomaly.kind,
+                anomaly.action,
+                anomaly.file,
+            )
+        return instance
 
     def save(self, path: Path) -> None:
-        """Atomic save via .new + os.replace."""
+        """Atomic save via .bak rotation (save_with_backup)."""
+        from brain.health.adaptive import compute_treatment
+        from brain.health.attempt_heal import save_with_backup
+
         payload = {"version": 1, "interests": [i.to_dict() for i in self.interests]}
-        tmp = path.with_suffix(path.suffix + ".new")
-        tmp.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
-        os.replace(tmp, path)
+        treatment = compute_treatment(path.parent, path.name)
+        save_with_backup(path, payload, backup_count=treatment.backup_count)
 
     def find_by_topic(self, topic: str) -> Interest | None:
         lower = topic.lower()

--- a/brain/engines/heartbeat.py
+++ b/brain/engines/heartbeat.py
@@ -136,9 +136,7 @@ class HeartbeatConfig:
             return cls()
 
     @classmethod
-    def _load_internal_with_anomaly(
-        cls, path: Path
-    ) -> tuple[HeartbeatConfig, BrainAnomaly | None]:
+    def _load_internal_with_anomaly(cls, path: Path) -> tuple[HeartbeatConfig, BrainAnomaly | None]:
         """Load heartbeat_config.json with self-healing from .bak rotation.
 
         Returns (cfg, anomaly_or_None). The outer load() uses the anomaly-dropping
@@ -236,9 +234,7 @@ class HeartbeatState:
             return None
 
     @classmethod
-    def load_with_anomaly(
-        cls, path: Path
-    ) -> tuple[HeartbeatState | None, BrainAnomaly | None]:
+    def load_with_anomaly(cls, path: Path) -> tuple[HeartbeatState | None, BrainAnomaly | None]:
         """Load state with self-healing from .bak rotation if corrupt.
 
         Returns (state_or_None, anomaly_or_None).
@@ -418,7 +414,8 @@ class HeartbeatEngine:
         # are not double-counted.
         if len(tick_anomalies) >= 2:
             _walk_persona_dir = (
-                self.interests_path.parent if self.interests_path is not None
+                self.interests_path.parent
+                if self.interests_path is not None
                 else self.state_path.parent
             )
             seen: set[tuple[str, str]] = {(a.file, a.kind) for a in tick_anomalies}

--- a/brain/engines/heartbeat.py
+++ b/brain/engines/heartbeat.py
@@ -10,11 +10,14 @@ from __future__ import annotations
 
 import json
 import logging
-import os
+import shutil
 from dataclasses import dataclass, field, replace
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Literal, get_args
+from typing import TYPE_CHECKING, Literal, get_args
+
+if TYPE_CHECKING:
+    from brain.health.anomaly import BrainAnomaly
 
 from brain.bridge.provider import LLMProvider
 from brain.memory.hebbian import HebbianMatrix
@@ -86,14 +89,11 @@ class HeartbeatConfig:
         return cfg
 
     @classmethod
-    def _load_internal(cls, path: Path) -> HeartbeatConfig:
-        """Load heartbeat_config.json only — the developer-calibration layer."""
-        if not path.exists():
-            return cls()
-        try:
-            data = json.loads(path.read_text(encoding="utf-8"))
-        except json.JSONDecodeError:
-            return cls()
+    def _parse_internal_data(cls, data: object) -> HeartbeatConfig:
+        """Build instance from already-parsed JSON data (dict expected).
+
+        Applies per-field type-coercion; falls back to defaults on type errors.
+        """
         if not isinstance(data, dict):
             return cls()
 
@@ -125,12 +125,42 @@ class HeartbeatConfig:
             # crash the CLI with a traceback.
             return cls()
 
+    @classmethod
+    def _load_internal_with_anomaly(
+        cls, path: Path
+    ) -> tuple[HeartbeatConfig, BrainAnomaly | None]:
+        """Load heartbeat_config.json with self-healing from .bak rotation.
+
+        Returns (cfg, anomaly_or_None). The outer load() uses the anomaly-dropping
+        wrapper _load_internal to preserve existing call sites unchanged.
+        """
+        from brain.health.attempt_heal import attempt_heal
+
+        data, anomaly = attempt_heal(path, dict)
+        return cls._parse_internal_data(data), anomaly
+
+    @classmethod
+    def _load_internal(cls, path: Path) -> HeartbeatConfig:
+        """Load heartbeat_config.json only — the developer-calibration layer."""
+        cfg, anomaly = cls._load_internal_with_anomaly(path)
+        if anomaly is not None:
+            logger.warning(
+                "HeartbeatConfig anomaly detected: %s action=%s file=%s",
+                anomaly.kind,
+                anomaly.action,
+                anomaly.file,
+            )
+        return cfg
+
     def save(self, path: Path) -> None:
-        """Atomic save via .new + os.replace.
+        """Atomic save via .bak rotation (save_with_backup).
 
         A crash mid-write leaves either the previous valid file or the new
         valid file — never a partial write that corrupts the user's config.
         """
+        from brain.health.adaptive import compute_treatment
+        from brain.health.attempt_heal import save_with_backup
+
         payload = {
             "dream_every_hours": self.dream_every_hours,
             "decay_rate_per_tick": self.decay_rate_per_tick,
@@ -146,9 +176,24 @@ class HeartbeatConfig:
             "growth_enabled": self.growth_enabled,
             "growth_every_hours": self.growth_every_hours,
         }
-        tmp = path.with_suffix(path.suffix + ".new")
-        tmp.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
-        os.replace(tmp, path)
+        treatment = compute_treatment(path.parent, path.name)
+        save_with_backup(path, payload, backup_count=treatment.backup_count)
+        if treatment.verify_after_write:
+            self._verify_after_write(path)
+
+    def _verify_after_write(self, path: Path) -> None:
+        """Re-read the written file; if corrupt, restore from .bak1."""
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+            if not isinstance(data, dict):
+                raise ValueError("non-dict payload after write")
+        except (json.JSONDecodeError, ValueError, OSError):
+            logger.error(
+                "HeartbeatConfig verify_after_write failed for %s; restoring from .bak1", path
+            )
+            bak1 = path.with_name(path.name + ".bak1")
+            if bak1.exists():
+                shutil.copy2(bak1, path)
 
 
 @dataclass
@@ -163,6 +208,44 @@ class HeartbeatState:
     last_trigger: str
 
     @classmethod
+    def _parse_state_data(cls, data: object) -> HeartbeatState | None:
+        """Build instance from already-parsed JSON data; return None on bad shape."""
+        if not isinstance(data, dict):
+            return None
+        try:
+            return cls(
+                last_tick_at=parse_iso_utc(data["last_tick_at"]),
+                last_dream_at=parse_iso_utc(data["last_dream_at"]),
+                last_research_at=parse_iso_utc(data["last_research_at"]),
+                # Back-compat: last_growth_at absent → fall back to last_tick_at.
+                last_growth_at=parse_iso_utc(data.get("last_growth_at") or data["last_tick_at"]),
+                tick_count=int(data["tick_count"]),
+                last_trigger=str(data["last_trigger"]),
+            )
+        except (KeyError, TypeError, ValueError):
+            return None
+
+    @classmethod
+    def load_with_anomaly(
+        cls, path: Path
+    ) -> tuple[HeartbeatState | None, BrainAnomaly | None]:
+        """Load state with self-healing from .bak rotation if corrupt.
+
+        Returns (state_or_None, anomaly_or_None).
+          - Missing file → (None, None) — normal first-tick path.
+          - Corrupt file → quarantine + restore from .bak1/.bak2/.bak3 or reset.
+            If all baks are corrupt/missing, data=={} → parse returns None → engine
+            treats as first-ever tick and reinitialises (same safe recovery as before).
+        """
+        if not path.exists():
+            return None, None
+
+        from brain.health.attempt_heal import attempt_heal
+
+        data, anomaly = attempt_heal(path, dict)
+        return cls._parse_state_data(data), anomaly
+
+    @classmethod
     def load(cls, path: Path) -> HeartbeatState | None:
         """Load state; return None if the file is missing or corrupt.
 
@@ -171,20 +254,15 @@ class HeartbeatState:
         file (user-facing crashes from a malformed JSON are worse UX than
         silently reinitialising).
         """
-        if not path.exists():
-            return None
-        try:
-            data = json.loads(path.read_text(encoding="utf-8"))
-            return cls(
-                last_tick_at=parse_iso_utc(data["last_tick_at"]),
-                last_dream_at=parse_iso_utc(data["last_dream_at"]),
-                last_research_at=parse_iso_utc(data["last_research_at"]),
-                last_growth_at=parse_iso_utc(data.get("last_growth_at") or data["last_tick_at"]),
-                tick_count=int(data["tick_count"]),
-                last_trigger=str(data["last_trigger"]),
+        state, anomaly = cls.load_with_anomaly(path)
+        if anomaly is not None:
+            logger.warning(
+                "HeartbeatState anomaly detected: %s action=%s file=%s",
+                anomaly.kind,
+                anomaly.action,
+                anomaly.file,
             )
-        except (json.JSONDecodeError, KeyError, TypeError, ValueError):
-            return None
+        return state
 
     @classmethod
     def fresh(cls, trigger: str) -> HeartbeatState:
@@ -200,7 +278,10 @@ class HeartbeatState:
         )
 
     def save(self, path: Path) -> None:
-        """Atomic save via write-to-.new + os.replace."""
+        """Atomic save via .bak rotation (save_with_backup)."""
+        from brain.health.adaptive import compute_treatment
+        from brain.health.attempt_heal import save_with_backup
+
         payload = {
             "last_tick_at": iso_utc(self.last_tick_at),
             "last_dream_at": iso_utc(self.last_dream_at),
@@ -209,9 +290,24 @@ class HeartbeatState:
             "tick_count": self.tick_count,
             "last_trigger": self.last_trigger,
         }
-        tmp = path.with_suffix(path.suffix + ".new")
-        tmp.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
-        os.replace(tmp, path)  # atomic on POSIX + Windows
+        treatment = compute_treatment(path.parent, path.name)
+        save_with_backup(path, payload, backup_count=treatment.backup_count)
+        if treatment.verify_after_write:
+            self._verify_after_write(path)
+
+    def _verify_after_write(self, path: Path) -> None:
+        """Re-read the written file; if corrupt, restore from .bak1."""
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+            if not isinstance(data, dict):
+                raise ValueError("non-dict payload after write")
+        except (json.JSONDecodeError, ValueError, OSError):
+            logger.error(
+                "HeartbeatState verify_after_write failed for %s; restoring from .bak1", path
+            )
+            bak1 = path.with_name(path.name + ".bak1")
+            if bak1.exists():
+                shutil.copy2(bak1, path)
 
 
 @dataclass(frozen=True)

--- a/brain/engines/heartbeat.py
+++ b/brain/engines/heartbeat.py
@@ -14,12 +14,12 @@ import shutil
 from dataclasses import dataclass, field, replace
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import TYPE_CHECKING, Literal, get_args
-
-if TYPE_CHECKING:
-    from brain.health.anomaly import BrainAnomaly
+from typing import Literal, get_args
 
 from brain.bridge.provider import LLMProvider
+from brain.health.alarm import compute_pending_alarms
+from brain.health.anomaly import BrainAnomaly
+from brain.health.walker import walk_persona
 from brain.memory.hebbian import HebbianMatrix
 from brain.memory.store import MemoryStore
 from brain.search.base import NoopWebSearcher, WebSearcher
@@ -73,7 +73,17 @@ class HeartbeatConfig:
         `path` points at heartbeat_config.json. user_preferences.json is
         looked up next to it (`path.parent / "user_preferences.json"`).
         """
-        cfg = cls._load_internal(path)
+        cfg, _ = cls.load_with_anomaly(path)
+        return cfg
+
+    @classmethod
+    def load_with_anomaly(cls, path: Path) -> tuple[HeartbeatConfig, BrainAnomaly | None]:
+        """Load heartbeat_config.json (with self-healing), then merge user_preferences.
+
+        Returns (cfg, anomaly_or_None). The anomaly, if any, comes from the
+        internal-load stage; user_preferences merge never raises anomalies.
+        """
+        cfg, anomaly = cls._load_internal_with_anomaly(path)
 
         # Merge user_preferences.json — only override fields explicitly
         # present in the file, so a user_preferences.json that omits
@@ -86,7 +96,7 @@ class HeartbeatConfig:
         if "dream_every_hours" in explicit_keys:
             prefs = UserPreferences.load(user_prefs_path)
             cfg = replace(cfg, dream_every_hours=prefs.dream_every_hours)
-        return cfg
+        return cfg, anomaly
 
     @classmethod
     def _parse_internal_data(cls, data: object) -> HeartbeatConfig:
@@ -329,6 +339,8 @@ class HeartbeatResult:
     research_gated_reason: str | None = None
     interests_bumped: int = 0
     growth_emotions_added: int = 0
+    anomalies: tuple[BrainAnomaly, ...] = ()
+    pending_alarms_count: int = 0
 
 
 @dataclass
@@ -389,11 +401,42 @@ class HeartbeatEngine:
         a HEARTBEAT: memory, and update state atomically.
         """
         now = datetime.now(UTC)
-        config = HeartbeatConfig.load(self.config_path)
-        state = HeartbeatState.load(self.state_path)
+
+        # Collect per-tick anomalies from direct heartbeat-engine loads (config + state).
+        tick_anomalies: list[BrainAnomaly] = []
+
+        config, config_anomaly = HeartbeatConfig.load_with_anomaly(self.config_path)
+        if config_anomaly is not None:
+            tick_anomalies.append(config_anomaly)
+
+        state, state_anomaly = HeartbeatState.load_with_anomaly(self.state_path)
+        if state_anomaly is not None:
+            tick_anomalies.append(state_anomaly)
+
+        # Cross-file walk gate: >=2 anomalies triggers a full persona scan.
+        # Deduplicate by (file, kind) so files already caught in direct loads
+        # are not double-counted.
+        if len(tick_anomalies) >= 2:
+            _walk_persona_dir = (
+                self.interests_path.parent if self.interests_path is not None
+                else self.state_path.parent
+            )
+            seen: set[tuple[str, str]] = {(a.file, a.kind) for a in tick_anomalies}
+            for walk_anomaly in walk_persona(_walk_persona_dir):
+                key = (walk_anomaly.file, walk_anomaly.kind)
+                if key not in seen:
+                    tick_anomalies.append(walk_anomaly)
+                    seen.add(key)
 
         # First-ever tick: defer all work
         if state is None:
+            # Compute pending alarms even on init tick (anomalies may exist from corrupt state)
+            if self.interests_path is not None:
+                persona_dir = self.interests_path.parent
+            else:
+                persona_dir = self.state_path.parent
+            pending_alarms_count = len(compute_pending_alarms(persona_dir))
+
             if not dry_run:
                 fresh = HeartbeatState.fresh(trigger=trigger)
                 fresh.save(self.state_path)
@@ -404,6 +447,8 @@ class HeartbeatEngine:
                         "initialized": True,
                         "note": "first-ever tick, work deferred",
                         "tick_count": 0,
+                        "anomalies": [a.to_dict() for a in tick_anomalies],
+                        "pending_alarms_count": pending_alarms_count,
                     }
                 )
             return HeartbeatResult(
@@ -416,6 +461,8 @@ class HeartbeatEngine:
                 research_deferred=False,
                 heartbeat_memory_id=None,
                 initialized=True,
+                anomalies=tuple(tick_anomalies),
+                pending_alarms_count=pending_alarms_count,
             )
 
         elapsed_seconds = (now - state.last_tick_at).total_seconds()
@@ -469,6 +516,13 @@ class HeartbeatEngine:
                 elapsed_seconds, memories_decayed, edges_pruned, dream_id
             )
 
+        # Compute pending alarms (always, before writing audit log).
+        if self.interests_path is not None:
+            persona_dir = self.interests_path.parent
+        else:
+            persona_dir = self.state_path.parent
+        pending_alarms_count = len(compute_pending_alarms(persona_dir))
+
         # Update state + log
         if not dry_run:
             state.last_tick_at = now
@@ -502,6 +556,8 @@ class HeartbeatEngine:
                         "emotions_added": growth_emotions_added,
                     },
                     "tick_count": state.tick_count,
+                    "anomalies": [a.to_dict() for a in tick_anomalies],
+                    "pending_alarms_count": pending_alarms_count,
                 }
             )
 
@@ -521,6 +577,8 @@ class HeartbeatEngine:
             research_gated_reason=research_gated_reason,
             interests_bumped=interests_bumped,
             growth_emotions_added=growth_emotions_added,
+            anomalies=tuple(tick_anomalies),
+            pending_alarms_count=pending_alarms_count,
         )
 
     # --- private helpers ---

--- a/brain/engines/reflex.py
+++ b/brain/engines/reflex.py
@@ -191,26 +191,39 @@ class ReflexArcSet:
 
 @dataclass(frozen=True)
 class ReflexLog:
-    """Fire-history log for one persona."""
+    """Fire-history log for one persona.
+
+    Stored as a single JSON object ``{"version": 1, "fires": [...]}`` —
+    atomic-rewrite, not append-only JSONL.  Corruption recovery delegates
+    to ``attempt_heal`` + ``.bak`` rotation; ``save_with_backup`` keeps up
+    to three rolling backups for the adaptive-treatment layer.
+    """
 
     fires: tuple[ArcFire, ...] = field(default_factory=tuple)
 
     @classmethod
     def load(cls, path: Path) -> ReflexLog:
-        """Load the log; return empty on corrupt/missing."""
-        if not path.exists():
-            return cls()
-        try:
-            data = json.loads(path.read_text(encoding="utf-8"))
-            if not isinstance(data, dict):
-                return cls()
-            fires_raw = data.get("fires", [])
-            if not isinstance(fires_raw, list):
-                return cls()
-            fires = tuple(ArcFire.from_dict(f) for f in fires_raw if isinstance(f, dict))
-            return cls(fires=fires)
-        except (json.JSONDecodeError, KeyError, TypeError, ValueError):
-            return cls()
+        """Load the log; heal from .bak rotation if corrupt, log WARNING."""
+        from brain.health.attempt_heal import attempt_heal
+
+        def _default_factory() -> dict:
+            return {"version": 1, "fires": []}
+
+        def _schema_validator(data: object) -> None:
+            if not isinstance(data, dict) or not isinstance(data.get("fires"), list):
+                raise ValueError("reflex log schema invalid: missing 'fires' list")
+
+        data, anomaly = attempt_heal(path, _default_factory, schema_validator=_schema_validator)
+        if anomaly is not None:
+            logger.warning(
+                "ReflexLog anomaly detected: %s action=%s file=%s",
+                anomaly.kind,
+                anomaly.action,
+                anomaly.file,
+            )
+        fires_raw = data.get("fires", [])
+        fires = tuple(ArcFire.from_dict(f) for f in fires_raw if isinstance(f, dict))
+        return cls(fires=fires)
 
     def save(self, path: Path) -> None:
         """Atomic save via .bak rotation (save_with_backup)."""

--- a/brain/engines/reflex.py
+++ b/brain/engines/reflex.py
@@ -9,12 +9,12 @@ from __future__ import annotations
 
 import json
 import logging
-import os
 from collections import defaultdict
 from collections.abc import Mapping
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from brain.bridge.provider import LLMProvider
 from brain.emotion.aggregate import aggregate_state
@@ -22,6 +22,9 @@ from brain.memory.store import Memory, MemoryStore
 from brain.utils.emotion import format_emotion_summary
 from brain.utils.memory import days_since_human
 from brain.utils.time import iso_utc, parse_iso_utc
+
+if TYPE_CHECKING:
+    from brain.health.anomaly import BrainAnomaly
 
 logger = logging.getLogger(__name__)
 
@@ -132,35 +135,58 @@ class ReflexArcSet:
     arcs: tuple[ReflexArc, ...]
 
     @classmethod
-    def load(cls, path: Path, *, default_path: Path) -> ReflexArcSet:
-        """Load arcs from path, falling back to default_path on corrupt/missing.
+    def load_with_anomaly(
+        cls, path: Path, *, default_path: Path
+    ) -> tuple[ReflexArcSet, BrainAnomaly | None]:
+        """Load arcs with self-healing from .bak rotation if corrupt.
 
-        Per-arc validation failures skip that arc, log warning, keep others.
+        Returns (instance, anomaly_or_None).
+          - Missing file → load from default_path, no anomaly.
+          - Corrupt file → quarantine, restore from .bak1/.bak2/.bak3 or
+            reset to default_path content.
+          - Per-arc validation failures skip that arc, log warning, keep others.
         """
-        source_path = path if path.exists() else default_path
-        if source_path != path:
+        from brain.health.attempt_heal import attempt_heal
+
+        def _default_factory() -> dict:
+            return json.loads(default_path.read_text(encoding="utf-8"))
+
+        def _schema_validator(data: object) -> None:
+            if (
+                not isinstance(data, dict)
+                or "arcs" not in data
+                or not isinstance(data["arcs"], list)
+            ):
+                raise ValueError("reflex arcs schema invalid: missing 'arcs' list")
+
+        if not path.exists():
             logger.warning("reflex arcs file %s not found, using defaults", path)
-
-        try:
-            data = json.loads(source_path.read_text(encoding="utf-8"))
-        except (json.JSONDecodeError, OSError) as exc:
-            logger.warning("reflex arcs load failed (%s), falling back to defaults", exc)
-            data = json.loads(default_path.read_text(encoding="utf-8"))
-
-        if not isinstance(data, dict) or "arcs" not in data or not isinstance(data["arcs"], list):
-            logger.warning(
-                "reflex arcs schema invalid at %s, falling back to defaults", source_path
-            )
-            data = json.loads(default_path.read_text(encoding="utf-8"))
+            data = _default_factory()
+            anomaly = None
+        else:
+            data, anomaly = attempt_heal(path, _default_factory, schema_validator=_schema_validator)
 
         arcs: list[ReflexArc] = []
-        for raw in data["arcs"]:
+        for raw in data.get("arcs", []):
             try:
                 arcs.append(ReflexArc.from_dict(raw))
             except (KeyError, ValueError, TypeError) as exc:
                 logger.warning("reflex arc %r failed to load: %s", raw.get("name"), exc)
                 continue
-        return cls(arcs=tuple(arcs))
+        return cls(arcs=tuple(arcs)), anomaly
+
+    @classmethod
+    def load(cls, path: Path, *, default_path: Path) -> ReflexArcSet:
+        """Load arcs from path; on corrupt file, quarantine + heal, log WARNING."""
+        instance, anomaly = cls.load_with_anomaly(path, default_path=default_path)
+        if anomaly is not None:
+            logger.warning(
+                "ReflexArcSet anomaly detected: %s action=%s file=%s",
+                anomaly.kind,
+                anomaly.action,
+                anomaly.file,
+            )
+        return instance
 
 
 @dataclass(frozen=True)
@@ -187,14 +213,16 @@ class ReflexLog:
             return cls()
 
     def save(self, path: Path) -> None:
-        """Atomic save via write-to-.new + os.replace."""
+        """Atomic save via .bak rotation (save_with_backup)."""
+        from brain.health.adaptive import compute_treatment
+        from brain.health.attempt_heal import save_with_backup
+
         payload = {
             "version": 1,
             "fires": [f.to_dict() for f in self.fires],
         }
-        tmp = path.with_suffix(path.suffix + ".new")
-        tmp.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
-        os.replace(tmp, path)
+        treatment = compute_treatment(path.parent, path.name)
+        save_with_backup(path, payload, backup_count=treatment.backup_count)
 
     def last_fire_for_arc(self, arc_name: str) -> datetime | None:
         """Return the most recent fired_at for the given arc, or None."""

--- a/brain/engines/research.py
+++ b/brain/engines/research.py
@@ -6,9 +6,7 @@ This module ships the types + engine scaffold. run_tick body lands in Task 3.
 
 from __future__ import annotations
 
-import json
 import logging
-import os
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
@@ -358,32 +356,49 @@ def _create_research_memory(
 
 @dataclass(frozen=True)
 class ResearchLog:
-    """Fire-history log for one persona."""
+    """Fire-history log for one persona.
+
+    Stored as a single JSON object ``{"version": 1, "fires": [...]}`` —
+    atomic-rewrite, not append-only JSONL.  Corruption recovery delegates
+    to ``attempt_heal`` + ``.bak`` rotation; ``save_with_backup`` keeps up
+    to three rolling backups for the adaptive-treatment layer.
+    """
 
     fires: tuple[ResearchFire, ...] = ()
 
     @classmethod
     def load(cls, path: Path) -> ResearchLog:
-        if not path.exists():
-            return cls()
-        try:
-            data = json.loads(path.read_text(encoding="utf-8"))
-            if not isinstance(data, dict):
-                return cls()
-            fires_raw = data.get("fires", [])
-            if not isinstance(fires_raw, list):
-                return cls()
-            return cls(
-                fires=tuple(ResearchFire.from_dict(f) for f in fires_raw if isinstance(f, dict))
+        """Load the log; heal from .bak rotation if corrupt, log WARNING."""
+        from brain.health.attempt_heal import attempt_heal
+
+        def _default_factory() -> dict:
+            return {"version": 1, "fires": []}
+
+        def _schema_validator(data: object) -> None:
+            if not isinstance(data, dict) or not isinstance(data.get("fires"), list):
+                raise ValueError("research log schema invalid: missing 'fires' list")
+
+        data, anomaly = attempt_heal(path, _default_factory, schema_validator=_schema_validator)
+        if anomaly is not None:
+            logger.warning(
+                "ResearchLog anomaly detected: %s action=%s file=%s",
+                anomaly.kind,
+                anomaly.action,
+                anomaly.file,
             )
-        except (json.JSONDecodeError, KeyError, TypeError, ValueError):
-            return cls()
+        fires_raw = data.get("fires", [])
+        return cls(
+            fires=tuple(ResearchFire.from_dict(f) for f in fires_raw if isinstance(f, dict))
+        )
 
     def save(self, path: Path) -> None:
+        """Atomic save via .bak rotation (save_with_backup)."""
+        from brain.health.adaptive import compute_treatment
+        from brain.health.attempt_heal import save_with_backup
+
         payload = {"version": 1, "fires": [f.to_dict() for f in self.fires]}
-        tmp = path.with_suffix(path.suffix + ".new")
-        tmp.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
-        os.replace(tmp, path)
+        treatment = compute_treatment(path.parent, path.name)
+        save_with_backup(path, payload, backup_count=treatment.backup_count)
 
     def appended(self, fire: ResearchFire) -> ResearchLog:
         return ResearchLog(fires=self.fires + (fire,))

--- a/brain/engines/research.py
+++ b/brain/engines/research.py
@@ -387,9 +387,7 @@ class ResearchLog:
                 anomaly.file,
             )
         fires_raw = data.get("fires", [])
-        return cls(
-            fires=tuple(ResearchFire.from_dict(f) for f in fires_raw if isinstance(f, dict))
-        )
+        return cls(fires=tuple(ResearchFire.from_dict(f) for f in fires_raw if isinstance(f, dict)))
 
     def save(self, path: Path) -> None:
         """Atomic save via .bak rotation (save_with_backup)."""

--- a/brain/growth/log.py
+++ b/brain/growth/log.py
@@ -20,6 +20,7 @@ from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
 
+from brain.health.jsonl_reader import read_jsonl_skipping_corrupt
 from brain.utils.time import iso_utc, parse_iso_utc
 
 logger = logging.getLogger(__name__)
@@ -62,29 +63,15 @@ def append_growth_event(path: Path, event: GrowthLogEvent) -> None:
 def read_growth_log(path: Path, *, limit: int | None = None) -> list[GrowthLogEvent]:
     """Read events oldest-first. `limit=N` returns the N most-recent events.
 
-    Corrupt lines (partial write, hand-edit) are skipped with a warning;
-    well-formed lines around them still parse.
+    Corrupt lines (partial write, hand-edit) are skipped with a warning via
+    `read_jsonl_skipping_corrupt`; well-formed lines around them still parse.
     """
-    if not path.exists():
-        return []
     events: list[GrowthLogEvent] = []
-    for line_index, raw in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
-        if not raw.strip():
-            continue
+    for data in read_jsonl_skipping_corrupt(path):
         try:
-            data = json.loads(raw)
             events.append(_event_from_dict(data))
-        except (json.JSONDecodeError, KeyError, TypeError, ValueError) as exc:
-            # Include line number + truncated content so a forensic grep can
-            # find and fix (or quarantine) the bad line. The exception alone
-            # doesn't tell you WHERE in the log the corruption is.
-            logger.warning(
-                "skipping malformed growth log line %d in %s: %.200s | content: %r",
-                line_index,
-                path,
-                exc,
-                raw[:200],
-            )
+        except (KeyError, TypeError, ValueError) as exc:
+            logger.warning("skipping growth log entry with schema error in %s: %s", path, exc)
             continue
     if limit is not None:
         events = events[-limit:]

--- a/brain/growth/scheduler.py
+++ b/brain/growth/scheduler.py
@@ -13,7 +13,6 @@ from __future__ import annotations
 
 import json
 import logging
-import os
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
@@ -114,32 +113,36 @@ def _read_current_vocabulary_names(vocab_path: Path) -> set[str]:
 
     Distinguishes three load outcomes:
       - Missing file → return empty set silently (fresh persona; expected).
-      - Corrupt JSON or wrong schema → return empty set BUT log a WARNING
-        with the file path. A silent fallback would mask the corruption,
-        and the scheduler would then think "no emotions exist" and might
-        re-add framework baselines on the next growth tick.
+      - Corrupt JSON or wrong schema → quarantine + heal from .bak or reset to
+        default; return names from the recovered data. Logs a WARNING so the
+        anomaly is visible.
       - Well-formed → return the set of names.
     """
     if not vocab_path.exists():
         return set()
-    try:
-        data = json.loads(vocab_path.read_text(encoding="utf-8"))
-    except json.JSONDecodeError as exc:
+
+    from brain.health.attempt_heal import attempt_heal
+
+    def _schema_validator(data: object) -> None:
+        if not isinstance(data, dict) or not isinstance(data.get("emotions"), list):
+            raise ValueError("emotion_vocabulary schema invalid: missing 'emotions' list")
+
+    data, anomaly = attempt_heal(
+        vocab_path,
+        lambda: {"version": 1, "emotions": []},
+        schema_validator=_schema_validator,
+    )
+
+    if anomaly is not None:
         logger.warning(
-            "growth scheduler: emotion_vocabulary at %s is corrupt JSON (%.200s); "
-            "treating as empty for this tick — fix or quarantine the file",
+            "growth scheduler: emotion_vocabulary at %s anomaly %s (action=%s); "
+            "proceeding with recovered data",
             vocab_path,
-            exc,
+            anomaly.kind,
+            anomaly.action,
         )
-        return set()
-    if not isinstance(data, dict) or not isinstance(data.get("emotions"), list):
-        logger.warning(
-            "growth scheduler: emotion_vocabulary at %s has invalid schema "
-            "(missing 'emotions' list); treating as empty for this tick",
-            vocab_path,
-        )
-        return set()
-    return {e["name"] for e in data["emotions"] if isinstance(e, dict) and "name" in e}
+
+    return {e["name"] for e in data.get("emotions", []) if isinstance(e, dict) and "name" in e}
 
 
 def _is_valid_name(name: str) -> bool:
@@ -149,7 +152,10 @@ def _is_valid_name(name: str) -> bool:
 
 
 def _append_to_vocabulary(vocab_path: Path, proposal: EmotionProposal) -> None:
-    """Atomic append to emotion_vocabulary.json — read, append entry, write `.new`, rename."""
+    """Atomic append to emotion_vocabulary.json via save_with_backup."""
+    from brain.health.adaptive import compute_treatment
+    from brain.health.attempt_heal import save_with_backup
+
     if vocab_path.exists():
         data = json.loads(vocab_path.read_text(encoding="utf-8"))
     else:
@@ -163,9 +169,8 @@ def _append_to_vocabulary(vocab_path: Path, proposal: EmotionProposal) -> None:
             "intensity_clamp": 10.0,
         }
     )
-    tmp = vocab_path.with_suffix(vocab_path.suffix + ".new")
-    tmp.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
-    os.replace(tmp, vocab_path)
+    treatment = compute_treatment(vocab_path.parent, vocab_path.name)
+    save_with_backup(vocab_path, data, backup_count=treatment.backup_count)
 
 
 def _default_reason_for(proposal: EmotionProposal) -> str:

--- a/brain/health/attempt_heal.py
+++ b/brain/health/attempt_heal.py
@@ -81,7 +81,9 @@ def _heal_from_baks(
             data = _load_and_validate(bak, schema_validator)
         except (json.JSONDecodeError, ValueError, TypeError):
             # This bak is also corrupt — quarantine it too.
-            bak_quarantine = path.with_name(f"{path.name}.bak{bak_index}.corrupt-{_filename_safe_timestamp(now)}")
+            bak_quarantine = path.with_name(
+                f"{path.name}.bak{bak_index}.corrupt-{_filename_safe_timestamp(now)}"
+            )
             os.replace(bak, bak_quarantine)
             continue
 

--- a/brain/persona_config.py
+++ b/brain/persona_config.py
@@ -14,12 +14,23 @@ See `docs/superpowers/audits/2026-04-25-principle-alignment-audit.md`
 from __future__ import annotations
 
 import json
-import os
+import logging
+import shutil
 from dataclasses import dataclass
 from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from brain.health.anomaly import BrainAnomaly
 
 DEFAULT_PROVIDER = "claude-cli"
 DEFAULT_SEARCHER = "ddgs"
+
+logger = logging.getLogger(__name__)
+
+
+def _default_persona_config_dict() -> dict:
+    return {"provider": DEFAULT_PROVIDER, "searcher": DEFAULT_SEARCHER}
 
 
 @dataclass
@@ -36,16 +47,10 @@ class PersonaConfig:
     searcher: str = DEFAULT_SEARCHER
 
     @classmethod
-    def load(cls, path: Path) -> PersonaConfig:
-        if not path.exists():
-            return cls()
-        try:
-            data = json.loads(path.read_text(encoding="utf-8"))
-        except json.JSONDecodeError:
-            return cls()
+    def _parse_data(cls, data: object) -> PersonaConfig:
+        """Build instance from already-parsed JSON data (dict expected)."""
         if not isinstance(data, dict):
             return cls()
-
         provider_raw = data.get("provider", DEFAULT_PROVIDER)
         searcher_raw = data.get("searcher", DEFAULT_SEARCHER)
         provider = (
@@ -56,9 +61,51 @@ class PersonaConfig:
         )
         return cls(provider=provider, searcher=searcher)
 
+    @classmethod
+    def load_with_anomaly(cls, path: Path) -> tuple[PersonaConfig, BrainAnomaly | None]:
+        """Load with self-healing from .bak rotation if corrupt.
+
+        Returns (instance, anomaly_or_None). Missing file → defaults, no anomaly.
+        Corrupt file → quarantine + restore from .bak1/.bak2/.bak3 or reset.
+        """
+        from brain.health.attempt_heal import attempt_heal
+
+        data, anomaly = attempt_heal(path, _default_persona_config_dict)
+        return cls._parse_data(data), anomaly
+
+    @classmethod
+    def load(cls, path: Path) -> PersonaConfig:
+        instance, anomaly = cls.load_with_anomaly(path)
+        if anomaly is not None:
+            logger.warning(
+                "PersonaConfig anomaly detected: %s action=%s file=%s",
+                anomaly.kind,
+                anomaly.action,
+                anomaly.file,
+            )
+        return instance
+
     def save(self, path: Path) -> None:
-        """Atomic save via .new + os.replace — same pattern as HeartbeatConfig."""
+        """Atomic save via .bak rotation (save_with_backup)."""
+        from brain.health.adaptive import compute_treatment
+        from brain.health.attempt_heal import save_with_backup
+
         payload = {"provider": self.provider, "searcher": self.searcher}
-        tmp = path.with_suffix(path.suffix + ".new")
-        tmp.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
-        os.replace(tmp, path)
+        treatment = compute_treatment(path.parent, path.name)
+        save_with_backup(path, payload, backup_count=treatment.backup_count)
+        if treatment.verify_after_write:
+            self._verify_after_write(path)
+
+    def _verify_after_write(self, path: Path) -> None:
+        """Re-read the written file; if corrupt, restore from .bak1."""
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+            if not isinstance(data, dict):
+                raise ValueError("non-dict payload after write")
+        except (json.JSONDecodeError, ValueError, OSError):
+            logger.error(
+                "PersonaConfig verify_after_write failed for %s; restoring from .bak1", path
+            )
+            bak1 = path.with_name(path.name + ".bak1")
+            if bak1.exists():
+                shutil.copy2(bak1, path)

--- a/brain/user_preferences.py
+++ b/brain/user_preferences.py
@@ -19,11 +19,22 @@ cadence field, user_preferences.json wins — the GUI is authoritative.
 from __future__ import annotations
 
 import json
-import os
+import logging
+import shutil
 from dataclasses import dataclass
 from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from brain.health.anomaly import BrainAnomaly
 
 DEFAULT_DREAM_EVERY_HOURS = 24.0
+
+logger = logging.getLogger(__name__)
+
+
+def _default_user_preferences_dict() -> dict:
+    return {"dream_every_hours": DEFAULT_DREAM_EVERY_HOURS}
 
 
 @dataclass
@@ -37,13 +48,8 @@ class UserPreferences:
     dream_every_hours: float = DEFAULT_DREAM_EVERY_HOURS
 
     @classmethod
-    def load(cls, path: Path) -> UserPreferences:
-        if not path.exists():
-            return cls()
-        try:
-            data = json.loads(path.read_text(encoding="utf-8"))
-        except json.JSONDecodeError:
-            return cls()
+    def _parse_data(cls, data: object) -> UserPreferences:
+        """Build instance from already-parsed JSON data (dict expected)."""
         if not isinstance(data, dict):
             return cls()
         try:
@@ -53,12 +59,54 @@ class UserPreferences:
         except (TypeError, ValueError):
             return cls()
 
+    @classmethod
+    def load_with_anomaly(cls, path: Path) -> tuple[UserPreferences, BrainAnomaly | None]:
+        """Load with self-healing from .bak rotation if corrupt.
+
+        Returns (instance, anomaly_or_None). Missing file → defaults, no anomaly.
+        Corrupt file → quarantine + restore from .bak1/.bak2/.bak3 or reset.
+        """
+        from brain.health.attempt_heal import attempt_heal
+
+        data, anomaly = attempt_heal(path, _default_user_preferences_dict)
+        return cls._parse_data(data), anomaly
+
+    @classmethod
+    def load(cls, path: Path) -> UserPreferences:
+        instance, anomaly = cls.load_with_anomaly(path)
+        if anomaly is not None:
+            logger.warning(
+                "UserPreferences anomaly detected: %s action=%s file=%s",
+                anomaly.kind,
+                anomaly.action,
+                anomaly.file,
+            )
+        return instance
+
     def save(self, path: Path) -> None:
-        """Atomic save via .new + os.replace."""
+        """Atomic save via .bak rotation (save_with_backup)."""
+        from brain.health.adaptive import compute_treatment
+        from brain.health.attempt_heal import save_with_backup
+
         payload = {"dream_every_hours": self.dream_every_hours}
-        tmp = path.with_suffix(path.suffix + ".new")
-        tmp.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
-        os.replace(tmp, path)
+        treatment = compute_treatment(path.parent, path.name)
+        save_with_backup(path, payload, backup_count=treatment.backup_count)
+        if treatment.verify_after_write:
+            self._verify_after_write(path)
+
+    def _verify_after_write(self, path: Path) -> None:
+        """Re-read the written file; if corrupt, restore from .bak1."""
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+            if not isinstance(data, dict):
+                raise ValueError("non-dict payload after write")
+        except (json.JSONDecodeError, ValueError, OSError):
+            logger.error(
+                "UserPreferences verify_after_write failed for %s; restoring from .bak1", path
+            )
+            bak1 = path.with_name(path.name + ".bak1")
+            if bak1.exists():
+                shutil.copy2(bak1, path)
 
 
 def read_raw_keys(path: Path) -> set[str]:

--- a/tests/unit/brain/emotion/test_persona_loader.py
+++ b/tests/unit/brain/emotion/test_persona_loader.py
@@ -7,7 +7,10 @@ import logging
 from pathlib import Path
 
 from brain.emotion import vocabulary
-from brain.emotion.persona_loader import load_persona_vocabulary
+from brain.emotion.persona_loader import (
+    load_persona_vocabulary,
+    load_persona_vocabulary_with_anomaly,
+)
 from brain.memory.store import Memory, MemoryStore
 
 
@@ -128,6 +131,55 @@ def test_load_per_entry_failure_skips_only_bad_entry(tmp_path: Path, caplog):
         assert any("test_bad_entry" in r.message for r in caplog.records)
     finally:
         _cleanup_emotion("test_good_entry")
+
+
+# ---- Health T10: attempt_heal wiring ----
+
+
+def test_load_persona_vocabulary_corrupt_quarantines_restores_from_bak(tmp_path: Path):
+    """Corrupt live vocab + valid .bak1 → restore .bak1, register its emotion, anomaly set."""
+    path = tmp_path / "emotion_vocabulary.json"
+    bak1 = tmp_path / "emotion_vocabulary.json.bak1"
+
+    good_vocab = {
+        "version": 1,
+        "emotions": [
+            {
+                "name": "test_heal_bak_a",
+                "description": "restored",
+                "category": "persona_extension",
+                "decay_half_life_days": 5.0,
+                "intensity_clamp": 10.0,
+            }
+        ],
+    }
+    bak1.write_text(json.dumps(good_vocab), encoding="utf-8")
+    path.write_text("{corrupt{{", encoding="utf-8")
+
+    try:
+        count, anomaly = load_persona_vocabulary_with_anomaly(path)
+        assert anomaly is not None
+        assert "bak1" in anomaly.action
+        assert count == 1
+        assert vocabulary.get("test_heal_bak_a") is not None
+        corrupt_files = list(tmp_path.glob("emotion_vocabulary.json.corrupt-*"))
+        assert len(corrupt_files) == 1
+    finally:
+        _cleanup_emotion("test_heal_bak_a")
+
+
+def test_load_persona_vocabulary_corrupt_no_bak_resets_to_default(tmp_path: Path):
+    """Corrupt vocab + no .bak → empty default written, count=0, anomaly with reset_to_default."""
+    path = tmp_path / "emotion_vocabulary.json"
+    path.write_text("{corrupt{{", encoding="utf-8")
+
+    count, anomaly = load_persona_vocabulary_with_anomaly(path)
+
+    assert anomaly is not None
+    assert anomaly.action == "reset_to_default"
+    assert count == 0
+    # Default file written back to disk
+    assert path.exists()
 
 
 def test_load_with_store_warns_on_missing_emotion(tmp_path: Path, caplog):

--- a/tests/unit/brain/engines/test_cli_heartbeat.py
+++ b/tests/unit/brain/engines/test_cli_heartbeat.py
@@ -153,3 +153,105 @@ def test_nell_heartbeat_verbose_shows_all_gated_reasons(
     assert "dream gated:" in out
     # Verbose mode shows interests bumped: 0
     assert "interests bumped: 0" in out
+
+
+# ---- Task 12: compact CLI health output ----
+
+
+def test_compact_cli_clean_tick_no_health_output(
+    nell_persona: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """No 🩹, no banner, no health output on clean tick."""
+    from brain.cli import main
+
+    main(["heartbeat", "--persona", "nell", "--trigger", "open", "--provider", "fake"])  # init
+    main(["heartbeat", "--persona", "nell", "--trigger", "close", "--provider", "fake"])
+    out = capsys.readouterr().out
+
+    assert "🩹" not in out
+    assert "Brain alarm" not in out
+    assert "nell health" not in out
+    assert "self-treated" not in out
+
+
+def test_compact_cli_self_treated_emits_bandage_line(
+    nell_persona: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """🩹 line appears when result.anomalies non-empty + no pending alarms."""
+    from datetime import UTC, datetime
+    from unittest.mock import patch
+
+    from brain.cli import main
+    from brain.engines.heartbeat import HeartbeatResult
+    from brain.health.anomaly import BrainAnomaly
+
+    anomaly = BrainAnomaly(
+        timestamp=datetime.now(UTC),
+        file="heartbeat_config.json",
+        kind="json_parse_error",
+        action="reset_to_default",
+        quarantine_path=None,
+        likely_cause="unknown",
+        detail="test",
+    )
+
+    def fake_run_tick(self, *, trigger="manual", dry_run=False):
+        return HeartbeatResult(
+            trigger=trigger,
+            elapsed_seconds=3600.0,
+            memories_decayed=0,
+            edges_pruned=0,
+            dream_id=None,
+            dream_gated_reason="not_due",
+            research_deferred=True,
+            heartbeat_memory_id=None,
+            initialized=False,
+            anomalies=(anomaly,),
+            pending_alarms_count=0,
+        )
+
+    with patch("brain.engines.heartbeat.HeartbeatEngine.run_tick", fake_run_tick):
+        rc = main(["heartbeat", "--persona", "nell", "--trigger", "close", "--provider", "fake"])
+    assert rc == 0
+
+    out = capsys.readouterr().out
+    assert "🩹" in out
+    assert "self-treated" in out
+    assert "Brain alarm" not in out
+
+
+def test_compact_cli_alarm_emits_banner_above_engine_status(
+    nell_persona: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Banner appears at top of output; persists until acknowledged."""
+    from unittest.mock import patch
+
+    from brain.cli import main
+    from brain.engines.heartbeat import HeartbeatResult
+
+    def fake_run_tick(self, *, trigger="manual", dry_run=False):
+        return HeartbeatResult(
+            trigger=trigger,
+            elapsed_seconds=3600.0,
+            memories_decayed=0,
+            edges_pruned=0,
+            dream_id=None,
+            dream_gated_reason="not_due",
+            research_deferred=True,
+            heartbeat_memory_id=None,
+            initialized=False,
+            anomalies=(),
+            pending_alarms_count=2,
+        )
+
+    with patch("brain.engines.heartbeat.HeartbeatEngine.run_tick", fake_run_tick):
+        rc = main(["heartbeat", "--persona", "nell", "--trigger", "close", "--provider", "fake"])
+    assert rc == 0
+
+    out = capsys.readouterr().out
+    assert "Brain alarm" in out
+    assert "nell health show" in out
+    # Banner must appear BEFORE the "Heartbeat tick complete" line
+    banner_pos = out.index("Brain alarm")
+    tick_pos = out.index("Heartbeat tick complete")
+    assert banner_pos < tick_pos

--- a/tests/unit/brain/engines/test_heartbeat.py
+++ b/tests/unit/brain/engines/test_heartbeat.py
@@ -1591,3 +1591,156 @@ def test_heartbeat_state_load_corrupt_file_restores_from_bak(tmp_path: Path) -> 
     assert state.last_trigger == "open"
     assert anomaly is not None
     assert "bak1" in anomaly.action
+
+
+# ---- Task 12: anomaly aggregation in heartbeat tick ----
+
+
+def test_heartbeat_audit_log_anomalies_field_always_present(live_engine: HeartbeatEngine) -> None:
+    """Every audit entry has 'anomalies' key (empty list on clean tick)."""
+    _seed_conversation(live_engine.store, "seed")
+    live_engine.run_tick(trigger="open")  # init tick
+    live_engine.run_tick(trigger="close")  # real tick
+
+    lines = live_engine.heartbeat_log_path.read_text().strip().splitlines()
+    for line in lines:
+        entry = json.loads(line)
+        assert "anomalies" in entry, f"Missing 'anomalies' key in audit entry: {entry}"
+        assert isinstance(entry["anomalies"], list)
+    # Clean tick: anomalies should be empty
+    tick_entry = json.loads(lines[-1])
+    assert tick_entry["anomalies"] == []
+    assert "pending_alarms_count" in tick_entry
+    assert tick_entry["pending_alarms_count"] == 0
+
+
+def test_heartbeat_corrupt_state_file_self_heals_and_records(tmp_path: Path) -> None:
+    """Corrupting heartbeat_state.json triggers heal + anomaly entry in audit log + result."""
+    store = MemoryStore(":memory:")
+    hebbian = HebbianMatrix(":memory:")
+    try:
+        engine = HeartbeatEngine(
+            store=store,
+            hebbian=hebbian,
+            provider=FakeProvider(),
+            state_path=tmp_path / "heartbeat_state.json",
+            config_path=tmp_path / "heartbeat_config.json",
+            dream_log_path=tmp_path / "dreams.log.jsonl",
+            heartbeat_log_path=tmp_path / "heartbeats.log.jsonl",
+            persona_name="Nell",
+            persona_system_prompt="You are Nell.",
+        )
+        # Corrupt the state file — will trigger load_with_anomaly to return an anomaly
+        state_path = tmp_path / "heartbeat_state.json"
+        # Write a valid state first so the file exists
+        HeartbeatState.fresh("manual").save(state_path)
+        # Now corrupt it
+        state_path.write_text("{corrupt json{{{", encoding="utf-8")
+
+        result = engine.run_tick(trigger="manual")
+        # Corrupt state → engine treats as first-tick (initialized=True)
+        # and should record the anomaly
+        assert result.initialized is True
+        # The anomaly should be in the result
+        assert len(result.anomalies) >= 1
+        anomaly_kinds = [a.kind for a in result.anomalies]
+        assert "json_parse_error" in anomaly_kinds
+
+        # Audit log entry also has the anomaly
+        log_lines = engine.heartbeat_log_path.read_text().strip().splitlines()
+        entry = json.loads(log_lines[-1])
+        assert "anomalies" in entry
+        assert len(entry["anomalies"]) >= 1
+        assert entry["anomalies"][0]["kind"] == "json_parse_error"
+    finally:
+        store.close()
+        hebbian.close()
+
+
+def test_heartbeat_multi_anomaly_tick_triggers_walk(tmp_path: Path) -> None:
+    """>=2 anomalies trigger cross-file walk; merged into audit entry."""
+    persona_dir = tmp_path / "persona"
+    persona_dir.mkdir()
+
+    store = MemoryStore(":memory:")
+    hebbian = HebbianMatrix(":memory:")
+    try:
+        engine = HeartbeatEngine(
+            store=store,
+            hebbian=hebbian,
+            provider=FakeProvider(),
+            state_path=persona_dir / "heartbeat_state.json",
+            config_path=persona_dir / "heartbeat_config.json",
+            dream_log_path=persona_dir / "dreams.log.jsonl",
+            heartbeat_log_path=persona_dir / "heartbeats.log.jsonl",
+            persona_name="Nell",
+            persona_system_prompt="You are Nell.",
+        )
+        # Corrupt BOTH config and state to generate 2 anomalies
+        (persona_dir / "heartbeat_config.json").write_text("{bad json{", encoding="utf-8")
+        (persona_dir / "heartbeat_state.json").write_text("{bad state{", encoding="utf-8")
+
+        from unittest.mock import patch
+
+        walk_calls = []
+
+        def fake_walk(d: Path) -> list:
+            walk_calls.append(d)
+            return []
+
+        with patch("brain.engines.heartbeat.walk_persona", side_effect=fake_walk):
+            result = engine.run_tick(trigger="manual")
+
+        # walk_persona must have been called because we had >=2 anomalies
+        assert len(walk_calls) >= 1
+        # Result should have >=2 anomalies
+        assert len(result.anomalies) >= 2
+    finally:
+        store.close()
+        hebbian.close()
+
+
+def test_heartbeat_alarm_increments_pending_alarms_count(tmp_path: Path) -> None:
+    """An identity-file reset_to_default → pending_alarms_count >= 1."""
+    from datetime import UTC, datetime
+    from unittest.mock import patch
+
+    from brain.health.anomaly import AlarmEntry
+
+    persona_dir = tmp_path / "persona"
+    persona_dir.mkdir()
+
+    store = MemoryStore(":memory:")
+    hebbian = HebbianMatrix(":memory:")
+    try:
+        engine = HeartbeatEngine(
+            store=store,
+            hebbian=hebbian,
+            provider=FakeProvider(),
+            state_path=persona_dir / "heartbeat_state.json",
+            config_path=persona_dir / "heartbeat_config.json",
+            dream_log_path=persona_dir / "dreams.log.jsonl",
+            heartbeat_log_path=persona_dir / "heartbeats.log.jsonl",
+            persona_name="Nell",
+            persona_system_prompt="You are Nell.",
+        )
+
+        # Patch compute_pending_alarms to return one alarm (simulates an
+        # identity-file reset_to_default becoming a pending alarm entry).
+        alarm = AlarmEntry(
+            file="emotion_vocabulary.json",
+            kind="json_parse_error",
+            first_seen_at=datetime.now(UTC),
+            occurrences_in_window=1,
+        )
+        with patch("brain.engines.heartbeat.compute_pending_alarms", return_value=[alarm]):
+            result = engine.run_tick(trigger="manual")
+
+        assert result.pending_alarms_count >= 1
+        # Audit log also has pending_alarms_count >= 1
+        log_lines = engine.heartbeat_log_path.read_text().strip().splitlines()
+        entry = json.loads(log_lines[-1])
+        assert entry["pending_alarms_count"] >= 1
+    finally:
+        store.close()
+        hebbian.close()

--- a/tests/unit/brain/engines/test_heartbeat.py
+++ b/tests/unit/brain/engines/test_heartbeat.py
@@ -1518,3 +1518,76 @@ def test_heartbeat_growth_fault_isolated(tmp_path: Path) -> None:
     finally:
         store.close()
         hebbian.close()
+
+
+# ---- Task 9: attempt_heal wiring for HeartbeatConfig + HeartbeatState ----
+
+
+def test_heartbeat_config_load_corrupt_file_quarantines_and_resets(tmp_path: Path) -> None:
+    """Corrupt heartbeat_config.json → defaults returned + quarantine file present."""
+    path = tmp_path / "heartbeat_config.json"
+    path.write_text("{corrupt json{{", encoding="utf-8")
+
+    cfg, anomaly = HeartbeatConfig._load_internal_with_anomaly(path)
+
+    assert cfg.dream_every_hours == 24.0
+    assert cfg.emit_memory == "conditional"
+    assert anomaly is not None
+    assert anomaly.kind == "json_parse_error"
+    corrupt_files = list(tmp_path.glob("heartbeat_config.json.corrupt-*"))
+    assert len(corrupt_files) == 1
+
+
+def test_heartbeat_config_load_corrupt_file_restores_from_bak(tmp_path: Path) -> None:
+    """Valid .bak1 + corrupt live heartbeat_config.json → .bak1 content returned."""
+    path = tmp_path / "heartbeat_config.json"
+    bak1 = tmp_path / "heartbeat_config.json.bak1"
+    bak1.write_text(
+        json.dumps({"dream_every_hours": 6.0, "emit_memory": "always"}), encoding="utf-8"
+    )
+    path.write_text("{corrupt", encoding="utf-8")
+
+    cfg, anomaly = HeartbeatConfig._load_internal_with_anomaly(path)
+
+    assert cfg.dream_every_hours == 6.0
+    assert cfg.emit_memory == "always"
+    assert anomaly is not None
+    assert "bak1" in anomaly.action
+
+
+def test_heartbeat_state_load_corrupt_file_quarantines_and_resets(tmp_path: Path) -> None:
+    """Corrupt heartbeat_state.json → None returned + quarantine file present."""
+    path = tmp_path / "heartbeat_state.json"
+    path.write_text("{corrupt json{{", encoding="utf-8")
+
+    state, anomaly = HeartbeatState.load_with_anomaly(path)
+
+    assert state is None
+    assert anomaly is not None
+    assert anomaly.kind == "json_parse_error"
+    corrupt_files = list(tmp_path.glob("heartbeat_state.json.corrupt-*"))
+    assert len(corrupt_files) == 1
+
+
+def test_heartbeat_state_load_corrupt_file_restores_from_bak(tmp_path: Path) -> None:
+    """Valid .bak1 + corrupt live heartbeat_state.json → .bak1 content returned."""
+    path = tmp_path / "heartbeat_state.json"
+    bak1 = tmp_path / "heartbeat_state.json.bak1"
+    valid_state = {
+        "last_tick_at": "2026-04-25T10:00:00Z",
+        "last_dream_at": "2026-04-25T10:00:00Z",
+        "last_research_at": "2026-04-25T10:00:00Z",
+        "last_growth_at": "2026-04-25T10:00:00Z",
+        "tick_count": 3,
+        "last_trigger": "open",
+    }
+    bak1.write_text(json.dumps(valid_state), encoding="utf-8")
+    path.write_text("{corrupt", encoding="utf-8")
+
+    state, anomaly = HeartbeatState.load_with_anomaly(path)
+
+    assert state is not None
+    assert state.tick_count == 3
+    assert state.last_trigger == "open"
+    assert anomaly is not None
+    assert "bak1" in anomaly.action

--- a/tests/unit/brain/engines/test_interests.py
+++ b/tests/unit/brain/engines/test_interests.py
@@ -79,9 +79,7 @@ def test_interestset_load_corrupt_quarantines_restores_from_bak(tmp_path: Path):
     bak1 = tmp_path / "interests.json.bak1"
 
     # .bak1 has a valid interest
-    bak1.write_text(
-        json.dumps({"version": 1, "interests": [_sample_dict()]}), encoding="utf-8"
-    )
+    bak1.write_text(json.dumps({"version": 1, "interests": [_sample_dict()]}), encoding="utf-8")
     path.write_text("{corrupt json{{", encoding="utf-8")
 
     result, anomaly = InterestSet.load_with_anomaly(path, default_path=DEFAULT_INTERESTS_PATH)

--- a/tests/unit/brain/engines/test_interests.py
+++ b/tests/unit/brain/engines/test_interests.py
@@ -70,6 +70,43 @@ def test_interestset_load_missing_falls_back_to_defaults(tmp_path: Path):
     assert loaded.interests == ()  # default is empty
 
 
+# ---- Health T10: attempt_heal wiring ----
+
+
+def test_interestset_load_corrupt_quarantines_restores_from_bak(tmp_path: Path):
+    """Corrupt live file + valid .bak1 → restore .bak1, return its data, anomaly set."""
+    path = tmp_path / "interests.json"
+    bak1 = tmp_path / "interests.json.bak1"
+
+    # .bak1 has a valid interest
+    bak1.write_text(
+        json.dumps({"version": 1, "interests": [_sample_dict()]}), encoding="utf-8"
+    )
+    path.write_text("{corrupt json{{", encoding="utf-8")
+
+    result, anomaly = InterestSet.load_with_anomaly(path, default_path=DEFAULT_INTERESTS_PATH)
+
+    assert anomaly is not None
+    assert "bak1" in anomaly.action
+    assert len(result.interests) == 1
+    assert result.interests[0].topic == "Test topic"
+    # original quarantined
+    corrupt_files = list(tmp_path.glob("interests.json.corrupt-*"))
+    assert len(corrupt_files) == 1
+
+
+def test_interestset_load_corrupt_no_bak_resets_to_default(tmp_path: Path):
+    """Corrupt live file + no .bak → reset to default (empty), anomaly with reset_to_default."""
+    path = tmp_path / "interests.json"
+    path.write_text("{corrupt json{{", encoding="utf-8")
+
+    result, anomaly = InterestSet.load_with_anomaly(path, default_path=DEFAULT_INTERESTS_PATH)
+
+    assert anomaly is not None
+    assert anomaly.action == "reset_to_default"
+    assert result.interests == ()
+
+
 def test_interestset_load_corrupt_falls_back(tmp_path: Path):
     bad = tmp_path / "interests.json"
     bad.write_text("not valid{", encoding="utf-8")

--- a/tests/unit/brain/engines/test_reflex.py
+++ b/tests/unit/brain/engines/test_reflex.py
@@ -140,9 +140,7 @@ def test_reflex_arc_set_load_corrupt_quarantines_restores_from_bak(tmp_path: Pat
     path = tmp_path / "reflex_arcs.json"
     bak1 = tmp_path / "reflex_arcs.json.bak1"
 
-    bak1.write_text(
-        json.dumps({"version": 1, "arcs": [_valid_arc_dict()]}), encoding="utf-8"
-    )
+    bak1.write_text(json.dumps({"version": 1, "arcs": [_valid_arc_dict()]}), encoding="utf-8")
     path.write_text("{corrupt{{", encoding="utf-8")
 
     result, anomaly = ReflexArcSet.load_with_anomaly(path, default_path=DEFAULT_ARCS_PATH)

--- a/tests/unit/brain/engines/test_reflex.py
+++ b/tests/unit/brain/engines/test_reflex.py
@@ -132,6 +132,58 @@ def test_reflex_arc_set_load_bad_arc_skipped_good_kept(tmp_path: Path):
     assert "broken" not in names
 
 
+# ---- Health T10: attempt_heal wiring ----
+
+
+def test_reflex_arc_set_load_corrupt_quarantines_restores_from_bak(tmp_path: Path):
+    """Corrupt live arcs file + valid .bak1 → restore .bak1, return its arcs, anomaly set."""
+    path = tmp_path / "reflex_arcs.json"
+    bak1 = tmp_path / "reflex_arcs.json.bak1"
+
+    bak1.write_text(
+        json.dumps({"version": 1, "arcs": [_valid_arc_dict()]}), encoding="utf-8"
+    )
+    path.write_text("{corrupt{{", encoding="utf-8")
+
+    result, anomaly = ReflexArcSet.load_with_anomaly(path, default_path=DEFAULT_ARCS_PATH)
+
+    assert anomaly is not None
+    assert "bak1" in anomaly.action
+    assert len(result.arcs) == 1
+    assert result.arcs[0].name == "test_arc"
+    corrupt_files = list(tmp_path.glob("reflex_arcs.json.corrupt-*"))
+    assert len(corrupt_files) == 1
+
+
+def test_reflex_arc_set_load_corrupt_no_bak_uses_defaults(tmp_path: Path):
+    """Corrupt arcs file + no .bak → falls back to default_path arcs, anomaly with reset_to_default."""
+    path = tmp_path / "reflex_arcs.json"
+    path.write_text("{corrupt{{", encoding="utf-8")
+
+    result, anomaly = ReflexArcSet.load_with_anomaly(path, default_path=DEFAULT_ARCS_PATH)
+
+    assert anomaly is not None
+    assert anomaly.action == "reset_to_default"
+    # default_path arcs loaded (4 OG arcs)
+    assert len(result.arcs) == 4
+
+
+def test_reflex_log_save_with_backup_creates_bak(tmp_path: Path):
+    """save() via save_with_backup creates .bak1 on second write."""
+    path = tmp_path / "reflex_log.json"
+    fire = ArcFire(
+        arc_name="test_arc",
+        fired_at=datetime.now(UTC),
+        trigger_state={"love": 6.0},
+        output_memory_id="mem-1",
+    )
+    log = ReflexLog(fires=(fire,))
+    log.save(path)
+    log.save(path)  # second write should rotate the first into .bak1
+    bak1 = tmp_path / "reflex_log.json.bak1"
+    assert bak1.exists()
+
+
 # ---- ReflexLog ----
 
 

--- a/tests/unit/brain/engines/test_reflex.py
+++ b/tests/unit/brain/engines/test_reflex.py
@@ -199,6 +199,43 @@ def test_reflex_log_load_corrupt_returns_empty(tmp_path: Path):
     assert log.fires == ()
 
 
+def test_reflex_log_load_corrupt_quarantines_and_warns(tmp_path: Path, caplog) -> None:
+    """Corrupt file is quarantined and WARNING is emitted (attempt_heal path)."""
+    import logging
+
+    caplog.set_level(logging.WARNING)
+    path = tmp_path / "log.json"
+    path.write_text("{{{not json", encoding="utf-8")
+    log = ReflexLog.load(path)
+    assert log.fires == ()
+    # Quarantine file should have been created
+    corrupt_files = list(tmp_path.glob("log.json.corrupt-*"))
+    assert len(corrupt_files) == 1
+    # Warning logged
+    warn_msgs = [r.getMessage() for r in caplog.records if "ReflexLog anomaly" in r.getMessage()]
+    assert len(warn_msgs) == 1
+
+
+def test_reflex_log_load_heals_from_bak(tmp_path: Path) -> None:
+    """When primary file is corrupt, load restores from .bak1."""
+    fire = ArcFire(
+        arc_name="restored_arc",
+        fired_at=datetime.now(UTC),
+        trigger_state={},
+        output_memory_id=None,
+    )
+    good_payload = {"version": 1, "fires": [fire.to_dict()]}
+    path = tmp_path / "log.json"
+    bak1 = tmp_path / "log.json.bak1"
+    import json
+
+    bak1.write_text(json.dumps(good_payload), encoding="utf-8")
+    path.write_text("{{{not json", encoding="utf-8")  # corrupt primary
+    log = ReflexLog.load(path)
+    assert len(log.fires) == 1
+    assert log.fires[0].arc_name == "restored_arc"
+
+
 def test_reflex_log_save_atomic(tmp_path: Path):
     path = tmp_path / "log.json"
     fire = ArcFire(

--- a/tests/unit/brain/engines/test_research.py
+++ b/tests/unit/brain/engines/test_research.py
@@ -309,3 +309,64 @@ def test_run_tick_renders_prompt_with_context(tmp_path: Path):
 
     assert "marine bioluminescence" in captured["prompt"]
     assert "Nell" in (captured["system"] or "")
+
+
+# ---- ResearchLog unit tests ----
+
+
+def test_research_log_load_missing_returns_empty(tmp_path: Path) -> None:
+    from brain.engines.research import ResearchLog
+
+    log = ResearchLog.load(tmp_path / "nope.json")
+    assert log.fires == ()
+
+
+def test_research_log_load_corrupt_returns_empty(tmp_path: Path) -> None:
+    """Corrupt file is healed to empty via attempt_heal; fires == ()."""
+    from brain.engines.research import ResearchLog
+
+    path = tmp_path / "research_log.json"
+    path.write_text("{{{not json", encoding="utf-8")
+    log = ResearchLog.load(path)
+    assert log.fires == ()
+
+
+def test_research_log_load_corrupt_quarantines_and_warns(tmp_path: Path, caplog) -> None:
+    """Corrupt primary is quarantined and a WARNING is emitted."""
+    import logging
+
+    from brain.engines.research import ResearchLog
+
+    caplog.set_level(logging.WARNING)
+    path = tmp_path / "research_log.json"
+    path.write_text("{{{not json", encoding="utf-8")
+    ResearchLog.load(path)
+    corrupt_files = list(tmp_path.glob("research_log.json.corrupt-*"))
+    assert len(corrupt_files) == 1
+    warn_msgs = [
+        r.getMessage() for r in caplog.records if "ResearchLog anomaly" in r.getMessage()
+    ]
+    assert len(warn_msgs) == 1
+
+
+def test_research_log_load_heals_from_bak(tmp_path: Path) -> None:
+    """When primary is corrupt, load restores the most recent valid .bak."""
+    from brain.engines.research import ResearchFire, ResearchLog
+
+    fire = ResearchFire(
+        interest_id="i1",
+        topic="marine bioluminescence",
+        fired_at=datetime.now(UTC),
+        trigger="days_since_human",
+        web_used=False,
+        web_result_count=0,
+        output_memory_id="mem-1",
+    )
+    good_payload = {"version": 1, "fires": [fire.to_dict()]}
+    path = tmp_path / "research_log.json"
+    bak1 = tmp_path / "research_log.json.bak1"
+    bak1.write_text(json.dumps(good_payload), encoding="utf-8")
+    path.write_text("{{{not json", encoding="utf-8")
+    log = ResearchLog.load(path)
+    assert len(log.fires) == 1
+    assert log.fires[0].topic == "marine bioluminescence"

--- a/tests/unit/brain/engines/test_research.py
+++ b/tests/unit/brain/engines/test_research.py
@@ -343,9 +343,7 @@ def test_research_log_load_corrupt_quarantines_and_warns(tmp_path: Path, caplog)
     ResearchLog.load(path)
     corrupt_files = list(tmp_path.glob("research_log.json.corrupt-*"))
     assert len(corrupt_files) == 1
-    warn_msgs = [
-        r.getMessage() for r in caplog.records if "ResearchLog anomaly" in r.getMessage()
-    ]
+    warn_msgs = [r.getMessage() for r in caplog.records if "ResearchLog anomaly" in r.getMessage()]
     assert len(warn_msgs) == 1
 
 

--- a/tests/unit/brain/growth/test_log.py
+++ b/tests/unit/brain/growth/test_log.py
@@ -126,7 +126,8 @@ def test_read_growth_log_skips_corrupt_lines(tmp_path: Path, caplog) -> None:
 
     # Hardening: warning includes line number + content preview so a forensic
     # grep of the logs can find and quarantine the bad line.
-    bad_warnings = [r for r in caplog.records if "malformed growth log line" in r.message]
+    # The warning is emitted by read_jsonl_skipping_corrupt (shared helper).
+    bad_warnings = [r for r in caplog.records if "malformed jsonl line" in r.message]
     assert len(bad_warnings) == 1
     msg = bad_warnings[0].getMessage()
     assert "line 2" in msg  # corrupt line is the 2nd line in the file

--- a/tests/unit/brain/growth/test_scheduler.py
+++ b/tests/unit/brain/growth/test_scheduler.py
@@ -250,7 +250,8 @@ def test_read_current_vocabulary_names_corrupt_quarantines_restores_bak(
     vocab_path = persona_dir / "emotion_vocabulary.json"
     bak1 = persona_dir / "emotion_vocabulary.json.bak1"
     bak1.write_text(
-        json.dumps({"version": 1, "emotions": [{"name": "joy"}, {"name": "love"}]}), encoding="utf-8"
+        json.dumps({"version": 1, "emotions": [{"name": "joy"}, {"name": "love"}]}),
+        encoding="utf-8",
     )
     vocab_path.write_text("{corrupt{{", encoding="utf-8")
 

--- a/tests/unit/brain/growth/test_scheduler.py
+++ b/tests/unit/brain/growth/test_scheduler.py
@@ -10,7 +10,7 @@ from unittest.mock import patch
 import pytest
 
 from brain.growth.proposal import EmotionProposal
-from brain.growth.scheduler import GrowthTickResult, run_growth_tick
+from brain.growth.scheduler import GrowthTickResult, _read_current_vocabulary_names, run_growth_tick
 from brain.memory.store import MemoryStore
 
 
@@ -187,11 +187,10 @@ def test_run_growth_tick_corrupt_vocabulary_logs_warning(
 ) -> None:
     """A corrupt emotion_vocabulary.json is detected and surfaces a WARNING.
 
-    Prior to hardening, the JSONDecodeError was silently swallowed, so a
-    corrupt vocab file looked indistinguishable from "no emotions yet" to
-    the scheduler. The scheduler still proceeds (returns empty set + tick
-    continues) but the warning gives the user / forensic-grep a thread to
-    pull on rather than silent degradation.
+    Post-T10 the scheduler routes through attempt_heal, which quarantines the
+    corrupt file and resets to default. The scheduler still completes (returns
+    empty set) but the anomaly surfaces a WARNING so the user / forensic-grep
+    has a thread to pull on rather than silent degradation.
     """
     import logging
 
@@ -205,10 +204,13 @@ def test_run_growth_tick_corrupt_vocabulary_logs_warning(
     # Tick still completes (no proposals from stub anyway).
     assert result.emotions_added == 0
 
-    # Warning surfaces both the path and the corruption.
-    corrupt_warnings = [r for r in caplog.records if "corrupt JSON" in r.getMessage()]
-    assert len(corrupt_warnings) == 1
-    assert "emotion_vocabulary.json" in corrupt_warnings[0].getMessage()
+    # Warning surfaces the anomaly — message contains "anomaly" and the filename.
+    anomaly_warnings = [
+        r
+        for r in caplog.records
+        if "anomaly" in r.getMessage() and "emotion_vocabulary.json" in r.getMessage()
+    ]
+    assert len(anomaly_warnings) == 1
 
 
 def test_run_growth_tick_invalid_vocabulary_schema_logs_warning(
@@ -226,8 +228,58 @@ def test_run_growth_tick_invalid_vocabulary_schema_logs_warning(
     result = run_growth_tick(persona_dir, store, datetime.now(UTC))
     assert result.emotions_added == 0
 
-    schema_warnings = [r for r in caplog.records if "invalid schema" in r.getMessage()]
+    # Post-T10: schema mismatch goes through attempt_heal; warning message
+    # contains "anomaly" and identifies the file.
+    schema_warnings = [
+        r
+        for r in caplog.records
+        if "anomaly" in r.getMessage() and "emotion_vocabulary.json" in r.getMessage()
+    ]
     assert len(schema_warnings) == 1
+
+
+# ---- Health T10: attempt_heal wiring ----
+
+
+def test_read_current_vocabulary_names_corrupt_quarantines_restores_bak(
+    persona_dir: Path, caplog
+) -> None:
+    """Corrupt vocab + valid .bak1 → names from .bak1 returned + quarantine created."""
+    import logging
+
+    vocab_path = persona_dir / "emotion_vocabulary.json"
+    bak1 = persona_dir / "emotion_vocabulary.json.bak1"
+    bak1.write_text(
+        json.dumps({"version": 1, "emotions": [{"name": "joy"}, {"name": "love"}]}), encoding="utf-8"
+    )
+    vocab_path.write_text("{corrupt{{", encoding="utf-8")
+
+    with caplog.at_level(logging.WARNING):
+        names = _read_current_vocabulary_names(vocab_path)
+
+    # Names restored from .bak1
+    assert "joy" in names
+    assert "love" in names
+    # Original quarantined
+    corrupt_files = list(persona_dir.glob("emotion_vocabulary.json.corrupt-*"))
+    assert len(corrupt_files) == 1
+
+
+def test_read_current_vocabulary_names_corrupt_no_bak_resets_to_default(
+    persona_dir: Path, caplog
+) -> None:
+    """Corrupt vocab + no .bak → empty set returned + warning logged."""
+    import logging
+
+    vocab_path = persona_dir / "emotion_vocabulary.json"
+    vocab_path.write_text("{corrupt{{", encoding="utf-8")
+
+    with caplog.at_level(logging.WARNING):
+        names = _read_current_vocabulary_names(vocab_path)
+
+    assert names == set()
+    # Some warning surfaced (either from attempt_heal or existing path)
+    assert any(r.levelno >= logging.WARNING for r in caplog.records)
 
 
 def test_run_growth_tick_missing_vocabulary_no_warning(

--- a/tests/unit/brain/health/test_cli_health.py
+++ b/tests/unit/brain/health/test_cli_health.py
@@ -1,0 +1,179 @@
+# tests/unit/brain/health/test_cli_health.py
+"""Tests for `nell health show/check/acknowledge` CLI subcommands — Task 13."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from brain.cli import main
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _setup_persona(personas_root: Path, name: str = "testpersona") -> Path:
+    persona_dir = personas_root / name
+    persona_dir.mkdir(parents=True)
+    from brain.memory.hebbian import HebbianMatrix
+    from brain.memory.store import MemoryStore
+
+    MemoryStore(db_path=persona_dir / "memories.db").close()
+    HebbianMatrix(db_path=persona_dir / "hebbian.db").close()
+    return persona_dir
+
+
+def _write_audit_log(persona_dir: Path, entries: list[dict]) -> None:
+    p = persona_dir / "heartbeats.log.jsonl"
+    p.write_text("\n".join(json.dumps(e) for e in entries) + "\n", encoding="utf-8")
+
+
+def _anomaly_entry(
+    file: str,
+    when: datetime,
+    action: str = "restored_from_bak1",
+    kind: str = "json_parse_error",
+    quarantine_path: str | None = None,
+    likely_cause: str = "unknown",
+) -> dict:
+    return {
+        "timestamp": when.isoformat().replace("+00:00", "Z"),
+        "anomalies": [
+            {
+                "timestamp": when.isoformat().replace("+00:00", "Z"),
+                "file": file,
+                "kind": kind,
+                "action": action,
+                "quarantine_path": quarantine_path,
+                "likely_cause": likely_cause,
+                "detail": "",
+            }
+        ],
+    }
+
+
+# ---------------------------------------------------------------------------
+# nell health show
+# ---------------------------------------------------------------------------
+
+
+def test_cli_health_show_clean(monkeypatch, tmp_path: Path, capsys):
+    """Healthy persona → 'Pending alarms: 0' + 'Recent self-treatments: 0'."""
+    monkeypatch.setenv("NELLBRAIN_HOME", str(tmp_path))
+    _setup_persona(tmp_path / "personas")
+
+    rc = main(["health", "show", "--persona", "testpersona"])
+
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "Pending alarms: 0" in out
+    assert "Recent self-treatments" in out
+    assert "0" in out
+
+
+def test_cli_health_show_with_treatment_history(monkeypatch, tmp_path: Path, capsys):
+    """Recent self-treatments listed; alarms section present (count 0)."""
+    monkeypatch.setenv("NELLBRAIN_HOME", str(tmp_path))
+    persona_dir = _setup_persona(tmp_path / "personas")
+
+    # Seed a self-treatment (restored_from_bak1 — healed, not an alarm)
+    when = datetime.now(UTC) - timedelta(hours=2)
+    _write_audit_log(persona_dir, [_anomaly_entry("user_preferences.json", when)])
+
+    rc = main(["health", "show", "--persona", "testpersona"])
+
+    assert rc == 0
+    out = capsys.readouterr().out
+    # The treatment was healed, so should appear in recent treatments
+    assert "Recent self-treatments" in out
+    assert "user_preferences.json" in out
+    # Not an alarm (restored_from_bak1 on a non-identity file)
+    assert "Pending alarms: 0" in out
+
+
+# ---------------------------------------------------------------------------
+# nell health check
+# ---------------------------------------------------------------------------
+
+
+def test_cli_health_check_clean_persona(monkeypatch, tmp_path: Path, capsys):
+    """All ✅ for a clean persona; exit 0."""
+    monkeypatch.setenv("NELLBRAIN_HOME", str(tmp_path))
+    _setup_persona(tmp_path / "personas")
+
+    rc = main(["health", "check", "--persona", "testpersona"])
+
+    assert rc == 0
+    out = capsys.readouterr().out
+    # No anomalies → summary says healthy
+    assert "healthy" in out.lower() or "0 file(s)" in out or "healed" in out
+
+
+def test_cli_health_check_corrupt_file_self_heals(monkeypatch, tmp_path: Path, capsys):
+    """Corrupt file shows ⚠️; exit 0 (self-treated, not alarming)."""
+    monkeypatch.setenv("NELLBRAIN_HOME", str(tmp_path))
+    persona_dir = _setup_persona(tmp_path / "personas")
+
+    # Corrupt a healable file (non-identity, so healed not alarmed)
+    (persona_dir / "user_preferences.json").write_text("{not json", encoding="utf-8")
+
+    rc = main(["health", "check", "--persona", "testpersona"])
+
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "⚠️" in out or "WARNING" in out or "user_preferences.json" in out
+
+
+def test_cli_health_check_unhealable_returns_exit_2(monkeypatch, tmp_path: Path):
+    """SQLite corruption → ❌ + exit 2."""
+    monkeypatch.setenv("NELLBRAIN_HOME", str(tmp_path))
+    persona_dir = _setup_persona(tmp_path / "personas")
+
+    # Corrupt the memories.db to force sqlite_integrity_fail
+    (persona_dir / "memories.db").write_bytes(b"not sqlite data at all")
+
+    rc = main(["health", "check", "--persona", "testpersona"])
+
+    assert rc == 2
+
+
+# ---------------------------------------------------------------------------
+# nell health acknowledge
+# ---------------------------------------------------------------------------
+
+
+def test_cli_health_acknowledge_all_clears_alarms(monkeypatch, tmp_path: Path):
+    """After acknowledge --all, compute_pending_alarms returns []."""
+    monkeypatch.setenv("NELLBRAIN_HOME", str(tmp_path))
+    persona_dir = _setup_persona(tmp_path / "personas")
+
+    # Seed an alarm-level anomaly (reset_to_default on an identity file)
+    when = datetime.now(UTC) - timedelta(hours=1)
+    _write_audit_log(
+        persona_dir,
+        [_anomaly_entry("emotion_vocabulary.json", when, action="reset_to_default")],
+    )
+
+    # Verify alarm exists before acknowledge
+    from brain.health.alarm import compute_pending_alarms
+
+    assert len(compute_pending_alarms(persona_dir)) == 1
+
+    rc = main(["health", "acknowledge", "--persona", "testpersona", "--all"])
+    assert rc == 0
+
+    # Alarm is now cleared
+    assert compute_pending_alarms(persona_dir) == []
+
+
+def test_cli_health_no_destructive_actions(monkeypatch, tmp_path: Path):
+    """`nell health restore`, `nell health add`, `nell health delete` raise SystemExit."""
+    monkeypatch.setenv("NELLBRAIN_HOME", str(tmp_path))
+
+    for forbidden in ("restore", "add", "delete"):
+        with pytest.raises(SystemExit):
+            main(["health", forbidden, "--persona", "testpersona"])

--- a/tests/unit/brain/test_persona_config.py
+++ b/tests/unit/brain/test_persona_config.py
@@ -6,6 +6,40 @@ from pathlib import Path
 
 from brain.persona_config import DEFAULT_PROVIDER, DEFAULT_SEARCHER, PersonaConfig
 
+# ---- Task 9: attempt_heal wiring ----
+
+
+def test_persona_config_load_corrupt_file_quarantines_and_resets(tmp_path: Path) -> None:
+    """Corrupt JSON → defaults returned + quarantine file present, original gone."""
+    path = tmp_path / "persona_config.json"
+    path.write_text("{this is not json", encoding="utf-8")
+
+    cfg, anomaly = PersonaConfig.load_with_anomaly(path)
+
+    assert cfg.provider == DEFAULT_PROVIDER
+    assert cfg.searcher == DEFAULT_SEARCHER
+    assert anomaly is not None
+    assert anomaly.kind == "json_parse_error"
+    # Original replaced by a quarantine file
+    assert not path.exists() or path.read_text().strip().startswith("{")  # reset default written
+    corrupt_files = list(tmp_path.glob("persona_config.json.corrupt-*"))
+    assert len(corrupt_files) == 1
+
+
+def test_persona_config_load_corrupt_file_restores_from_bak(tmp_path: Path) -> None:
+    """A valid .bak1 + corrupt live file → .bak1 content returned."""
+    path = tmp_path / "persona_config.json"
+    bak1 = tmp_path / "persona_config.json.bak1"
+    bak1.write_text('{"provider": "ollama", "searcher": "noop"}\n', encoding="utf-8")
+    path.write_text("{corrupt", encoding="utf-8")
+
+    cfg, anomaly = PersonaConfig.load_with_anomaly(path)
+
+    assert cfg.provider == "ollama"
+    assert cfg.searcher == "noop"
+    assert anomaly is not None
+    assert "bak1" in anomaly.action
+
 
 def test_load_missing_file_returns_defaults(tmp_path: Path) -> None:
     """No persona_config.json → defaults."""

--- a/tests/unit/brain/test_user_preferences.py
+++ b/tests/unit/brain/test_user_preferences.py
@@ -10,6 +10,36 @@ from brain.user_preferences import (
     read_raw_keys,
 )
 
+# ---- Task 9: attempt_heal wiring ----
+
+
+def test_user_preferences_load_corrupt_file_quarantines_and_resets(tmp_path: Path) -> None:
+    """Corrupt JSON → defaults returned + quarantine file present."""
+    path = tmp_path / "user_preferences.json"
+    path.write_text("{not json at all", encoding="utf-8")
+
+    prefs, anomaly = UserPreferences.load_with_anomaly(path)
+
+    assert prefs.dream_every_hours == DEFAULT_DREAM_EVERY_HOURS
+    assert anomaly is not None
+    assert anomaly.kind == "json_parse_error"
+    corrupt_files = list(tmp_path.glob("user_preferences.json.corrupt-*"))
+    assert len(corrupt_files) == 1
+
+
+def test_user_preferences_load_corrupt_file_restores_from_bak(tmp_path: Path) -> None:
+    """Valid .bak1 + corrupt live file → .bak1 content returned."""
+    path = tmp_path / "user_preferences.json"
+    bak1 = tmp_path / "user_preferences.json.bak1"
+    bak1.write_text('{"dream_every_hours": 8.0}\n', encoding="utf-8")
+    path.write_text("{corrupt", encoding="utf-8")
+
+    prefs, anomaly = UserPreferences.load_with_anomaly(path)
+
+    assert prefs.dream_every_hours == 8.0
+    assert anomaly is not None
+    assert "bak1" in anomaly.action
+
 
 def test_load_missing_file_returns_defaults(tmp_path: Path) -> None:
     prefs = UserPreferences.load(tmp_path / "nope.json")


### PR DESCRIPTION
## Summary

Implements **PR-2 (Tasks 9-14)** of the brain-health module. PR-1 (#18) shipped the `brain/health/` package internals. This PR wires those helpers into every load/save path in the framework so the brain auto-heals corruption silently as part of normal operation, surfaces anomalies through the heartbeat audit log + compact CLI, and adds `nell health show / check / acknowledge` for inspection.

- **Spec:** [docs/superpowers/specs/2026-04-25-brain-health-module-design.md](docs/superpowers/specs/2026-04-25-brain-health-module-design.md)
- **Plan:** [docs/superpowers/plans/2026-04-25-brain-health-module-plan.md](docs/superpowers/plans/2026-04-25-brain-health-module-plan.md)

After this lands, the brain auto-heals when files corrupt, adapts backup depth on recurring failures, surfaces anomalies in the audit log + compact CLI banner, and runs proactive walks via `nell health check`.

## What landed

**T9 — Wired into config + state files** (4 modules)
- `PersonaConfig`, `UserPreferences`, `HeartbeatConfig._load_internal`, `HeartbeatState`
- Each gains `*_with_anomaly` variant; legacy `load` is a thin wrapper that drops the anomaly
- `save` uses `save_with_backup(path, payload, backup_count=compute_treatment(...))`
- Verify-after-write activates when treatment.verify_after_write is True
- `HeartbeatConfig.load` preserves PR-C user_preferences.json merge; `HeartbeatState.load` preserves first-tick-defer + last_growth_at back-compat

**T10 — Wired into identity files**
- `InterestSet`, `ReflexArcSet`, `load_persona_vocabulary`, growth scheduler vocabulary writes
- New `ReflexArcSet` class added (refactored from inline arc-loading code)

**T11 — Generalized log readers**
- `read_jsonl_skipping_corrupt` shared helper (from PR-1) replaces inline per-line skip in growth log
- `research_log.json` + `reflex_log.json` clarified as single-JSON-object atomic-rewrite (use `attempt_heal`/`save_with_backup`, not the JSONL helper)
- `heartbeats.log.jsonl` already wired in PR-1's adaptive + alarm modules

**T12 — Heartbeat tick anomaly aggregation**
- `HeartbeatResult` gains `anomalies: tuple[BrainAnomaly, ...]` + `pending_alarms_count: int`
- `run_tick` collects anomalies from config + state loads, runs cross-file `walk_persona` if `len(anomalies) >= 2` (deduped by `(file, kind)`), computes `pending_alarms_count` via `compute_pending_alarms`
- Audit log payload always carries `anomalies` (empty list when clean) + `pending_alarms_count`
- Compact CLI: `🩹` line on self-treated tick, persistent banner at top when alarms pending

**T13 — `nell health` CLI** (3 read-only/append-only subcommands)
- `nell health show --persona X` — pending alarms + recent self-treatments (last 7 days)
- `nell health check --persona X` — proactive walk; ✅/⚠️/❌ per file; exit 2 on unhealable alarms
- `nell health acknowledge --persona X [--file <name>] [--all]` — appends `user_acknowledged` entry to audit log
- No `restore`/`add`/`delete` subcommands (manual recovery via `cp <quarantine> <path>` is the deliberate user action)

**T14 — Acceptance**
- 615 tests passing (was 578 after PR-1 merge; +37 new across T9-T13)
- ruff check + format check clean
- Zero `import anthropic` in `brain/health/`
- Sandbox smoke against `nell.sandbox`: clean tick silent (no 🩹, no banner); manual corruption of `heartbeat_state.json` → tick completes, 🩹 line appears, `nell health show` records `restored_from_bak1` (cause: user_edit), forensic copy preserved with Windows-safe dashes in timestamp

## Self-heal flow proven on live persona

```
=== before === { "last_tick_at": "2026-04-25T23:35:14.087914Z", ... tick_count: 5 }

=== corrupt heartbeat_state.json (echo "{not json" > ...) ===

=== run tick ===
Heartbeat tick complete (manual).
  elapsed: 7.72h
  decayed: 878 memories, pruned 0 edges
  reflex fired: body_grief_whisper
  🩹 brain self-treated 1 file (heartbeat_state.json) — see `nell health show` for details

=== nell health show ===
Health for persona 'nell.sandbox':
  Pending alarms: 0
  Recent self-treatments (last 7 days): 1
    2026-04-25T23:35:44.083262Z  heartbeat_state.json  restored_from_bak1  (cause: user_edit)
             forensic: heartbeat_state.json.corrupt-2026-04-25T23-35-44.083262Z
```

## Acceptance criteria (spec §8 — all 15 met)

- [x] `brain/health/` package shipped (PR-1)
- [x] Every atomic-rewrite load uses `attempt_heal`
- [x] Every atomic-rewrite save uses `save_with_backup`
- [x] Every append-only log reader uses `read_jsonl_skipping_corrupt`
- [x] `MemoryStore` + `HebbianMatrix` run `PRAGMA integrity_check` (PR-1)
- [x] Heartbeat tick aggregates anomalies + audit log carries them + `pending_alarms_count` computed
- [x] Cross-file walk fires automatically when `len(anomalies) >= 2`
- [x] `nell health show / check / acknowledge` work
- [x] `reconstruct_vocabulary_from_memories` reconstructs against real memories.db (PR-1; T12 didn't yet wire it into the heartbeat reset path — captured as follow-up)
- [x] Adaptive backup-depth + verify-after-write activate after 3 corruptions in 7 days
- [x] Compact heartbeat CLI shows three states (silent / 🩹 / banner)
- [x] `uv run pytest -q` green; lint + format clean
- [x] `rg 'import anthropic' brain/health/` zero
- [x] Sandbox smoke proven (above)

## Follow-ups (future PR, captured in plan §9)

1. **Reconstruction wiring at heartbeat layer.** `reconstruct_vocabulary_from_memories` exists (PR-1) but isn't yet auto-invoked when an `emotion_vocabulary.json` `reset_to_default` anomaly fires during a heartbeat tick. T12 stayed out of scope on this; a small follow-up wires it.
2. **Soul module health.** When the soul module lands as a Phase 2a-extension, its heal strategy needs design.
3. **Growth scheduler internal anomalies.** Anomalies from `_read_current_vocabulary_names` inside `run_growth_tick` aren't surfaced to the heartbeat anomaly collector. Threading a collector through `run_growth_tick`'s API would surface them but is more invasive than this PR's scope.