### PR TITLE
SP-1: Provider interface rework — chat(messages) alongside generate()

### DIFF
--- a/brain/bridge/chat.py
+++ b/brain/bridge/chat.py
@@ -1,0 +1,152 @@
+"""Structured message types for multi-turn LLM chat.
+
+These frozen dataclasses are the lingua franca between providers and callers.
+They are provider-agnostic — OllamaProvider, ClaudeCliProvider, and future
+providers all produce / consume these same types.
+
+ChatMessage   — one turn in a conversation (user / assistant / system / tool)
+ToolCall      — a function invocation requested by the assistant
+ChatResponse  — full provider response including optional tool-calls
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+ChatRole = Literal["system", "user", "assistant", "tool"]
+
+
+@dataclass(frozen=True)
+class ChatMessage:
+    """One turn in a multi-turn conversation.
+
+    Attributes
+    ----------
+    role:
+        Speaker: "system", "user", "assistant", or "tool".
+    content:
+        Text body of the message.
+    tool_call_id:
+        For role="tool" responses — the id of the ToolCall this answers.
+        Must be None for all other roles.
+    tool_calls:
+        For role="assistant" turns that requested tool invocations.
+        Empty tuple for all other roles.
+    """
+
+    role: ChatRole
+    content: str
+    tool_call_id: str | None = None
+    tool_calls: tuple[ToolCall, ...] = field(default_factory=tuple)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialise for provider transport.
+
+        Omits optional fields that are empty/None so the payload stays clean.
+        Converts the tool_calls tuple to a list of plain dicts for JSON
+        serialisation.
+        """
+        d: dict[str, Any] = {"role": self.role, "content": self.content}
+        if self.tool_call_id is not None:
+            d["tool_call_id"] = self.tool_call_id
+        if self.tool_calls:
+            d["tool_calls"] = [tc.to_dict() for tc in self.tool_calls]
+        return d
+
+
+@dataclass(frozen=True)
+class ToolCall:
+    """A function invocation requested by the assistant.
+
+    Attributes
+    ----------
+    id:
+        Provider-assigned unique id for this specific call.
+    name:
+        The tool/function name (must match the schema registered with the provider).
+    arguments:
+        Parsed argument dict.  Providers return either pre-parsed dicts or
+        JSON strings — from_provider_dict handles both.
+    """
+
+    id: str
+    name: str
+    arguments: dict[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        """Round-trip back to provider wire format."""
+        return {
+            "id": self.id,
+            "function": {
+                "name": self.name,
+                "arguments": self.arguments,
+            },
+        }
+
+    @classmethod
+    def from_provider_dict(cls, d: dict[str, Any]) -> ToolCall:
+        """Parse a provider-native tool-call dict.
+
+        Handles both OpenAI/Ollama shape:
+            {"id": "...", "function": {"name": "...", "arguments": "{...}" or {...}}}
+
+        The ``arguments`` field may arrive as a pre-parsed dict (Claude) or as
+        a JSON-encoded string (Ollama sometimes, older OpenAI shapes).
+
+        Raises
+        ------
+        ValueError
+            If the dict is missing required keys or arguments is not parseable.
+        """
+        try:
+            call_id: str = d["id"]
+            func = d["function"]
+            name: str = func["name"]
+            raw_args = func["arguments"]
+        except (KeyError, TypeError) as exc:
+            raise ValueError(
+                f"ToolCall.from_provider_dict: missing required fields in {d!r}"
+            ) from exc
+
+        if isinstance(raw_args, dict):
+            arguments = raw_args
+        elif isinstance(raw_args, str):
+            try:
+                arguments = json.loads(raw_args)
+            except json.JSONDecodeError as exc:
+                raise ValueError(
+                    f"ToolCall.from_provider_dict: cannot parse arguments JSON: {raw_args!r}"
+                ) from exc
+            if not isinstance(arguments, dict):
+                raise ValueError(
+                    f"ToolCall.from_provider_dict: arguments must decode to a dict, got {type(arguments).__name__}"
+                )
+        else:
+            raise ValueError(
+                f"ToolCall.from_provider_dict: arguments must be dict or str, got {type(raw_args).__name__}"
+            )
+
+        return cls(id=call_id, name=name, arguments=arguments)
+
+
+@dataclass(frozen=True)
+class ChatResponse:
+    """Full response from a multi-turn chat call.
+
+    Attributes
+    ----------
+    content:
+        Text reply from the assistant.  Empty string if the assistant only
+        produced tool-calls and no prose.
+    tool_calls:
+        Tool invocations the assistant wants to make (empty tuple if none).
+    raw:
+        Provider-native payload for debugging / logging.  None if the provider
+        does not expose raw data (e.g. FakeProvider).
+    """
+
+    content: str
+    tool_calls: tuple[ToolCall, ...] = field(default_factory=tuple)
+    raw: dict[str, Any] | None = None

--- a/brain/bridge/provider.py
+++ b/brain/bridge/provider.py
@@ -1,4 +1,18 @@
-"""LLM provider abstraction — ABC + concrete providers + factory."""
+"""LLM provider abstraction — ABC + concrete providers + factory.
+
+Two call shapes coexist here:
+
+  generate(prompt, *, system) -> str
+      Simple single-turn text generation.  All existing engines (dream,
+      heartbeat, reflex, research, growth) use this surface.  Do not change it.
+
+  chat(messages, *, tools, options) -> ChatResponse
+      Multi-turn structured chat with optional tool-calling.  Used by the
+      chat engine, brain-tools, and the bridge daemon (SP-3, SP-4, SP-6, SP-7).
+
+Both shapes live on LLMProvider so callers can swap providers without caring
+which shape they need.
+"""
 
 from __future__ import annotations
 
@@ -6,20 +20,91 @@ import hashlib
 import json
 import subprocess
 from abc import ABC, abstractmethod
+from typing import Any
+
+import httpx
+
+from brain.bridge.chat import ChatMessage, ChatResponse, ToolCall
 
 _DEFAULT_TIMEOUT_SECONDS = 300
 
 
+# ---------------------------------------------------------------------------
+# Exceptions
+# ---------------------------------------------------------------------------
+
+
+class ProviderError(RuntimeError):
+    """Raised when a provider call fails with structured context.
+
+    Attributes
+    ----------
+    stage:
+        Short machine-readable tag identifying where the failure occurred
+        (e.g. "ollama_http", "ollama_parse", "claude_cli_timeout").
+    detail:
+        Human-readable explanation with whatever context is available.
+    """
+
+    def __init__(self, stage: str, detail: str) -> None:
+        super().__init__(f"[{stage}] {detail}")
+        self.stage = stage
+        self.detail = detail
+
+
+# ---------------------------------------------------------------------------
+# Abstract base
+# ---------------------------------------------------------------------------
+
+
 class LLMProvider(ABC):
-    """Abstract LLM provider. Subclasses implement `generate` and `name`."""
+    """Abstract LLM provider.  Subclasses implement both call shapes."""
 
     @abstractmethod
     def generate(self, prompt: str, *, system: str | None = None) -> str:
-        """Return the LLM's completion for the given prompt."""
+        """Return the LLM's completion for the given prompt.
+
+        Unchanged from Week-1 contract.  Engines (dream, heartbeat, reflex,
+        research, growth) call this — do not touch it.
+        """
 
     @abstractmethod
     def name(self) -> str:
         """Return a short provider name (e.g. 'fake', 'claude-cli:sonnet')."""
+
+    @abstractmethod
+    def chat(
+        self,
+        messages: list[ChatMessage],
+        *,
+        tools: list[dict[str, Any]] | None = None,
+        options: dict[str, Any] | None = None,
+    ) -> ChatResponse:
+        """Multi-turn structured chat with optional tool-calls.
+
+        Parameters
+        ----------
+        messages:
+            Conversation history in chronological order.
+        tools:
+            Optional list of tool schemas (raw JSON-schema dicts in the shape
+            OpenAI / Ollama / Claude all consume).  None means no tool-calling.
+        options:
+            Provider-specific generation options (temperature, top_p, etc.).
+        """
+
+    def healthy(self) -> bool:
+        """Quick liveness check.  Default: assume healthy.
+
+        Providers that can check (e.g. Ollama /api/tags) override this.
+        ClaudeCliProvider and FakeProvider default to True.
+        """
+        return True
+
+
+# ---------------------------------------------------------------------------
+# FakeProvider — deterministic, zero network
+# ---------------------------------------------------------------------------
 
 
 class FakeProvider(LLMProvider):
@@ -33,6 +118,32 @@ class FakeProvider(LLMProvider):
     def name(self) -> str:
         return "fake"
 
+    def chat(
+        self,
+        messages: list[ChatMessage],
+        *,
+        tools: list[dict[str, Any]] | None = None,
+        options: dict[str, Any] | None = None,
+    ) -> ChatResponse:
+        """Return a deterministic ChatResponse.
+
+        tool_calls is always empty — FakeProvider never synthesises tool calls.
+        The content hash is derived from the serialised messages so tests can
+        assert determinism without caring about the exact value.
+        """
+        seed = json.dumps([m.to_dict() for m in messages], sort_keys=True).encode()
+        h = hashlib.sha256(seed).hexdigest()[:16]
+        return ChatResponse(
+            content=f"FAKE_CHAT: response {h}",
+            tool_calls=(),
+            raw=None,
+        )
+
+
+# ---------------------------------------------------------------------------
+# ClaudeCliProvider — shells out to `claude` CLI
+# ---------------------------------------------------------------------------
+
 
 class ClaudeCliProvider(LLMProvider):
     """Shells out to `claude -p <prompt> --output-format json`.
@@ -40,6 +151,24 @@ class ClaudeCliProvider(LLMProvider):
     Uses Hana's Claude Code subscription — no per-token API billing.
     Per the feedback memory: this is the default Claude path for
     companion-emergence and Hana's other projects.
+
+    Chat surface note
+    -----------------
+    The Claude CLI (as of 2026-04) exposes only text-based input:
+      - ``-p / --print`` for the user turn
+      - ``--system-prompt`` for the system message
+      - ``--input-format`` supports "text" (default) or "stream-json" but NOT
+        a structured messages-array format.
+
+    Therefore ClaudeCliProvider.chat() flattens the messages array into the
+    text surface:
+      - The first "system" message → ``--system-prompt``.
+      - Remaining messages are serialised as a "User: …\\nAssistant: …" script
+        ending at the final user turn, passed via ``-p``.
+      - tool_calls are NOT surfaced — Claude CLI v1 does not return structured
+        tool-call objects to the caller.
+
+    For tool-calling chat, use OllamaProvider with a tool-capable model.
     """
 
     def __init__(
@@ -84,53 +213,228 @@ class ClaudeCliProvider(LLMProvider):
     def name(self) -> str:
         return f"claude-cli:{self._model}"
 
+    def chat(
+        self,
+        messages: list[ChatMessage],
+        *,
+        tools: list[dict[str, Any]] | None = None,
+        options: dict[str, Any] | None = None,
+    ) -> ChatResponse:
+        """Flatten messages array into Claude CLI's text-only surface.
+
+        The Claude CLI does not expose a structured messages-array input
+        format in v1.  We translate:
+          - First system message → --system-prompt
+          - Remaining messages → "User: ...\\nAssistant: ..." conversation
+            script, ending at the last user turn, passed via -p.
+        tool_calls in the returned ChatResponse are always an empty tuple.
+
+        Raises
+        ------
+        ProviderError("claude_cli_timeout", ...)
+            If the subprocess exceeds the configured timeout.
+        ProviderError("claude_cli_exit", ...)
+            If the subprocess exits with a non-zero return code.
+        ProviderError("claude_cli_parse", ...)
+            If the JSON output cannot be parsed or lacks "result".
+        """
+        system_prompt: str | None = None
+        conversation_messages: list[ChatMessage] = []
+
+        for msg in messages:
+            if msg.role == "system" and system_prompt is None:
+                system_prompt = msg.content
+            else:
+                conversation_messages.append(msg)
+
+        # Build a flat conversation script for the -p flag.
+        # Format: "User: ...\nAssistant: ...\nUser: ..." ending on user turn.
+        if not conversation_messages:
+            flat_prompt = ""
+        elif len(conversation_messages) == 1:
+            flat_prompt = conversation_messages[0].content
+        else:
+            parts: list[str] = []
+            role_labels = {"user": "User", "assistant": "Assistant", "tool": "Tool"}
+            for msg in conversation_messages:
+                label = role_labels.get(msg.role, msg.role.capitalize())
+                parts.append(f"{label}: {msg.content}")
+            flat_prompt = "\n".join(parts)
+
+        cmd = ["claude", "-p", flat_prompt, "--output-format", "json", "--model", self._model]
+        if system_prompt is not None:
+            cmd.extend(["--system-prompt", system_prompt])
+
+        try:
+            result = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                timeout=self._timeout,
+                check=False,
+            )
+        except subprocess.TimeoutExpired as exc:
+            raise ProviderError(
+                "claude_cli_timeout",
+                f"subprocess timed out after {self._timeout}s",
+            ) from exc
+
+        if result.returncode != 0:
+            raise ProviderError(
+                "claude_cli_exit",
+                f"exit {result.returncode}: {result.stderr.strip()}",
+            )
+
+        try:
+            payload = json.loads(result.stdout)
+            content = str(payload["result"])
+        except (json.JSONDecodeError, KeyError, TypeError) as exc:
+            raise ProviderError(
+                "claude_cli_parse",
+                f"unexpected output format: {result.stdout[:200]!r}",
+            ) from exc
+
+        return ChatResponse(content=content, tool_calls=(), raw=None)
+
+
+# ---------------------------------------------------------------------------
+# OllamaProvider — httpx-based, full tool-call support
+# ---------------------------------------------------------------------------
+
 
 class OllamaProvider(LLMProvider):
-    """Placeholder for local Ollama integration.
+    """Local Ollama integration over httpx.
 
-    Stub — fill in when Ollama integration lands. Fill in by:
-    1. Replacing raise with an httpx POST to {host}/api/generate
-    2. Parsing the streamed/non-streamed response
-    3. Adding the httpx dep to pyproject
+    Full port of OG NellBrain's OllamaProvider (nell_bridge_providers.py).
 
     Default model: huihui_ai/qwen2.5-abliterated:7b — uncensored Qwen2.5
-    abliterated variant. Same base architecture as Nell's nell-dpo
-    fine-tune, light enough for most local hardware (~4.7GB), works
-    well with the brain's emotional + creative tone. Users can override
-    via `OllamaProvider(model="...")`.
+    abliterated variant.  Same base architecture as Nell's nell-dpo fine-tune,
+    light enough for most local hardware (~4.7GB), works well with the brain's
+    emotional + creative tone.  Users can override via OllamaProvider(model="…").
+
+    Streaming
+    ---------
+    # TODO(streaming): chat_stream() — Phase 6.5 scope.  The non-streaming
+    # chat() here is sufficient for all SP-1 through SP-5 use-cases.  When
+    # Phase 6.5 lands, add a chat_stream() that POSTs with stream=True and
+    # yields token chunks.
     """
 
     def __init__(
         self,
         model: str = "huihui_ai/qwen2.5-abliterated:7b",
         host: str = "http://localhost:11434",
+        timeout: float = 300.0,
     ) -> None:
         self._model = model
-        self._host = host
-
-    def generate(self, prompt: str, *, system: str | None = None) -> str:
-        raise NotImplementedError(
-            "OllamaProvider is a stub; fill in when the local Ollama stack is available."
-        )
+        self._host = host.rstrip("/")
+        self._timeout = timeout
 
     def name(self) -> str:
         return f"ollama:{self._model}"
+
+    def healthy(self) -> bool:
+        """GET /api/tags — True if Ollama is reachable and responds 200."""
+        try:
+            r = httpx.get(f"{self._host}/api/tags", timeout=5.0)
+            return r.status_code == 200
+        except httpx.RequestError:
+            return False
+
+    def chat(
+        self,
+        messages: list[ChatMessage],
+        *,
+        tools: list[dict[str, Any]] | None = None,
+        options: dict[str, Any] | None = None,
+    ) -> ChatResponse:
+        """POST to /api/chat and parse the structured response.
+
+        Raises
+        ------
+        ProviderError("ollama_http", ...)
+            HTTP error response from Ollama (4xx / 5xx).
+        ProviderError("ollama_request", ...)
+            Network-level failure (connection refused, DNS, etc.).
+        ProviderError("ollama_parse", ...)
+            Response body is not valid JSON or missing expected fields.
+        """
+        payload: dict[str, Any] = {
+            "model": self._model,
+            "messages": [m.to_dict() for m in messages],
+            "stream": False,
+        }
+        if tools:
+            payload["tools"] = tools
+        if options:
+            payload["options"] = options
+
+        url = f"{self._host}/api/chat"
+        try:
+            resp = httpx.post(url, json=payload, timeout=self._timeout)
+            resp.raise_for_status()
+        except httpx.HTTPStatusError as exc:
+            raise ProviderError(
+                "ollama_http",
+                f"{exc.response.status_code}: {exc.response.text[:200]}",
+            ) from exc
+        except httpx.RequestError as exc:
+            raise ProviderError("ollama_request", str(exc)) from exc
+
+        try:
+            data = resp.json()
+        except ValueError as exc:
+            raise ProviderError("ollama_parse", f"invalid json: {exc}") from exc
+
+        msg = data.get("message") or {}
+        content: str = msg.get("content", "") or ""
+        raw_tool_calls: list[dict[str, Any]] = msg.get("tool_calls") or []
+
+        parsed_tool_calls: list[ToolCall] = []
+        for tc_dict in raw_tool_calls:
+            try:
+                parsed_tool_calls.append(ToolCall.from_provider_dict(tc_dict))
+            except ValueError as exc:
+                raise ProviderError(
+                    "ollama_parse",
+                    f"malformed tool_call in response: {exc}",
+                ) from exc
+
+        return ChatResponse(
+            content=content,
+            tool_calls=tuple(parsed_tool_calls),
+            raw=data,
+        )
+
+    def generate(self, prompt: str, *, system: str | None = None) -> str:
+        """Single-turn text generation.
+
+        Implemented by delegating to chat() so all request/response logic
+        lives in one place.  This is the first working Ollama generate() path
+        in companion-emergence — previously this raised NotImplementedError.
+        """
+        messages: list[ChatMessage] = []
+        if system:
+            messages.append(ChatMessage(role="system", content=system))
+        messages.append(ChatMessage(role="user", content=prompt))
+        response = self.chat(messages)
+        return response.content
+
+
+# ---------------------------------------------------------------------------
+# Factory
+# ---------------------------------------------------------------------------
 
 
 def get_provider(name: str) -> LLMProvider:
     """Resolve a provider identifier to an instance.
 
-    Raises ValueError on unknown name. Raises NotImplementedError for
-    Phase 1 stubs (ollama) with a user-friendly message pointing to
-    the working alternatives.
+    Raises ValueError on unknown name.
     """
     if name == "fake":
         return FakeProvider()
     if name == "claude-cli":
         return ClaudeCliProvider()
     if name == "ollama":
-        raise NotImplementedError(
-            "The 'ollama' provider is not yet implemented (Phase 1 stub). "
-            "Use 'claude-cli' (default, subscription-backed) or 'fake' (for tests)."
-        )
+        return OllamaProvider()
     raise ValueError(f"Unknown provider: {name!r}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "platformdirs>=4.2",
     "numpy>=1.26",
     "ddgs>=6.0",
+    "httpx>=0.27",
 ]
 
 [project.optional-dependencies]

--- a/tests/unit/brain/bridge/test_chat.py
+++ b/tests/unit/brain/bridge/test_chat.py
@@ -1,0 +1,169 @@
+"""Tests for brain.bridge.chat — ChatMessage, ToolCall, ChatResponse."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from brain.bridge.chat import ChatMessage, ChatResponse, ToolCall
+
+# ---------------------------------------------------------------------------
+# ChatMessage construction + to_dict round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_chat_message_system_to_dict() -> None:
+    """System message serialises to role + content only."""
+    m = ChatMessage(role="system", content="You are Nell.")
+    d = m.to_dict()
+    assert d == {"role": "system", "content": "You are Nell."}
+
+
+def test_chat_message_user_to_dict() -> None:
+    """User message serialises cleanly without optional fields."""
+    m = ChatMessage(role="user", content="Hello Nell.")
+    d = m.to_dict()
+    assert d == {"role": "user", "content": "Hello Nell."}
+    assert "tool_call_id" not in d
+    assert "tool_calls" not in d
+
+
+def test_chat_message_assistant_no_tool_calls_to_dict() -> None:
+    """Assistant message without tool_calls omits that field."""
+    m = ChatMessage(role="assistant", content="Hi Hana.")
+    d = m.to_dict()
+    assert d == {"role": "assistant", "content": "Hi Hana."}
+    assert "tool_calls" not in d
+
+
+def test_chat_message_assistant_with_tool_calls_to_dict() -> None:
+    """Assistant message with tool_calls includes serialised tool_calls list."""
+    tc = ToolCall(id="call_1", name="search", arguments={"query": "dreams"})
+    m = ChatMessage(role="assistant", content="", tool_calls=(tc,))
+    d = m.to_dict()
+    assert d["role"] == "assistant"
+    assert d["tool_calls"] == [tc.to_dict()]
+    assert "tool_call_id" not in d
+
+
+def test_chat_message_tool_response_to_dict() -> None:
+    """Tool response message includes tool_call_id."""
+    m = ChatMessage(role="tool", content="found it", tool_call_id="call_1")
+    d = m.to_dict()
+    assert d == {"role": "tool", "content": "found it", "tool_call_id": "call_1"}
+
+
+def test_chat_message_is_frozen() -> None:
+    """ChatMessage is immutable — attribute assignment raises FrozenInstanceError."""
+    import dataclasses
+
+    m = ChatMessage(role="user", content="hi")
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        m.content = "changed"  # type: ignore[misc]
+
+
+def test_chat_message_default_tool_calls_is_empty_tuple() -> None:
+    """Default tool_calls is an empty tuple, not a mutable list."""
+    m = ChatMessage(role="user", content="test")
+    assert m.tool_calls == ()
+    assert isinstance(m.tool_calls, tuple)
+
+
+def test_chat_message_default_tool_call_id_is_none() -> None:
+    m = ChatMessage(role="user", content="test")
+    assert m.tool_call_id is None
+
+
+# ---------------------------------------------------------------------------
+# ToolCall construction + from_provider_dict
+# ---------------------------------------------------------------------------
+
+
+def test_tool_call_construction() -> None:
+    """ToolCall stores id, name, and arguments."""
+    tc = ToolCall(id="c1", name="get_weather", arguments={"city": "London"})
+    assert tc.id == "c1"
+    assert tc.name == "get_weather"
+    assert tc.arguments == {"city": "London"}
+
+
+def test_tool_call_from_provider_dict_with_dict_arguments() -> None:
+    """from_provider_dict handles pre-parsed dict arguments (Claude shape)."""
+    d = {
+        "id": "call_abc",
+        "function": {
+            "name": "recall",
+            "arguments": {"topic": "heartbeat", "limit": 5},
+        },
+    }
+    tc = ToolCall.from_provider_dict(d)
+    assert tc.id == "call_abc"
+    assert tc.name == "recall"
+    assert tc.arguments == {"topic": "heartbeat", "limit": 5}
+
+
+def test_tool_call_from_provider_dict_with_string_arguments() -> None:
+    """from_provider_dict handles JSON-encoded string arguments (Ollama shape)."""
+    d = {
+        "id": "call_xyz",
+        "function": {
+            "name": "write_memory",
+            "arguments": json.dumps({"content": "Hana loves dreams"}),
+        },
+    }
+    tc = ToolCall.from_provider_dict(d)
+    assert tc.name == "write_memory"
+    assert tc.arguments == {"content": "Hana loves dreams"}
+
+
+def test_tool_call_from_provider_dict_malformed_raises_value_error() -> None:
+    """from_provider_dict raises ValueError on structurally invalid input."""
+    with pytest.raises(ValueError, match="missing required fields"):
+        ToolCall.from_provider_dict({"no_id": "here"})
+
+
+def test_tool_call_from_provider_dict_bad_json_string_raises_value_error() -> None:
+    """from_provider_dict raises ValueError when arguments string is not valid JSON."""
+    d = {
+        "id": "c1",
+        "function": {"name": "f", "arguments": "{not valid json}"},
+    }
+    with pytest.raises(ValueError, match="cannot parse arguments JSON"):
+        ToolCall.from_provider_dict(d)
+
+
+def test_tool_call_from_provider_dict_non_dict_arguments_raises_value_error() -> None:
+    """from_provider_dict raises ValueError when arguments decodes to non-dict."""
+    d = {
+        "id": "c1",
+        "function": {"name": "f", "arguments": json.dumps([1, 2, 3])},
+    }
+    with pytest.raises(ValueError, match="must decode to a dict"):
+        ToolCall.from_provider_dict(d)
+
+
+# ---------------------------------------------------------------------------
+# ChatResponse construction
+# ---------------------------------------------------------------------------
+
+
+def test_chat_response_construction() -> None:
+    """ChatResponse stores content, tool_calls, and raw."""
+    tc = ToolCall(id="c1", name="foo", arguments={})
+    resp = ChatResponse(content="hello", tool_calls=(tc,), raw={"model": "llama3"})
+    assert resp.content == "hello"
+    assert resp.tool_calls == (tc,)
+    assert resp.raw == {"model": "llama3"}
+
+
+def test_chat_response_empty_tool_calls_default() -> None:
+    """Default tool_calls is an empty tuple."""
+    resp = ChatResponse(content="hi")
+    assert resp.tool_calls == ()
+    assert isinstance(resp.tool_calls, tuple)
+
+
+def test_chat_response_raw_defaults_to_none() -> None:
+    resp = ChatResponse(content="hi")
+    assert resp.raw is None

--- a/tests/unit/brain/bridge/test_provider.py
+++ b/tests/unit/brain/bridge/test_provider.py
@@ -47,11 +47,24 @@ def test_fake_provider_output_has_dream_prefix() -> None:
     assert FakeProvider().generate("anything").startswith("DREAM:")
 
 
-def test_ollama_provider_raises_not_implemented() -> None:
-    """OllamaProvider.generate raises NotImplementedError with a clear message."""
-    p = OllamaProvider()
-    with pytest.raises(NotImplementedError, match="stub"):
-        p.generate("anything")
+def test_ollama_provider_generate_raises_provider_error_when_unreachable() -> None:
+    """OllamaProvider.generate raises ProviderError when Ollama is not running.
+
+    The stub NotImplementedError is gone — OllamaProvider is fully implemented.
+    On CI (no local Ollama) the request fails with a network error, surfaced as
+    ProviderError("ollama_request", ...).
+    """
+    from unittest.mock import patch
+
+    import httpx
+
+    from brain.bridge.provider import ProviderError
+
+    with patch("httpx.post", side_effect=httpx.RequestError("connection refused")):
+        p = OllamaProvider()
+        with pytest.raises(ProviderError) as exc_info:
+            p.generate("anything")
+    assert exc_info.value.stage == "ollama_request"
 
 
 def test_ollama_provider_name_includes_model() -> None:
@@ -127,11 +140,15 @@ def test_get_provider_resolves_known_names() -> None:
     assert isinstance(get_provider("claude-cli"), ClaudeCliProvider)
 
 
-def test_get_provider_ollama_raises_user_friendly_error() -> None:
-    """ollama is a Phase 1 stub — factory should give user a clear
-    message instead of returning an instance that crashes on first use."""
-    with pytest.raises(NotImplementedError, match="not yet implemented"):
-        get_provider("ollama")
+def test_get_provider_ollama_returns_instance() -> None:
+    """get_provider("ollama") now returns a real OllamaProvider — no longer a stub.
+
+    SP-1 ships OllamaProvider with a full httpx-based implementation, so the
+    factory must hand back a usable instance.  The test that previously asserted
+    NotImplementedError is updated to assert the new behaviour.
+    """
+    provider = get_provider("ollama")
+    assert isinstance(provider, OllamaProvider)
 
 
 def test_get_provider_unknown_name_raises() -> None:

--- a/tests/unit/brain/bridge/test_provider_chat.py
+++ b/tests/unit/brain/bridge/test_provider_chat.py
@@ -1,0 +1,364 @@
+"""Tests for provider.chat() implementations — FakeProvider, ClaudeCliProvider, OllamaProvider."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from brain.bridge.chat import ChatMessage, ChatResponse
+from brain.bridge.provider import (
+    ClaudeCliProvider,
+    FakeProvider,
+    OllamaProvider,
+    ProviderError,
+    get_provider,
+)
+
+# ---------------------------------------------------------------------------
+# ProviderError
+# ---------------------------------------------------------------------------
+
+
+def test_provider_error_carries_stage_and_detail() -> None:
+    """ProviderError stores stage + detail as attributes."""
+    err = ProviderError("ollama_http", "503: service unavailable")
+    assert err.stage == "ollama_http"
+    assert err.detail == "503: service unavailable"
+    assert "[ollama_http]" in str(err)
+    assert "503: service unavailable" in str(err)
+
+
+def test_provider_error_is_runtime_error() -> None:
+    """ProviderError is a RuntimeError subclass."""
+    assert issubclass(ProviderError, RuntimeError)
+
+
+# ---------------------------------------------------------------------------
+# FakeProvider.chat
+# ---------------------------------------------------------------------------
+
+
+def test_fake_provider_chat_returns_chat_response() -> None:
+    """FakeProvider.chat returns a ChatResponse instance."""
+    p = FakeProvider()
+    resp = p.chat([ChatMessage(role="user", content="hi")])
+    assert isinstance(resp, ChatResponse)
+
+
+def test_fake_provider_chat_is_deterministic() -> None:
+    """Same messages → same content every call."""
+    p = FakeProvider()
+    msgs = [ChatMessage(role="user", content="tell me a dream")]
+    a = p.chat(msgs)
+    b = p.chat(msgs)
+    assert a.content == b.content
+
+
+def test_fake_provider_chat_content_has_fake_prefix() -> None:
+    p = FakeProvider()
+    resp = p.chat([ChatMessage(role="user", content="hello")])
+    assert resp.content.startswith("FAKE_CHAT:")
+
+
+def test_fake_provider_chat_tool_calls_always_empty() -> None:
+    """FakeProvider never synthesises tool calls."""
+    p = FakeProvider()
+    resp = p.chat([ChatMessage(role="user", content="use tools")])
+    assert resp.tool_calls == ()
+
+
+def test_fake_provider_chat_with_tools_param_still_empty_tool_calls() -> None:
+    """Passing a tools list doesn't make FakeProvider return tool_calls."""
+    p = FakeProvider()
+    tools = [{"name": "search", "description": "search the web"}]
+    resp = p.chat([ChatMessage(role="user", content="search for dreams")], tools=tools)
+    assert resp.tool_calls == ()
+
+
+def test_fake_provider_chat_different_messages_differ() -> None:
+    """Different message content → different response content."""
+    p = FakeProvider()
+    r1 = p.chat([ChatMessage(role="user", content="foo")])
+    r2 = p.chat([ChatMessage(role="user", content="bar")])
+    assert r1.content != r2.content
+
+
+# ---------------------------------------------------------------------------
+# ClaudeCliProvider.chat
+# ---------------------------------------------------------------------------
+
+
+def _make_claude_result(content: str = "hello", rc: int = 0) -> MagicMock:
+    """Build a subprocess.CompletedProcess mock."""
+    m = MagicMock()
+    m.returncode = rc
+    m.stdout = json.dumps({"result": content})
+    m.stderr = ""
+    return m
+
+
+def test_claude_cli_chat_calls_subprocess_with_p_flag() -> None:
+    """ClaudeCliProvider.chat uses -p for the flattened conversation."""
+    with patch("subprocess.run", return_value=_make_claude_result()) as mock_run:
+        p = ClaudeCliProvider(model="sonnet")
+        p.chat([ChatMessage(role="user", content="hello")])
+
+    cmd = mock_run.call_args[0][0]
+    assert cmd[0] == "claude"
+    assert "-p" in cmd
+    assert "hello" in cmd
+
+
+def test_claude_cli_chat_passes_system_prompt_flag() -> None:
+    """System message in the list → --system-prompt flag."""
+    with patch("subprocess.run", return_value=_make_claude_result()) as mock_run:
+        p = ClaudeCliProvider()
+        p.chat(
+            [
+                ChatMessage(role="system", content="you are nell"),
+                ChatMessage(role="user", content="hi"),
+            ]
+        )
+
+    cmd = mock_run.call_args[0][0]
+    assert "--system-prompt" in cmd
+    assert "you are nell" in cmd
+
+
+def test_claude_cli_chat_parses_success() -> None:
+    """Successful call returns ChatResponse with correct content."""
+    with patch("subprocess.run", return_value=_make_claude_result("dream response")):
+        p = ClaudeCliProvider()
+        resp = p.chat([ChatMessage(role="user", content="dream")])
+
+    assert isinstance(resp, ChatResponse)
+    assert resp.content == "dream response"
+    assert resp.tool_calls == ()
+
+
+def test_claude_cli_chat_nonzero_exit_raises_provider_error() -> None:
+    """Non-zero exit code → ProviderError("claude_cli_exit", ...)."""
+    bad = MagicMock()
+    bad.returncode = 1
+    bad.stdout = ""
+    bad.stderr = "auth failure"
+
+    with patch("subprocess.run", return_value=bad):
+        p = ClaudeCliProvider()
+        with pytest.raises(ProviderError) as exc_info:
+            p.chat([ChatMessage(role="user", content="x")])
+
+    assert exc_info.value.stage == "claude_cli_exit"
+    assert "auth failure" in exc_info.value.detail
+
+
+def test_claude_cli_chat_timeout_raises_provider_error() -> None:
+    """Subprocess timeout → ProviderError("claude_cli_timeout", ...)."""
+    with patch(
+        "subprocess.run",
+        side_effect=subprocess.TimeoutExpired(cmd="claude", timeout=300),
+    ):
+        p = ClaudeCliProvider()
+        with pytest.raises(ProviderError) as exc_info:
+            p.chat([ChatMessage(role="user", content="x")])
+
+    assert exc_info.value.stage == "claude_cli_timeout"
+
+
+def test_claude_cli_chat_bad_json_raises_provider_error() -> None:
+    """Non-JSON stdout → ProviderError("claude_cli_parse", ...)."""
+    bad = MagicMock()
+    bad.returncode = 0
+    bad.stdout = "not json at all"
+    bad.stderr = ""
+
+    with patch("subprocess.run", return_value=bad):
+        p = ClaudeCliProvider()
+        with pytest.raises(ProviderError) as exc_info:
+            p.chat([ChatMessage(role="user", content="x")])
+
+    assert exc_info.value.stage == "claude_cli_parse"
+
+
+# ---------------------------------------------------------------------------
+# OllamaProvider.chat
+# ---------------------------------------------------------------------------
+
+
+def _make_ollama_response(content: str = "hello", tool_calls: list | None = None) -> MagicMock:
+    """Build a mock httpx.Response for Ollama /api/chat."""
+    payload = {
+        "model": "test-model",
+        "message": {
+            "role": "assistant",
+            "content": content,
+        },
+        "done": True,
+    }
+    if tool_calls is not None:
+        payload["message"]["tool_calls"] = tool_calls
+
+    mock_resp = MagicMock()
+    mock_resp.status_code = 200
+    mock_resp.json.return_value = payload
+    mock_resp.raise_for_status = MagicMock()  # no-op
+    return mock_resp
+
+
+def test_ollama_chat_builds_correct_payload() -> None:
+    """OllamaProvider.chat POSTs with model, messages, stream=False."""
+    with patch("httpx.post", return_value=_make_ollama_response()) as mock_post:
+        p = OllamaProvider(model="llama3", host="http://localhost:11434")
+        p.chat([ChatMessage(role="user", content="hello")])
+
+    _, kwargs = mock_post.call_args
+    payload = kwargs["json"]
+    assert payload["model"] == "llama3"
+    assert payload["stream"] is False
+    assert payload["messages"] == [{"role": "user", "content": "hello"}]
+
+
+def test_ollama_chat_includes_tools_when_provided() -> None:
+    """tools= list is forwarded in the payload."""
+    tools = [{"name": "search", "type": "function"}]
+    with patch("httpx.post", return_value=_make_ollama_response()) as mock_post:
+        p = OllamaProvider()
+        p.chat([ChatMessage(role="user", content="x")], tools=tools)
+
+    payload = mock_post.call_args[1]["json"]
+    assert payload["tools"] == tools
+
+
+def test_ollama_chat_parses_content() -> None:
+    """Content from message.content lands in ChatResponse.content."""
+    with patch("httpx.post", return_value=_make_ollama_response("Nell's reply")):
+        p = OllamaProvider()
+        resp = p.chat([ChatMessage(role="user", content="x")])
+
+    assert resp.content == "Nell's reply"
+
+
+def test_ollama_chat_parses_tool_calls() -> None:
+    """tool_calls in the response are parsed into ToolCall instances."""
+    raw_tc = [{"id": "c1", "function": {"name": "recall", "arguments": {"topic": "hana"}}}]
+    with patch("httpx.post", return_value=_make_ollama_response(tool_calls=raw_tc)):
+        p = OllamaProvider()
+        resp = p.chat([ChatMessage(role="user", content="x")])
+
+    assert len(resp.tool_calls) == 1
+    assert resp.tool_calls[0].name == "recall"
+    assert resp.tool_calls[0].arguments == {"topic": "hana"}
+
+
+def test_ollama_chat_http_error_raises_provider_error() -> None:
+    """HTTP error response → ProviderError("ollama_http", ...)."""
+    import httpx
+
+    mock_resp = MagicMock()
+    mock_resp.status_code = 503
+    mock_resp.text = "service unavailable"
+
+    with patch(
+        "httpx.post",
+        side_effect=httpx.HTTPStatusError("503", request=MagicMock(), response=mock_resp),
+    ):
+        p = OllamaProvider()
+        with pytest.raises(ProviderError) as exc_info:
+            p.chat([ChatMessage(role="user", content="x")])
+
+    assert exc_info.value.stage == "ollama_http"
+
+
+def test_ollama_chat_request_error_raises_provider_error() -> None:
+    """Network error → ProviderError("ollama_request", ...)."""
+    import httpx
+
+    with patch("httpx.post", side_effect=httpx.RequestError("connection refused")):
+        p = OllamaProvider()
+        with pytest.raises(ProviderError) as exc_info:
+            p.chat([ChatMessage(role="user", content="x")])
+
+    assert exc_info.value.stage == "ollama_request"
+
+
+def test_ollama_chat_invalid_json_raises_provider_error() -> None:
+    """Non-JSON response body → ProviderError("ollama_parse", ...)."""
+    mock_resp = MagicMock()
+    mock_resp.raise_for_status = MagicMock()
+    mock_resp.json.side_effect = ValueError("no json")
+
+    with patch("httpx.post", return_value=mock_resp):
+        p = OllamaProvider()
+        with pytest.raises(ProviderError) as exc_info:
+            p.chat([ChatMessage(role="user", content="x")])
+
+    assert exc_info.value.stage == "ollama_parse"
+
+
+# ---------------------------------------------------------------------------
+# OllamaProvider.healthy
+# ---------------------------------------------------------------------------
+
+
+def test_ollama_healthy_true_on_200() -> None:
+    """healthy() returns True when /api/tags responds 200."""
+    mock_resp = MagicMock()
+    mock_resp.status_code = 200
+
+    with patch("httpx.get", return_value=mock_resp):
+        assert OllamaProvider().healthy() is True
+
+
+def test_ollama_healthy_false_on_request_error() -> None:
+    """healthy() returns False when Ollama is unreachable."""
+    import httpx
+
+    with patch("httpx.get", side_effect=httpx.RequestError("refused")):
+        assert OllamaProvider().healthy() is False
+
+
+# ---------------------------------------------------------------------------
+# OllamaProvider.generate — calls chat() under the hood
+# ---------------------------------------------------------------------------
+
+
+def test_ollama_generate_delegates_to_chat() -> None:
+    """generate() returns the text content from chat()."""
+    with patch("httpx.post", return_value=_make_ollama_response("dream text")):
+        p = OllamaProvider()
+        result = p.generate("dream prompt", system="you are nell")
+
+    assert result == "dream text"
+
+
+def test_ollama_generate_includes_system_message_when_provided() -> None:
+    """generate() with system= sends a system ChatMessage first."""
+    with patch("httpx.post", return_value=_make_ollama_response()) as mock_post:
+        p = OllamaProvider()
+        p.generate("hello", system="be nell")
+
+    payload = mock_post.call_args[1]["json"]
+    messages = payload["messages"]
+    assert messages[0]["role"] == "system"
+    assert messages[0]["content"] == "be nell"
+    assert messages[1]["role"] == "user"
+
+
+# ---------------------------------------------------------------------------
+# get_provider factory — ollama no longer raises
+# ---------------------------------------------------------------------------
+
+
+def test_get_provider_ollama_returns_instance() -> None:
+    """get_provider("ollama") returns an OllamaProvider instance (no NotImplementedError)."""
+    provider = get_provider("ollama")
+    assert isinstance(provider, OllamaProvider)
+
+
+def test_get_provider_ollama_name_includes_model() -> None:
+    """The returned OllamaProvider has the expected default model name."""
+    provider = get_provider("ollama")
+    assert provider.name().startswith("ollama:")

--- a/tests/unit/brain/engines/test_cli.py
+++ b/tests/unit/brain/engines/test_cli.py
@@ -66,12 +66,28 @@ def test_nell_dream_real_cycle_with_fake_provider(
     assert len(dreams) == 1
 
 
-def test_nell_dream_ollama_surfaces_not_implemented(nell_persona: Path) -> None:
-    """--provider ollama fails cleanly with NotImplementedError at factory time."""
+def test_nell_dream_ollama_surfaces_provider_error_when_unreachable(
+    nell_persona: Path,
+) -> None:
+    """--provider ollama now attempts a real Ollama call.
+
+    SP-1 ships a working OllamaProvider, so the factory no longer raises
+    NotImplementedError.  On CI / dev machines without a local Ollama daemon,
+    the httpx request fails and surfaces as ProviderError("ollama_request").
+    We mock the network layer so the test is deterministic.
+    """
+    from unittest.mock import patch
+
+    import httpx
+
+    from brain.bridge.provider import ProviderError
     from brain.cli import main
 
-    with pytest.raises(NotImplementedError, match="not yet implemented"):
-        main(["dream", "--persona", "nell", "--provider", "ollama"])
+    with patch("httpx.post", side_effect=httpx.RequestError("connection refused")):
+        with pytest.raises(ProviderError) as exc_info:
+            main(["dream", "--persona", "nell", "--provider", "ollama"])
+
+    assert exc_info.value.stage == "ollama_request"
 
 
 def test_nell_dream_unknown_provider_fails(nell_persona: Path) -> None:

--- a/tests/unit/brain/engines/test_dream.py
+++ b/tests/unit/brain/engines/test_dream.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 import pytest
 
+from brain.bridge.chat import ChatMessage, ChatResponse
 from brain.bridge.provider import FakeProvider, LLMProvider
 from brain.engines.dream import DreamEngine, NoSeedAvailable
 from brain.memory.hebbian import HebbianMatrix
@@ -25,6 +26,9 @@ class _PrefixedFakeProvider(LLMProvider):
     def name(self) -> str:
         return "fake-prefixed"
 
+    def chat(self, messages: list[ChatMessage], *, tools=None, options=None) -> ChatResponse:  # type: ignore[override]
+        return ChatResponse(content=self.generate(messages[-1].content), tool_calls=())
+
 
 class _UnprefixedFakeProvider(LLMProvider):
     """Returns a response WITHOUT the DREAM prefix — exercises the engine's
@@ -36,6 +40,9 @@ class _UnprefixedFakeProvider(LLMProvider):
 
     def name(self) -> str:
         return "fake-unprefixed"
+
+    def chat(self, messages: list[ChatMessage], *, tools=None, options=None) -> ChatResponse:  # type: ignore[override]
+        return ChatResponse(content=self.generate(messages[-1].content), tool_calls=())
 
 
 @pytest.fixture

--- a/uv.lock
+++ b/uv.lock
@@ -3,6 +3,28 @@ revision = 3
 requires-python = ">=3.12"
 
 [[package]]
+name = "anyio"
+version = "4.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/14/2c5dd9f512b66549ae92767a9c7b330ae88e1932ca57876909410251fe13/anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc", size = 231622, upload-time = "2026-03-24T12:59:09.671Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/42/e921fccf5015463e32a3cf6ee7f980a6ed0f395ceeaa45060b61d86486c2/anyio-4.13.0-py3-none-any.whl", hash = "sha256:08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708", size = 114353, upload-time = "2026-03-24T12:59:08.246Z" },
+]
+
+[[package]]
+name = "certifi"
+version = "2026.4.22"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/25/ee/6caf7a40c36a1220410afe15a1cc64993a1f864871f698c0f93acb72842a/certifi-2026.4.22.tar.gz", hash = "sha256:8d455352a37b71bf76a79caa83a3d6c25afee4a385d632127b6afb3963f1c580", size = 137077, upload-time = "2026-04-22T11:26:11.191Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/22/30/7cd8fdcdfbc5b869528b079bfb76dcdf6056b1a2097a662e5e8c04f42965/certifi-2026.4.22-py3-none-any.whl", hash = "sha256:3cb2210c8f88ba2318d29b0388d1023c8492ff72ecdde4ebdaddbb13a31b1c4a", size = 135707, upload-time = "2026-04-22T11:26:09.372Z" },
+]
+
+[[package]]
 name = "click"
 version = "8.3.3"
 source = { registry = "https://pypi.org/simple" }
@@ -29,6 +51,7 @@ version = "0.0.1"
 source = { editable = "." }
 dependencies = [
     { name = "ddgs" },
+    { name = "httpx" },
     { name = "numpy" },
     { name = "platformdirs" },
 ]
@@ -43,6 +66,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "ddgs", specifier = ">=6.0" },
+    { name = "httpx", specifier = ">=0.27" },
     { name = "numpy", specifier = ">=1.26" },
     { name = "platformdirs", specifier = ">=4.2" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
@@ -147,6 +171,52 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c9/f2/aa1f5af106ea0ef0351d11a2fe05d28618463160137326eeb3073b7d788b/ddgs-9.14.1.tar.gz", hash = "sha256:85b878225a622ba145aff33c0f2f0dceb90d6cfaa291af253021d10cb261a8bb", size = 57157, upload-time = "2026-04-20T12:09:21.313Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4f/a0/c0b568acd6ec819ec94ecfd4eebd00edc855efab06e589ad17d0412ff4ce/ddgs-9.14.1-py3-none-any.whl", hash = "sha256:e6b853be092532add9c0d611c4b121f0b27092de66756401057c2100f6b1ab44", size = 67019, upload-time = "2026-04-20T12:09:19.867Z" },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.13"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ce/cc/762dfb036166873f0059f3b7de4565e1b5bc3d6f28a414c13da27e442f99/idna-3.13.tar.gz", hash = "sha256:585ea8fe5d69b9181ec1afba340451fba6ba764af97026f92a91d4eef164a242", size = 194210, upload-time = "2026-04-22T16:42:42.314Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/13/ad7d7ca3808a898b4612b6fe93cde56b53f3034dcde235acb1f0e1df24c6/idna-3.13-py3-none-any.whl", hash = "sha256:892ea0cde124a99ce773decba204c5552b69c3c67ffd5f232eb7696135bc8bb3", size = 68629, upload-time = "2026-04-22T16:42:40.909Z" },
 ]
 
 [[package]]
@@ -426,4 +496,13 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/88/27/0195d15fe7a897cbcba0904792c4b7c9fdd958456c3a17d2ea6093716a9a/ruff-0.15.11-py3-none-win32.whl", hash = "sha256:476a2aa56b7da0b73a3ee80b6b2f0e19cce544245479adde7baa65466664d5f3", size = 10655535, upload-time = "2026-04-16T18:46:12.47Z" },
     { url = "https://files.pythonhosted.org/packages/3a/5e/c927b325bd4c1d3620211a4b96f47864633199feed60fa936025ab27e090/ruff-0.15.11-py3-none-win_amd64.whl", hash = "sha256:8b6756d88d7e234fb0c98c91511aae3cd519d5e3ed271cae31b20f39cb2a12a3", size = 11779692, upload-time = "2026-04-16T18:46:17.268Z" },
     { url = "https://files.pythonhosted.org/packages/63/b6/aeadee5443e49baa2facd51131159fd6301cc4ccfc1541e4df7b021c37dd/ruff-0.15.11-py3-none-win_arm64.whl", hash = "sha256:063fed18cc1bbe0ee7393957284a6fe8b588c6a406a285af3ee3f46da2391ee4", size = 11032614, upload-time = "2026-04-16T18:46:34.487Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
 ]


### PR DESCRIPTION
## Summary

First sub-project from the master reference roadmap. Adds `chat(messages, *, tools, options) -> ChatResponse` to `LLMProvider` alongside the existing `generate(prompt, *, system) -> str`. Engines (dream, reflex, research, growth, heartbeat) keep their existing `generate()` paths unchanged. Chat engine, brain-tools rewrite, and bridge daemon (SP-3 / SP-4 / SP-6 / SP-7) will use the new `chat()` interface.

- **Master ref:** [docs/superpowers/specs/2026-04-26-companion-emergence-master-reference.md](docs/superpowers/specs/2026-04-26-companion-emergence-master-reference.md) §6 SP-1
- **OG reference:** `NellBrain/nell_bridge_providers.py` (158 lines, full working impl)

## Changes

**New `brain/bridge/chat.py`** — frozen-dataclass types:
- `ChatMessage(role, content, tool_call_id?, tool_calls?)` with `to_dict()` for provider transport
- `ToolCall(id, name, arguments)` with `from_provider_dict()` that handles both string-JSON args (Ollama/some Claude) and dict args (other Claude shapes), raises `ValueError` on malformed
- `ChatResponse(content, tool_calls, raw)`

**`brain/bridge/provider.py`** — additive:
- `ProviderError(stage, detail)` exception (port from OG)
- `LLMProvider.chat()` abstract method + `healthy()` default-True hook
- `FakeProvider.chat()` deterministic, never produces tool_calls
- `OllamaProvider.chat()` full port from OG (httpx POST `/api/chat`, parses content + tool_calls, raises `ProviderError` with stage context on http/request/parse failure)
- `OllamaProvider.generate()` now wraps `chat()` — first working Ollama path in the framework
- `OllamaProvider.healthy()` via GET `/api/tags`
- `ClaudeCliProvider.chat()` flattens messages into Claude CLI's text surface (system → `--system-prompt`; conversation → `-p` script). Tool-calling not surfaced via Claude CLI in v1 — for tool chat use Ollama
- `get_provider("ollama")` no longer raises `NotImplementedError`

**`pyproject.toml`** — `httpx>=0.27` added.

**Streaming deferred** to Phase 6.5 — `# TODO(streaming)` comment in OllamaProvider where it would land.

## Test plan

- [x] 17 tests for chat types (`tests/unit/brain/bridge/test_chat.py`) — message construction, frozen, to_dict round-trip, ToolCall string vs dict argument parsing, malformed args raises
- [x] 27 tests for provider chat impls (`tests/unit/brain/bridge/test_provider_chat.py`) — all three providers, all error paths (timeout, non-zero exit, http error, request error, parse error), payload shape, ProviderError stage+detail
- [x] 2 existing tests updated (`test_provider.py` + `test_cli.py`) for the new ollama behavior — assertions of `NotImplementedError` replaced with assertions about `ProviderError` (no Ollama running on test box) or successful instance construction
- [x] 2 local provider stubs in `test_dream.py` given a `chat()` stub so they satisfy the now-abstract interface
- [x] Full suite: **665 passed** (was 621; +44 net)
- [x] `ruff check && ruff format --check` clean
- [x] `uv sync --extra dev` works with httpx + dev deps

## Deviations from brief

- **Net new tests = 44, brief said 15-20.** Higher coverage on every error path (timeout / non-zero exit / http / request / parse) plus both string + dict argument shapes in `ToolCall.from_provider_dict`. All load-bearing — each exercises a distinct code path. No filler.
- **`--input-format=json` doesn't exist on Claude CLI.** Confirmed via `claude --help` — only `text` and `stream-json` are supported, neither accepts a messages array. The brief flagged the text-flattening fallback as the correct choice if structured-input wasn't there. That's the path implemented; documented in the `ClaudeCliProvider.chat()` docstring.

## Follow-ups (carried into other sub-projects)

- **SP-3 brain-tools rewrite** — uses `chat()` with `tools` param to surface brain APIs (memory search, emotion read, etc.) as LLM-callable tools
- **SP-6 chat engine** — uses `chat()` directly; constructs `ChatMessage` arrays from voice.md + brain context + user input
- **Phase 6.5** — `chat_stream()` for streaming responses (currently deferred)