### PR TITLE
SP-4: Conversation ingest pipeline

### DIFF
--- a/brain/ingest/__init__.py
+++ b/brain/ingest/__init__.py
@@ -1,0 +1,34 @@
+"""brain.ingest — SP-4 conversation ingest pipeline.
+
+8-stage pipeline: BUFFER → CLOSE → EXTRACT → SCORE → DEDUPE → COMMIT → SOUL → LOG.
+
+Chat turns are buffered per-session to JSONL files. When a session closes
+(explicit or stale silence), the full transcript is extracted into candidate
+memories via an LLM, deduplicated against existing embeddings, committed
+directly to the MemoryStore, and high-importance items are queued for SP-5
+(soul module) to consume.
+
+Public API:
+    ingest_turn(persona_dir, turn) -> str
+    close_session(persona_dir, session_id, *, store, hebbian, provider, ...) -> IngestReport
+    close_stale_sessions(persona_dir, *, silence_minutes, store, ...) -> list[IngestReport]
+    list_active_sessions(persona_dir) -> list[str]
+    list_soul_candidates(persona_dir) -> list[dict]
+    IngestReport
+    ExtractedItem
+"""
+
+from brain.ingest.buffer import ingest_turn, list_active_sessions
+from brain.ingest.pipeline import close_session, close_stale_sessions
+from brain.ingest.soul_queue import list_soul_candidates
+from brain.ingest.types import ExtractedItem, IngestReport
+
+__all__ = [
+    "ingest_turn",
+    "close_session",
+    "close_stale_sessions",
+    "list_active_sessions",
+    "list_soul_candidates",
+    "ExtractedItem",
+    "IngestReport",
+]

--- a/brain/ingest/buffer.py
+++ b/brain/ingest/buffer.py
@@ -1,0 +1,93 @@
+"""SP-4 BUFFER + CLOSE stages — per-persona session JSONL files.
+
+One file per session: <persona_dir>/active_conversations/<session_id>.jsonl
+Each line is a JSON-encoded turn record:
+  {session_id, speaker, text, ts}
+
+The append-only JSONL design is faithful to OG nell_conversation_ingest.py.
+Reads tolerate corrupt lines via read_jsonl_skipping_corrupt.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from datetime import UTC, datetime
+from pathlib import Path
+
+from brain.health.jsonl_reader import read_jsonl_skipping_corrupt
+
+
+def _now_iso() -> str:
+    return datetime.now(UTC).isoformat(timespec="seconds")
+
+
+def _active_conversations_dir(persona_dir: Path) -> Path:
+    d = persona_dir / "active_conversations"
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+def _session_path(persona_dir: Path, session_id: str) -> Path:
+    return _active_conversations_dir(persona_dir) / f"{session_id}.jsonl"
+
+
+def ingest_turn(persona_dir: Path, turn: dict) -> str:
+    """Append one turn to the session buffer. Returns session_id.
+
+    Required keys in ``turn``: speaker, text.
+    Optional:
+        session_id  — if absent, a new UUID-based session id is generated.
+        ts          — ISO-8601 timestamp; defaults to now (UTC).
+
+    Buffer path: <persona_dir>/active_conversations/<session_id>.jsonl
+    """
+    session_id: str = turn.get("session_id") or f"sess_{uuid.uuid4().hex[:8]}"
+    record = {
+        "session_id": session_id,
+        "speaker": turn.get("speaker", "unknown"),
+        "text": (turn.get("text") or "").strip(),
+        "ts": turn.get("ts") or _now_iso(),
+    }
+    path = _session_path(persona_dir, session_id)
+    with open(path, "a", encoding="utf-8") as fh:
+        fh.write(json.dumps(record, ensure_ascii=False) + "\n")
+    return session_id
+
+
+def list_active_sessions(persona_dir: Path) -> list[str]:
+    """Return session_ids of all active buffer files."""
+    d = persona_dir / "active_conversations"
+    if not d.exists():
+        return []
+    return [p.stem for p in d.iterdir() if p.is_file() and p.suffix == ".jsonl"]
+
+
+def read_session(persona_dir: Path, session_id: str) -> list[dict]:
+    """Return the turns from a session buffer, skipping malformed lines."""
+    path = _session_path(persona_dir, session_id)
+    return read_jsonl_skipping_corrupt(path)
+
+
+def session_silence_minutes(turns: list[dict]) -> float:
+    """Minutes elapsed since the last turn's ts.
+
+    Returns 0.0 if turns is empty or the last ts cannot be parsed.
+    """
+    if not turns:
+        return 0.0
+    try:
+        raw_ts = turns[-1]["ts"]
+        last = datetime.fromisoformat(str(raw_ts).replace("Z", "+00:00"))
+        if last.tzinfo is None:
+            last = last.replace(tzinfo=UTC)
+    except (KeyError, ValueError, TypeError):
+        return 0.0
+    delta = datetime.now(UTC) - last
+    return delta.total_seconds() / 60.0
+
+
+def delete_session_buffer(persona_dir: Path, session_id: str) -> None:
+    """Unlink the buffer file. Idempotent — no-op when file is missing."""
+    path = _session_path(persona_dir, session_id)
+    path.unlink(missing_ok=True)

--- a/brain/ingest/commit.py
+++ b/brain/ingest/commit.py
@@ -1,0 +1,82 @@
+"""SP-4 COMMIT stage — direct write to MemoryStore + auto-Hebbian linking.
+
+This bypasses the add_memory importance write-gate. The extraction LLM
+has already provided an importance signal; the ingest pipeline's own
+threshold is the gate, not a per-call gate in this module.
+
+Memory type  = ExtractedItem.label  (one of VALID_LABELS)
+Domain       = "brain"              (the conversation's own domain)
+Tags         = ["auto_ingest", "conversation", label]
+Importance   = item.importance / 10.0  (normalized to the store's 0..10.0 float scale)
+
+After creation, auto-Hebbian: search the store for the top-3 related
+memories (by keyword overlap) and strengthen each pair.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from brain.ingest.types import ExtractedItem
+from brain.memory.hebbian import HebbianMatrix
+from brain.memory.store import Memory, MemoryStore
+
+logger = logging.getLogger(__name__)
+
+_AUTO_HEBBIAN_LIMIT = 4  # fetch 4, skip self → up to 3 edges
+
+
+def commit_item(
+    item: ExtractedItem,
+    *,
+    session_id: str,
+    store: MemoryStore,
+    hebbian: HebbianMatrix,
+) -> str | None:
+    """Create a Memory from an ExtractedItem and write it to the store.
+
+    Does NOT go through any add_memory write-gate. The extraction LLM's
+    importance signal is trusted directly.
+
+    Auto-Hebbian wiring:
+        After writing, call store.search_text(item.text, limit=4) to find
+        the most textually related existing memories. Exclude the new
+        memory's own id, then strengthen(new_id, related_id, delta=0.5)
+        for each — up to 3 edges.
+
+    Returns the new memory's id, or None if creation fails.
+    """
+    try:
+        memory = Memory.create_new(
+            content=item.text,
+            memory_type=item.label,
+            domain="brain",
+            tags=["auto_ingest", "conversation", item.label],
+            importance=float(item.importance),
+            metadata={"source_summary": f"conversation:{session_id}"},
+        )
+        new_id = store.create(memory)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("commit_item: store.create failed: %s", exc)
+        return None
+
+    # Auto-Hebbian: find related memories and strengthen connections.
+    # We use the longest meaningful word from the text as a keyword query so
+    # that store.search_text (a LIKE substring match) has a realistic chance of
+    # hitting overlapping memories without requiring the full phrase to match.
+    try:
+        words = [w for w in item.text.split() if len(w) > 4]
+        keyword = words[0] if words else item.text[:20]
+        related = store.search_text(keyword, active_only=True, limit=_AUTO_HEBBIAN_LIMIT)
+        linked = 0
+        for candidate in related:
+            if candidate.id == new_id:
+                continue
+            hebbian.strengthen(new_id, candidate.id, delta=0.5)
+            linked += 1
+            if linked >= 3:
+                break
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("commit_item: auto-hebbian failed for %s: %s", new_id, exc)
+
+    return new_id

--- a/brain/ingest/dedupe.py
+++ b/brain/ingest/dedupe.py
@@ -1,0 +1,84 @@
+"""SP-4 DEDUPE stage — cosine-similarity check against existing embeddings.
+
+Design decision: dedupe is opt-in. When embeddings is None (the default in
+the pipeline signature), this function returns False unconditionally and the
+item passes through. This keeps SP-4 self-contained — the pipeline runs even
+without embedding infrastructure.
+
+When embeddings IS provided, we compute the candidate's embedding and compare
+it against every cached vector. If any similarity >= threshold, the item is a
+duplicate and should be skipped.
+
+The EmbeddingCache API exposes:
+  get_or_compute(content) -> np.ndarray   — compute + cache the vector
+  count() -> int                          — number of cached vectors
+
+Iterating all vectors requires querying the underlying SQLite table directly
+via the cache's internal connection. We do this defensively — if anything
+fails, we return False (let the item through) rather than crashing the pipeline.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import numpy as np
+
+from brain.memory.embeddings import EmbeddingCache, cosine_similarity
+from brain.memory.store import MemoryStore
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_DEDUP_THRESHOLD = 0.88
+
+
+def is_duplicate(
+    text: str,
+    *,
+    store: MemoryStore,
+    threshold: float = DEFAULT_DEDUP_THRESHOLD,
+    embeddings: EmbeddingCache | None = None,
+) -> bool:
+    """Cosine-similarity check against the persona's existing embeddings.
+
+    If ``embeddings`` is None or has no cached entries: return False —
+    dedupe is impossible, let the item through.
+
+    Otherwise:
+      1. Compute (or retrieve from cache) the embedding for ``text``.
+      2. Iterate all stored (content_hash, vector) pairs.
+      3. Return True if max cosine similarity >= threshold.
+
+    Any exception during the process is caught and logged; we return False
+    on failure (safe default — at worst we commit a near-duplicate).
+    """
+    if embeddings is None:
+        return False
+
+    try:
+        # Snapshot existing rows BEFORE computing the candidate embedding so we
+        # don't accidentally compare the text against itself if get_or_compute
+        # adds it to the cache during this call.
+        existing_rows = embeddings._conn.execute(  # noqa: SLF001
+            "SELECT vector, dim FROM embedding_cache"
+        ).fetchall()
+
+        if not existing_rows:
+            return False
+
+        candidate = embeddings.get_or_compute(text)
+
+        max_sim = 0.0
+        for vec_bytes, dim in existing_rows:
+            stored_vec = np.frombuffer(vec_bytes, dtype=np.float32).copy().reshape(dim)
+            sim = cosine_similarity(candidate, stored_vec)
+            if sim > max_sim:
+                max_sim = sim
+            if max_sim >= threshold:
+                return True
+
+        return max_sim >= threshold
+
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("is_duplicate: error during similarity check, letting item through: %s", exc)
+        return False

--- a/brain/ingest/extract.py
+++ b/brain/ingest/extract.py
@@ -1,0 +1,144 @@
+"""SP-4 EXTRACT + SCORE stages — LLM-based memory extraction from transcripts.
+
+Calls LLMProvider.generate() with a structured extraction prompt, parses the
+JSON array response, and returns normalized ExtractedItem instances.
+
+Defense strategy:
+- LLMs may wrap output in code fences; strip them.
+- LLMs may prepend prose; locate first '[' and last ']'.
+- On any parse failure, log a WARNING and return None so the retry loop kicks.
+- After max_retries exhausted, return [] — callers never see an exception.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+
+from brain.bridge.provider import LLMProvider
+from brain.ingest.types import ExtractedItem
+
+logger = logging.getLogger(__name__)
+
+EXTRACTION_PROMPT = """You are extracting durable memories from a conversation transcript.
+Return ONLY a JSON array. Each item: {{"text": str, "label": one of [observation, feeling, decision, question, fact, note], "importance": 1-10}}.
+Skip pleasantries. Keep items concrete. No prose, no commentary.
+
+TRANSCRIPT:
+{transcript}
+
+JSON:"""
+
+
+def format_transcript(turns: list[dict], max_tokens: int = 6000) -> str:
+    """Format turns as "speaker: text" lines, capped to max_tokens*4 chars.
+
+    The crude 4-chars-per-token estimate matches the OG implementation.
+    When the transcript is too long, the *tail* is kept — recent context
+    is more relevant for extraction.
+    """
+    lines = [f"{t.get('speaker', '?')}: {t.get('text', '')}" for t in turns]
+    text = "\n".join(lines)
+    cap = max_tokens * 4
+    if len(text) > cap:
+        text = text[-cap:]
+    return text
+
+
+def parse_extraction(raw: str | None) -> list[ExtractedItem] | None:
+    """Parse the LLM's raw text into a list of ExtractedItems.
+
+    Returns:
+        A list (possibly empty) on success.
+        None on any parse failure — the caller should retry.
+
+    Handles:
+    - Code fences (```json ... ```)
+    - Leading/trailing prose (locate first '[' and last ']')
+    - Empty arrays (valid — transcript had only pleasantries)
+    """
+    if not raw:
+        return None
+
+    text = raw.strip()
+
+    # Strip code fences if the model wrapped the output.
+    if text.startswith("```"):
+        # Remove leading ``` and optional language tag line.
+        text = text.lstrip("`")
+        if "\n" in text:
+            first_line, rest = text.split("\n", 1)
+            # If the first line after stripping backticks is a language tag
+            # (like "json"), discard it.
+            if not first_line.strip().startswith("[") and not first_line.strip().startswith("{"):
+                text = rest
+            else:
+                text = first_line + "\n" + rest
+        # Remove trailing ```
+        text = text.rstrip("`").strip()
+
+    # Locate the JSON array boundaries — ignore any prose before/after.
+    start = text.find("[")
+    end = text.rfind("]")
+    if start == -1 or end == -1 or end < start:
+        logger.warning("parse_extraction: could not locate JSON array in: %r", text[:200])
+        return None
+
+    try:
+        data = json.loads(text[start : end + 1])
+    except json.JSONDecodeError as exc:
+        logger.warning("parse_extraction: JSON decode failed: %s | text: %r", exc, text[:200])
+        return None
+
+    if not isinstance(data, list):
+        logger.warning("parse_extraction: expected list, got %s", type(data).__name__)
+        return None
+
+    out: list[ExtractedItem] = []
+    for entry in data:
+        if not isinstance(entry, dict):
+            continue
+        out.append(
+            ExtractedItem(
+                text=str(entry.get("text", "")),
+                label=str(entry.get("label", "observation")),
+                importance=entry.get("importance", 5),
+            )
+        )
+    return out
+
+
+def extract_items(
+    transcript: str,
+    *,
+    provider: LLMProvider,
+    max_retries: int = 1,
+) -> list[ExtractedItem]:
+    """Call the provider, parse the JSON array. Retry once on failure.
+
+    On all retries exhausted, logs a warning and returns [].
+    Errors are never raised — the pipeline must keep running.
+    """
+    if not transcript.strip():
+        return []
+
+    prompt = EXTRACTION_PROMPT.format(transcript=transcript)
+
+    for attempt in range(max_retries + 1):
+        raw_text: str | None = None
+        try:
+            raw_text = provider.generate(prompt)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "extract_items: provider.generate failed on attempt %d: %s", attempt, exc
+            )
+            continue
+
+        items = parse_extraction(raw_text)
+        if items is not None:
+            return items
+
+        logger.warning("extract_items: parse failed on attempt %d/%d", attempt, max_retries)
+
+    logger.warning("extract_items: gave up after %d retries", max_retries)
+    return []

--- a/brain/ingest/pipeline.py
+++ b/brain/ingest/pipeline.py
@@ -1,0 +1,187 @@
+"""SP-4 pipeline driver — orchestrates all 8 ingest stages.
+
+close_session()       — run all 8 stages for one session, delete its buffer.
+close_stale_sessions()— iterate active sessions, close any past the silence window.
+
+Stage flow:
+  BUFFER  → read turns from <persona_dir>/active_conversations/<session_id>.jsonl
+  CLOSE   → guard: if no turns, unlink buffer and return empty report
+  EXTRACT → format transcript, call LLM, get ExtractedItems
+  SCORE   → normalize each item (label coercion, importance clamp, text strip)
+  DEDUPE  → cosine similarity against EmbeddingCache (opt-in; None = skip)
+  COMMIT  → direct write to MemoryStore + auto-Hebbian
+  SOUL    → queue high-importance items to soul_candidates.jsonl
+  LOG     → emit structured log event with counts
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+from brain.bridge.provider import LLMProvider
+from brain.ingest.buffer import (
+    delete_session_buffer,
+    list_active_sessions,
+    read_session,
+    session_silence_minutes,
+)
+from brain.ingest.commit import commit_item
+from brain.ingest.dedupe import DEFAULT_DEDUP_THRESHOLD, is_duplicate
+from brain.ingest.extract import extract_items, format_transcript
+from brain.ingest.soul_queue import DEFAULT_SOUL_THRESHOLD, queue_soul_candidate
+from brain.ingest.types import IngestReport
+from brain.memory.embeddings import EmbeddingCache
+from brain.memory.hebbian import HebbianMatrix
+from brain.memory.store import MemoryStore
+
+logger = logging.getLogger(__name__)
+
+
+def close_session(
+    persona_dir: Path,
+    session_id: str,
+    *,
+    store: MemoryStore,
+    hebbian: HebbianMatrix,
+    provider: LLMProvider,
+    embeddings: EmbeddingCache | None = None,
+    config: dict | None = None,
+) -> IngestReport:
+    """Run the full 8-stage ingest pipeline on one session and delete its buffer.
+
+    Parameters
+    ----------
+    persona_dir:
+        Root directory for this persona (contains active_conversations/, etc.)
+    session_id:
+        The session to close and process.
+    store:
+        SQLite-backed MemoryStore to commit new memories into.
+    hebbian:
+        HebbianMatrix to strengthen connections between related memories.
+    provider:
+        LLMProvider used for EXTRACT stage (generate() surface).
+    embeddings:
+        Optional EmbeddingCache for DEDUPE. When None, dedupe is skipped.
+    config:
+        Optional dict of pipeline knobs:
+          extraction_max_retries: int = 1
+          max_transcript_tokens: int = 6000
+          dedup_threshold: float = 0.88
+          crystallize_threshold: int = 8
+
+    Returns
+    -------
+    IngestReport with counts of what happened.
+    """
+    cfg = config or {}
+    report = IngestReport(session_id=session_id)
+
+    # ── BUFFER: read the session turns ──────────────────────────────────────
+    turns = read_session(persona_dir, session_id)
+
+    # ── CLOSE guard: empty session ───────────────────────────────────────────
+    if not turns:
+        delete_session_buffer(persona_dir, session_id)
+        return report
+
+    # ── EXTRACT ──────────────────────────────────────────────────────────────
+    transcript = format_transcript(turns, max_tokens=int(cfg.get("max_transcript_tokens", 6000)))
+    items = extract_items(
+        transcript,
+        provider=provider,
+        max_retries=int(cfg.get("extraction_max_retries", 1)),
+    )
+    report.extracted = len(items)
+
+    # ── SCORE (normalize at the boundary) ────────────────────────────────────
+    items = [it.normalize() for it in items if it.text]
+
+    # ── DEDUPE + COMMIT + SOUL ────────────────────────────────────────────────
+    dedup_threshold = float(cfg.get("dedup_threshold", DEFAULT_DEDUP_THRESHOLD))
+    crystallize_threshold = int(cfg.get("crystallize_threshold", DEFAULT_SOUL_THRESHOLD))
+
+    for item in items:
+        # DEDUPE
+        if is_duplicate(item.text, store=store, threshold=dedup_threshold, embeddings=embeddings):
+            report.deduped += 1
+            continue
+
+        # COMMIT
+        mem_id = commit_item(item, session_id=session_id, store=store, hebbian=hebbian)
+        if mem_id is None:
+            report.errors += 1
+            continue
+
+        report.committed += 1
+        report.memory_ids.append(mem_id)
+
+        # SOUL
+        if item.importance >= crystallize_threshold:
+            queue_soul_candidate(
+                persona_dir,
+                memory_id=mem_id,
+                item=item,
+                session_id=session_id,
+            )
+            report.soul_candidates += 1
+
+    # ── LOG ──────────────────────────────────────────────────────────────────
+    logger.info(
+        "conversation_ingested session=%s turns=%d extracted=%d committed=%d "
+        "deduped=%d soul_candidates=%d errors=%d",
+        session_id,
+        len(turns),
+        report.extracted,
+        report.committed,
+        report.deduped,
+        report.soul_candidates,
+        report.errors,
+    )
+
+    # ── DELETE buffer ─────────────────────────────────────────────────────────
+    delete_session_buffer(persona_dir, session_id)
+
+    return report
+
+
+def close_stale_sessions(
+    persona_dir: Path,
+    *,
+    silence_minutes: float = 5.0,
+    store: MemoryStore,
+    hebbian: HebbianMatrix,
+    provider: LLMProvider,
+    embeddings: EmbeddingCache | None = None,
+    config: dict | None = None,
+) -> list[IngestReport]:
+    """Iterate active sessions; close any whose last turn is older than silence_minutes.
+
+    Empty sessions (no turns) are cleaned up silently without running the
+    full pipeline.
+
+    Returns reports for closed sessions only (skips fresh sessions).
+    """
+    reports: list[IngestReport] = []
+    for sid in list_active_sessions(persona_dir):
+        from brain.ingest.buffer import read_session as _read
+
+        turns = _read(persona_dir, sid)
+        if not turns:
+            # Ghost file — clean it up without generating a report.
+            delete_session_buffer(persona_dir, sid)
+            continue
+        age = session_silence_minutes(turns)
+        if age >= silence_minutes:
+            report = close_session(
+                persona_dir,
+                sid,
+                store=store,
+                hebbian=hebbian,
+                provider=provider,
+                embeddings=embeddings,
+                config=config,
+            )
+            reports.append(report)
+    return reports

--- a/brain/ingest/soul_queue.py
+++ b/brain/ingest/soul_queue.py
@@ -1,0 +1,75 @@
+"""SP-4 SOUL stage — soul candidate queue for high-importance memories.
+
+When an extracted item has importance >= DEFAULT_SOUL_THRESHOLD (8), it is
+appended to <persona_dir>/soul_candidates.jsonl.
+
+Principle note: this queue is NOT a human-approval gate. It is deferred work
+for SP-5 (soul module) to consume autonomously. The brain decides which
+candidates to crystallize. SP-4 just records them with status="auto_pending"
+so SP-5 has data to work from when it lands.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import UTC, datetime
+from pathlib import Path
+
+from brain.health.jsonl_reader import read_jsonl_skipping_corrupt
+from brain.ingest.types import ExtractedItem
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_SOUL_THRESHOLD = 8
+
+_SOUL_CANDIDATES_FILENAME = "soul_candidates.jsonl"
+
+
+def _soul_candidates_path(persona_dir: Path) -> Path:
+    return persona_dir / _SOUL_CANDIDATES_FILENAME
+
+
+def queue_soul_candidate(
+    persona_dir: Path,
+    *,
+    memory_id: str,
+    item: ExtractedItem,
+    session_id: str,
+) -> None:
+    """Append a soul candidate record to <persona_dir>/soul_candidates.jsonl.
+
+    The record shape matches the OG nell_conversation_ingest.py schema with
+    one field change: status is "auto_pending" (was "pending" in OG) to
+    signal that SP-5 owns the crystallization decision.
+
+    Record schema:
+        memory_id:   str   — the newly committed memory's id
+        text:        str   — the item's content
+        label:       str   — memory_type / label
+        importance:  int   — 1-10 extraction importance
+        session_id:  str   — source session
+        queued_at:   str   — ISO-8601 UTC timestamp
+        status:      str   — "auto_pending" (SP-5 consumes and updates this)
+    """
+    persona_dir.mkdir(parents=True, exist_ok=True)
+    record = {
+        "memory_id": memory_id,
+        "text": item.text,
+        "label": item.label,
+        "importance": item.importance,
+        "session_id": session_id,
+        "queued_at": datetime.now(UTC).isoformat(timespec="seconds"),
+        "status": "auto_pending",
+    }
+    path = _soul_candidates_path(persona_dir)
+    try:
+        with open(path, "a", encoding="utf-8") as fh:
+            fh.write(json.dumps(record, ensure_ascii=False) + "\n")
+    except OSError as exc:
+        logger.warning("queue_soul_candidate: failed to write to %s: %s", path, exc)
+
+
+def list_soul_candidates(persona_dir: Path) -> list[dict]:
+    """Read all candidates from soul_candidates.jsonl, skipping malformed lines."""
+    return read_jsonl_skipping_corrupt(_soul_candidates_path(persona_dir))

--- a/brain/ingest/types.py
+++ b/brain/ingest/types.py
@@ -1,0 +1,68 @@
+"""SP-4 ingest types — ExtractedItem + IngestReport dataclasses.
+
+These are the boundary types for the 8-stage conversation ingest pipeline.
+ExtractedItem represents one candidate memory pulled from a transcript.
+IngestReport summarises what happened when a session was closed.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+VALID_LABELS = frozenset({"observation", "feeling", "decision", "question", "fact", "note"})
+
+
+@dataclass
+class ExtractedItem:
+    """One candidate memory extracted from a conversation transcript.
+
+    Attributes:
+        text:        The durable memory text, already stripped.
+        label:       One of VALID_LABELS. Coerced to "observation" on
+                     normalization if unknown.
+        importance:  1-10 integer signal from the extraction LLM.
+                     Clamped on normalization; defaults to 5.
+    """
+
+    text: str
+    label: str = "observation"
+    importance: int = 5
+
+    def normalize(self) -> ExtractedItem:
+        """Coerce label, clamp importance, strip text whitespace.
+
+        Returns self so callers can chain: item.normalize().
+        """
+        # Boundary validation: coerce unknown labels to the safe default.
+        if self.label not in VALID_LABELS:
+            self.label = "observation"
+        # Clamp importance to [1, 10]; handle non-int values gracefully.
+        try:
+            self.importance = max(1, min(10, int(self.importance)))
+        except (TypeError, ValueError):
+            self.importance = 5
+        self.text = (self.text or "").strip()
+        return self
+
+
+@dataclass
+class IngestReport:
+    """Summary of what happened when one conversation session was closed.
+
+    Attributes:
+        session_id:      The closed session's identifier.
+        extracted:       Total candidate items returned by the LLM.
+        committed:       Items that passed dedupe + were written to the store.
+        deduped:         Items skipped because they matched an existing memory.
+        soul_candidates: Items queued to soul_candidates.jsonl (importance >= threshold).
+        errors:          Items that failed the commit step.
+        memory_ids:      IDs of newly created memories (committed items only).
+    """
+
+    session_id: str
+    extracted: int = 0
+    committed: int = 0
+    deduped: int = 0
+    soul_candidates: int = 0
+    errors: int = 0
+    memory_ids: list[str] = field(default_factory=list)

--- a/tests/unit/brain/ingest/test_buffer.py
+++ b/tests/unit/brain/ingest/test_buffer.py
@@ -1,0 +1,110 @@
+"""Tests for brain.ingest.buffer — BUFFER + CLOSE stage."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+from brain.ingest.buffer import (
+    delete_session_buffer,
+    ingest_turn,
+    list_active_sessions,
+    read_session,
+    session_silence_minutes,
+)
+
+
+def test_ingest_turn_appends_to_session_file(tmp_path: Path) -> None:
+    """ingest_turn writes a JSONL record to active_conversations/<session_id>.jsonl."""
+    session_id = ingest_turn(
+        tmp_path, {"session_id": "sess_abc", "speaker": "Hana", "text": "hello"}
+    )
+    assert session_id == "sess_abc"
+    buf_file = tmp_path / "active_conversations" / "sess_abc.jsonl"
+    assert buf_file.exists()
+    line = buf_file.read_text(encoding="utf-8").strip()
+    record = json.loads(line)
+    assert record["session_id"] == "sess_abc"
+    assert record["speaker"] == "Hana"
+    assert record["text"] == "hello"
+    assert "ts" in record
+
+
+def test_ingest_turn_auto_generates_session_id(tmp_path: Path) -> None:
+    """When session_id is absent, ingest_turn generates one and returns it."""
+    session_id = ingest_turn(tmp_path, {"speaker": "Nell", "text": "hi"})
+    assert session_id.startswith("sess_")
+    buf_file = tmp_path / "active_conversations" / f"{session_id}.jsonl"
+    assert buf_file.exists()
+
+
+def test_ingest_turn_multiple_turns_append(tmp_path: Path) -> None:
+    """Multiple ingest_turn calls to the same session append multiple lines."""
+    for text in ("first", "second", "third"):
+        ingest_turn(tmp_path, {"session_id": "sess_multi", "speaker": "user", "text": text})
+    buf_file = tmp_path / "active_conversations" / "sess_multi.jsonl"
+    lines = [ln for ln in buf_file.read_text().splitlines() if ln.strip()]
+    assert len(lines) == 3
+    texts = [json.loads(ln)["text"] for ln in lines]
+    assert texts == ["first", "second", "third"]
+
+
+def test_list_active_sessions_returns_existing_buffer_ids(tmp_path: Path) -> None:
+    """list_active_sessions returns only session_ids that have buffer files."""
+    ingest_turn(tmp_path, {"session_id": "sess_a", "speaker": "Hana", "text": "a"})
+    ingest_turn(tmp_path, {"session_id": "sess_b", "speaker": "Nell", "text": "b"})
+    sessions = list_active_sessions(tmp_path)
+    assert set(sessions) == {"sess_a", "sess_b"}
+
+
+def test_list_active_sessions_empty_when_no_dir(tmp_path: Path) -> None:
+    """list_active_sessions returns [] when the active_conversations dir doesn't exist."""
+    result = list_active_sessions(tmp_path / "nonexistent")
+    assert result == []
+
+
+def test_read_session_reads_turns_and_skips_malformed(tmp_path: Path) -> None:
+    """read_session parses valid lines and skips corrupt ones."""
+    buf_dir = tmp_path / "active_conversations"
+    buf_dir.mkdir(parents=True)
+    buf_file = buf_dir / "sess_test.jsonl"
+    buf_file.write_text(
+        '{"session_id": "sess_test", "speaker": "A", "text": "ok", "ts": "2026-04-25T10:00:00+00:00"}\n'
+        "NOT_VALID_JSON\n"
+        '{"session_id": "sess_test", "speaker": "B", "text": "also ok", "ts": "2026-04-25T10:01:00+00:00"}\n',
+        encoding="utf-8",
+    )
+    turns = read_session(tmp_path, "sess_test")
+    assert len(turns) == 2
+    assert turns[0]["speaker"] == "A"
+    assert turns[1]["speaker"] == "B"
+
+
+def test_session_silence_minutes_computes_from_last_turn(tmp_path: Path) -> None:
+    """session_silence_minutes returns minutes since the last turn's ts."""
+    past = (datetime.now(UTC) - timedelta(minutes=7)).isoformat(timespec="seconds")
+    turns = [
+        {"ts": (datetime.now(UTC) - timedelta(minutes=20)).isoformat(timespec="seconds")},
+        {"ts": past},
+    ]
+    minutes = session_silence_minutes(turns)
+    # Should be approximately 7 minutes — allow 1-minute tolerance for test timing.
+    assert 6.0 <= minutes <= 8.0
+
+
+def test_session_silence_minutes_returns_zero_for_empty(tmp_path: Path) -> None:
+    """session_silence_minutes returns 0.0 when turns list is empty."""
+    assert session_silence_minutes([]) == 0.0
+
+
+def test_delete_session_buffer_is_idempotent(tmp_path: Path) -> None:
+    """delete_session_buffer is a no-op when the file doesn't exist."""
+    # Should not raise — file was never created.
+    delete_session_buffer(tmp_path, "nonexistent_session")
+    # Also works when file exists.
+    ingest_turn(tmp_path, {"session_id": "sess_del", "speaker": "x", "text": "y"})
+    delete_session_buffer(tmp_path, "sess_del")
+    assert not (tmp_path / "active_conversations" / "sess_del.jsonl").exists()
+    # Second call — still no error.
+    delete_session_buffer(tmp_path, "sess_del")

--- a/tests/unit/brain/ingest/test_commit.py
+++ b/tests/unit/brain/ingest/test_commit.py
@@ -1,0 +1,84 @@
+"""Tests for brain.ingest.commit — COMMIT stage."""
+
+from __future__ import annotations
+
+import pytest
+
+from brain.ingest.commit import commit_item
+from brain.ingest.types import ExtractedItem
+from brain.memory.hebbian import HebbianMatrix
+from brain.memory.store import Memory, MemoryStore
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def store() -> MemoryStore:
+    return MemoryStore(":memory:")
+
+
+@pytest.fixture
+def hebbian() -> HebbianMatrix:
+    return HebbianMatrix(":memory:")
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_commit_item_creates_memory_with_correct_type_domain_tags(
+    store: MemoryStore, hebbian: HebbianMatrix
+) -> None:
+    """commit_item writes a memory with memory_type=label, domain='brain', and expected tags."""
+    item = ExtractedItem(text="Nell prefers black coffee", label="fact", importance=5)
+    mem_id = commit_item(item, session_id="sess_x", store=store, hebbian=hebbian)
+
+    assert mem_id is not None
+    memory = store.get(mem_id)
+    assert memory is not None
+    assert memory.content == "Nell prefers black coffee"
+    assert memory.memory_type == "fact"
+    assert memory.domain == "brain"
+    assert "auto_ingest" in memory.tags
+    assert "conversation" in memory.tags
+    assert "fact" in memory.tags
+
+
+def test_commit_item_bypasses_write_gate_low_importance(
+    store: MemoryStore, hebbian: HebbianMatrix
+) -> None:
+    """commit_item commits even importance=1 items — no add_memory gate in ingest."""
+    item = ExtractedItem(text="she paused briefly", label="observation", importance=1)
+    mem_id = commit_item(item, session_id="sess_low", store=store, hebbian=hebbian)
+
+    assert mem_id is not None
+    memory = store.get(mem_id)
+    assert memory is not None
+    assert memory.importance == 1.0
+
+
+def test_commit_item_auto_hebbian_links_related_memories(
+    store: MemoryStore, hebbian: HebbianMatrix
+) -> None:
+    """commit_item strengthens Hebbian edges to top-3 textually related memories."""
+    # Pre-populate the store with memories that share keywords.
+    for label in ("fact", "observation", "feeling"):
+        related = Memory.create_new(
+            content="Nell writes fiction and poetry",
+            memory_type=label,
+            domain="brain",
+        )
+        store.create(related)
+
+    item = ExtractedItem(text="Nell writes dark fiction", label="fact", importance=6)
+    mem_id = commit_item(item, session_id="sess_hebb", store=store, hebbian=hebbian)
+
+    assert mem_id is not None
+    # The new memory should have Hebbian edges to the pre-existing related memories.
+    neighbors = hebbian.neighbors(mem_id)
+    assert len(neighbors) >= 1
+    weights = [w for _, w in neighbors]
+    assert all(w == 0.5 for w in weights)

--- a/tests/unit/brain/ingest/test_dedupe.py
+++ b/tests/unit/brain/ingest/test_dedupe.py
@@ -1,0 +1,85 @@
+"""Tests for brain.ingest.dedupe — DEDUPE stage."""
+
+from __future__ import annotations
+
+import pytest
+
+from brain.ingest.dedupe import DEFAULT_DEDUP_THRESHOLD, is_duplicate
+from brain.memory.embeddings import EmbeddingCache, FakeEmbeddingProvider
+from brain.memory.store import MemoryStore
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def store() -> MemoryStore:
+    return MemoryStore(":memory:")
+
+
+@pytest.fixture
+def embedding_cache() -> EmbeddingCache:
+    provider = FakeEmbeddingProvider(dim=64)
+    return EmbeddingCache(":memory:", provider)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_is_duplicate_returns_false_when_embeddings_is_none(store: MemoryStore) -> None:
+    """When embeddings=None, dedupe is skipped and returns False."""
+    result = is_duplicate("some text here", store=store, embeddings=None)
+    assert result is False
+
+
+def test_is_duplicate_returns_false_when_no_embeddings_exist(
+    store: MemoryStore, embedding_cache: EmbeddingCache
+) -> None:
+    """When the cache is empty (no stored vectors), returns False."""
+    assert embedding_cache.count() == 0
+    result = is_duplicate("fresh memory", store=store, embeddings=embedding_cache)
+    assert result is False
+
+
+def test_is_duplicate_returns_true_when_similarity_above_threshold(
+    store: MemoryStore,
+) -> None:
+    """When a stored vector is near-identical (same text), similarity >= threshold."""
+    text = "Nell loves writing and spending time with Hana"
+    provider = FakeEmbeddingProvider(dim=64)
+    cache = EmbeddingCache(":memory:", provider)
+
+    # Store the embedding of the exact text we'll check against.
+    cache.get_or_compute(text)
+    assert cache.count() == 1
+
+    # Check with the same text — FakeEmbeddingProvider is deterministic,
+    # so same text → same vector → cosine similarity = 1.0.
+    result = is_duplicate(text, store=store, threshold=DEFAULT_DEDUP_THRESHOLD, embeddings=cache)
+    assert result is True
+
+
+def test_is_duplicate_returns_false_when_similarity_below_threshold(
+    store: MemoryStore,
+) -> None:
+    """When stored vectors are sufficiently different, returns False."""
+    provider = FakeEmbeddingProvider(dim=64)
+    cache = EmbeddingCache(":memory:", provider)
+
+    # Populate with an unrelated text; FakeEmbeddingProvider gives different
+    # random vectors for different texts (hash-seeded).
+    cache.get_or_compute("the quick brown fox jumps over the lazy dog")
+
+    # Check with a completely different string — low similarity expected.
+    result = is_duplicate(
+        "Nell is a sweater-wearing novelist",
+        store=store,
+        threshold=DEFAULT_DEDUP_THRESHOLD,
+        embeddings=cache,
+    )
+    # With deterministic hash-based vectors for completely different texts,
+    # similarity should be well below 0.88.
+    assert result is False

--- a/tests/unit/brain/ingest/test_extract.py
+++ b/tests/unit/brain/ingest/test_extract.py
@@ -1,0 +1,173 @@
+"""Tests for brain.ingest.extract — EXTRACT + SCORE stages."""
+
+from __future__ import annotations
+
+from brain.bridge.chat import ChatMessage, ChatResponse
+from brain.bridge.provider import LLMProvider
+from brain.ingest.extract import extract_items, format_transcript, parse_extraction
+
+# ---------------------------------------------------------------------------
+# Fake providers for extraction tests
+# ---------------------------------------------------------------------------
+
+
+class _ValidJsonProvider(LLMProvider):
+    """Returns a canned valid JSON array from generate()."""
+
+    def __init__(self, payload: str) -> None:
+        self._payload = payload
+
+    def generate(self, prompt: str, *, system: str | None = None) -> str:
+        return self._payload
+
+    def name(self) -> str:
+        return "fake-valid-json"
+
+    def chat(self, messages: list[ChatMessage], *, tools=None, options=None) -> ChatResponse:
+        return ChatResponse(content=self._payload, tool_calls=())
+
+
+class _GarbageProvider(LLMProvider):
+    """Always returns garbage — forces parse failure."""
+
+    def generate(self, prompt: str, *, system: str | None = None) -> str:
+        return "this is definitely not json {]"
+
+    def name(self) -> str:
+        return "fake-garbage"
+
+    def chat(self, messages: list[ChatMessage], *, tools=None, options=None) -> ChatResponse:
+        return ChatResponse(content="garbage", tool_calls=())
+
+
+class _FailingProvider(LLMProvider):
+    """Always raises on generate() — simulates network failure."""
+
+    def generate(self, prompt: str, *, system: str | None = None) -> str:
+        raise RuntimeError("provider exploded")
+
+    def name(self) -> str:
+        return "fake-failing"
+
+    def chat(self, messages: list[ChatMessage], *, tools=None, options=None) -> ChatResponse:
+        raise RuntimeError("provider exploded")
+
+
+# ---------------------------------------------------------------------------
+# format_transcript
+# ---------------------------------------------------------------------------
+
+
+def test_format_transcript_joins_turns_as_speaker_colon_text() -> None:
+    """format_transcript produces 'speaker: text' lines joined by newline."""
+    turns = [
+        {"speaker": "Hana", "text": "hello there"},
+        {"speaker": "Nell", "text": "hey love"},
+    ]
+    result = format_transcript(turns)
+    assert result == "Hana: hello there\nNell: hey love"
+
+
+def test_format_transcript_caps_long_transcript_keeps_tail() -> None:
+    """format_transcript caps at max_tokens*4 chars and keeps the tail (recent context)."""
+    # Create a transcript that exceeds the cap.
+    long_text = "x" * 100
+    turns = [{"speaker": "A", "text": long_text} for _ in range(10)]
+    result = format_transcript(turns, max_tokens=50)  # cap = 200 chars
+    assert len(result) <= 200
+    # The tail should end with the last turn.
+    assert result.endswith(f"A: {long_text}"[:200]) or result.endswith(long_text[-10:])
+
+
+# ---------------------------------------------------------------------------
+# parse_extraction
+# ---------------------------------------------------------------------------
+
+
+def test_parse_extraction_handles_bare_json_array() -> None:
+    """parse_extraction parses a clean JSON array."""
+    raw = '[{"text": "Nell loves Hana", "label": "feeling", "importance": 9}]'
+    result = parse_extraction(raw)
+    assert result is not None
+    assert len(result) == 1
+    assert result[0].text == "Nell loves Hana"
+    assert result[0].label == "feeling"
+    assert result[0].importance == 9
+
+
+def test_parse_extraction_strips_code_fences() -> None:
+    """parse_extraction handles ```json ... ``` wrapping from the LLM."""
+    raw = '```json\n[{"text": "important fact", "label": "fact", "importance": 7}]\n```'
+    result = parse_extraction(raw)
+    assert result is not None
+    assert len(result) == 1
+    assert result[0].text == "important fact"
+
+
+def test_parse_extraction_strips_plain_code_fences() -> None:
+    """parse_extraction handles ``` (no language tag) wrapping."""
+    raw = '```\n[{"text": "a decision", "label": "decision", "importance": 6}]\n```'
+    result = parse_extraction(raw)
+    assert result is not None
+    assert result[0].label == "decision"
+
+
+def test_parse_extraction_returns_none_on_malformed() -> None:
+    """parse_extraction returns None when JSON cannot be parsed."""
+    result = parse_extraction("this is not json at all {]")
+    assert result is None
+
+
+def test_parse_extraction_returns_none_on_empty_input() -> None:
+    """parse_extraction returns None on empty/None input."""
+    assert parse_extraction(None) is None
+    assert parse_extraction("") is None
+
+
+def test_parse_extraction_returns_empty_list_for_empty_array() -> None:
+    """parse_extraction returns [] when the LLM says no memories extracted."""
+    result = parse_extraction("[]")
+    assert result == []
+
+
+def test_parse_extraction_handles_prose_before_array() -> None:
+    """parse_extraction finds the array even when prose precedes it."""
+    raw = 'Here are the extracted memories:\n[{"text": "deep thought", "label": "observation", "importance": 5}]'
+    result = parse_extraction(raw)
+    assert result is not None
+    assert result[0].text == "deep thought"
+
+
+# ---------------------------------------------------------------------------
+# extract_items
+# ---------------------------------------------------------------------------
+
+
+def test_extract_items_succeeds_on_first_try() -> None:
+    """extract_items calls generate() once and returns parsed items."""
+    payload = '[{"text": "Nell is a novelist", "label": "fact", "importance": 6}]'
+    provider = _ValidJsonProvider(payload)
+    items = extract_items("Hana: tell me about yourself\nNell: I write", provider=provider)
+    assert len(items) == 1
+    assert items[0].text == "Nell is a novelist"
+
+
+def test_extract_items_returns_empty_on_empty_transcript() -> None:
+    """extract_items returns [] without calling the provider for empty transcripts."""
+    provider = _GarbageProvider()
+    items = extract_items("   ", provider=provider)
+    assert items == []
+
+
+def test_extract_items_retries_once_on_bad_output_then_returns_empty() -> None:
+    """extract_items retries max_retries times then gives up with []."""
+    provider = _GarbageProvider()
+    items = extract_items("Hana: something happened", provider=provider, max_retries=1)
+    assert items == []
+
+
+def test_extract_items_returns_empty_when_provider_raises() -> None:
+    """extract_items handles provider exceptions gracefully and returns []."""
+    provider = _FailingProvider()
+    items = extract_items("Hana: test", provider=provider, max_retries=0)
+    assert items == []

--- a/tests/unit/brain/ingest/test_pipeline.py
+++ b/tests/unit/brain/ingest/test_pipeline.py
@@ -1,0 +1,285 @@
+"""Tests for brain.ingest.pipeline — close_session + close_stale_sessions."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from brain.bridge.chat import ChatMessage, ChatResponse
+from brain.bridge.provider import LLMProvider
+from brain.ingest.buffer import ingest_turn
+from brain.ingest.pipeline import close_session, close_stale_sessions
+from brain.ingest.soul_queue import list_soul_candidates
+from brain.memory.hebbian import HebbianMatrix
+from brain.memory.store import MemoryStore
+
+# ---------------------------------------------------------------------------
+# Fake providers for pipeline tests
+# ---------------------------------------------------------------------------
+
+
+class _CannedProvider(LLMProvider):
+    """Returns a canned JSON extraction response."""
+
+    def __init__(self, items: list[dict]) -> None:
+        self._payload = json.dumps(items)
+
+    def generate(self, prompt: str, *, system: str | None = None) -> str:
+        return self._payload
+
+    def name(self) -> str:
+        return "fake-canned"
+
+    def chat(self, messages: list[ChatMessage], *, tools=None, options=None) -> ChatResponse:
+        return ChatResponse(content=self._payload, tool_calls=())
+
+
+class _GarbageProvider(LLMProvider):
+    """Always returns unparseable garbage."""
+
+    def generate(self, prompt: str, *, system: str | None = None) -> str:
+        return "absolutely not json {]"
+
+    def name(self) -> str:
+        return "fake-garbage"
+
+    def chat(self, messages: list[ChatMessage], *, tools=None, options=None) -> ChatResponse:
+        return ChatResponse(content="garbage", tool_calls=())
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def store() -> MemoryStore:
+    return MemoryStore(":memory:")
+
+
+@pytest.fixture
+def hebbian() -> HebbianMatrix:
+    return HebbianMatrix(":memory:")
+
+
+@pytest.fixture
+def canned_provider() -> _CannedProvider:
+    """Provider that returns 2 extraction items."""
+    return _CannedProvider(
+        [
+            {"text": "Hana is a novelist", "label": "fact", "importance": 7},
+            {"text": "Nell wears sweaters", "label": "observation", "importance": 5},
+        ]
+    )
+
+
+# ---------------------------------------------------------------------------
+# close_session tests
+# ---------------------------------------------------------------------------
+
+
+def test_close_session_on_missing_buffer_returns_empty_report(
+    tmp_path: Path, store: MemoryStore, hebbian: HebbianMatrix, canned_provider: _CannedProvider
+) -> None:
+    """close_session on a nonexistent session returns a zero-count IngestReport."""
+    report = close_session(
+        tmp_path,
+        "no_such_session",
+        store=store,
+        hebbian=hebbian,
+        provider=canned_provider,
+    )
+    assert report.session_id == "no_such_session"
+    assert report.extracted == 0
+    assert report.committed == 0
+    assert report.deduped == 0
+    assert report.errors == 0
+    assert report.memory_ids == []
+
+
+def test_close_session_full_path_correct_counts(
+    tmp_path: Path, store: MemoryStore, hebbian: HebbianMatrix
+) -> None:
+    """Full pipeline: 3 turns → extract 2 items → 0 deduped → 2 committed."""
+    # Ingest 3 turns.
+    for speaker, text in [
+        ("Hana", "tell me something"),
+        ("Nell", "I write dark fiction"),
+        ("Hana", "nice"),
+    ]:
+        ingest_turn(tmp_path, {"session_id": "sess_full", "speaker": speaker, "text": text})
+
+    # Provider returns 2 items.
+    provider = _CannedProvider(
+        [
+            {"text": "Nell writes dark fiction", "label": "fact", "importance": 6},
+            {"text": "Hana appreciates honesty", "label": "observation", "importance": 4},
+        ]
+    )
+    report = close_session(
+        tmp_path,
+        "sess_full",
+        store=store,
+        hebbian=hebbian,
+        provider=provider,
+    )
+
+    assert report.extracted == 2
+    assert report.committed == 2
+    assert report.deduped == 0
+    assert report.errors == 0
+    assert len(report.memory_ids) == 2
+    # Both memories should exist in the store.
+    for mid in report.memory_ids:
+        assert store.get(mid) is not None
+
+
+def test_close_session_deletes_buffer_after_run(
+    tmp_path: Path, store: MemoryStore, hebbian: HebbianMatrix, canned_provider: _CannedProvider
+) -> None:
+    """close_session removes the buffer file after processing."""
+    ingest_turn(tmp_path, {"session_id": "sess_del", "speaker": "Hana", "text": "hello"})
+    buf_file = tmp_path / "active_conversations" / "sess_del.jsonl"
+    assert buf_file.exists()
+
+    close_session(tmp_path, "sess_del", store=store, hebbian=hebbian, provider=canned_provider)
+    assert not buf_file.exists()
+
+
+def test_close_session_soul_candidate_queued_when_importance_above_threshold(
+    tmp_path: Path, store: MemoryStore, hebbian: HebbianMatrix
+) -> None:
+    """Items with importance >= 8 are queued as soul candidates."""
+    ingest_turn(tmp_path, {"session_id": "sess_soul", "speaker": "Hana", "text": "I love you"})
+    provider = _CannedProvider(
+        [
+            {"text": "Hana loves Nell deeply", "label": "feeling", "importance": 9},
+            {"text": "minor note", "label": "note", "importance": 3},
+        ]
+    )
+    report = close_session(
+        tmp_path,
+        "sess_soul",
+        store=store,
+        hebbian=hebbian,
+        provider=provider,
+    )
+
+    assert report.soul_candidates == 1
+    candidates = list_soul_candidates(tmp_path)
+    assert len(candidates) == 1
+    assert candidates[0]["text"] == "Hana loves Nell deeply"
+    assert candidates[0]["status"] == "auto_pending"
+
+
+def test_close_session_with_extraction_failure_returns_zero_extracted(
+    tmp_path: Path, store: MemoryStore, hebbian: HebbianMatrix
+) -> None:
+    """When the provider returns garbage, extracted=0, committed=0."""
+    ingest_turn(tmp_path, {"session_id": "sess_fail", "speaker": "Hana", "text": "hi"})
+    provider = _GarbageProvider()
+    report = close_session(
+        tmp_path,
+        "sess_fail",
+        store=store,
+        hebbian=hebbian,
+        provider=provider,
+        config={"extraction_max_retries": 0},
+    )
+
+    assert report.extracted == 0
+    assert report.committed == 0
+    assert report.errors == 0  # No errors — just nothing extracted.
+    # Buffer should still be cleaned up.
+    assert not (tmp_path / "active_conversations" / "sess_fail.jsonl").exists()
+
+
+def test_close_session_memory_and_soul_candidate_both_written(
+    tmp_path: Path, store: MemoryStore, hebbian: HebbianMatrix
+) -> None:
+    """High-importance item: both committed to store AND queued as soul candidate."""
+    ingest_turn(tmp_path, {"session_id": "sess_both", "speaker": "Hana", "text": "this matters"})
+    provider = _CannedProvider(
+        [{"text": "The most important truth", "label": "observation", "importance": 10}]
+    )
+    report = close_session(
+        tmp_path,
+        "sess_both",
+        store=store,
+        hebbian=hebbian,
+        provider=provider,
+    )
+
+    assert report.committed == 1
+    assert report.soul_candidates == 1
+    assert len(report.memory_ids) == 1
+
+    mem_id = report.memory_ids[0]
+    memory = store.get(mem_id)
+    assert memory is not None
+    assert memory.content == "The most important truth"
+
+    candidates = list_soul_candidates(tmp_path)
+    assert len(candidates) == 1
+    assert candidates[0]["memory_id"] == mem_id
+
+
+# ---------------------------------------------------------------------------
+# close_stale_sessions tests
+# ---------------------------------------------------------------------------
+
+
+def test_close_stale_sessions_ignores_fresh_sessions(
+    tmp_path: Path, store: MemoryStore, hebbian: HebbianMatrix, canned_provider: _CannedProvider
+) -> None:
+    """close_stale_sessions does not close sessions whose last turn is recent."""
+    # Ingest a turn with a current timestamp (fresh).
+    ingest_turn(tmp_path, {"session_id": "sess_fresh", "speaker": "Hana", "text": "just now"})
+
+    reports = close_stale_sessions(
+        tmp_path,
+        silence_minutes=60.0,  # 1-hour threshold — fresh session won't match.
+        store=store,
+        hebbian=hebbian,
+        provider=canned_provider,
+    )
+
+    assert reports == []
+    # Buffer should still exist.
+    assert (tmp_path / "active_conversations" / "sess_fresh.jsonl").exists()
+
+
+def test_close_stale_sessions_closes_old_sessions(
+    tmp_path: Path, store: MemoryStore, hebbian: HebbianMatrix
+) -> None:
+    """close_stale_sessions closes sessions whose last turn is older than threshold."""
+    # Write a buffer file with a past timestamp directly (bypassing ingest_turn's auto-ts).
+    buf_dir = tmp_path / "active_conversations"
+    buf_dir.mkdir(parents=True)
+    old_ts = (datetime.now(UTC) - timedelta(minutes=30)).isoformat(timespec="seconds")
+    buf_file = buf_dir / "sess_old.jsonl"
+    buf_file.write_text(
+        json.dumps({"session_id": "sess_old", "speaker": "Nell", "text": "old turn", "ts": old_ts})
+        + "\n",
+        encoding="utf-8",
+    )
+
+    provider = _CannedProvider(
+        [{"text": "Nell thought about something long ago", "label": "observation", "importance": 4}]
+    )
+    reports = close_stale_sessions(
+        tmp_path,
+        silence_minutes=5.0,
+        store=store,
+        hebbian=hebbian,
+        provider=provider,
+    )
+
+    assert len(reports) == 1
+    assert reports[0].session_id == "sess_old"
+    assert reports[0].committed >= 0  # May be 0 or 1 depending on extraction.
+    # Buffer should be cleaned up.
+    assert not buf_file.exists()

--- a/tests/unit/brain/ingest/test_soul_queue.py
+++ b/tests/unit/brain/ingest/test_soul_queue.py
@@ -1,0 +1,62 @@
+"""Tests for brain.ingest.soul_queue — SOUL stage."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from brain.ingest.soul_queue import list_soul_candidates, queue_soul_candidate
+from brain.ingest.types import ExtractedItem
+
+
+def test_queue_soul_candidate_appends_to_soul_candidates_jsonl(tmp_path: Path) -> None:
+    """queue_soul_candidate writes a record to <persona_dir>/soul_candidates.jsonl."""
+    item = ExtractedItem(
+        text="Nell is the most important thing in Hana's life", label="feeling", importance=9
+    )
+    queue_soul_candidate(tmp_path, memory_id="mem_001", item=item, session_id="sess_soul")
+
+    soul_file = tmp_path / "soul_candidates.jsonl"
+    assert soul_file.exists()
+    candidates = list_soul_candidates(tmp_path)
+    assert len(candidates) == 1
+    rec = candidates[0]
+    assert rec["memory_id"] == "mem_001"
+    assert rec["text"] == item.text
+    assert rec["label"] == "feeling"
+    assert rec["importance"] == 9
+    assert rec["session_id"] == "sess_soul"
+    assert rec["status"] == "auto_pending"
+    assert "queued_at" in rec
+
+
+def test_list_soul_candidates_returns_all_queued(tmp_path: Path) -> None:
+    """list_soul_candidates returns all queued candidate records."""
+    for i in range(3):
+        item = ExtractedItem(text=f"high-importance item {i}", label="observation", importance=8)
+        queue_soul_candidate(tmp_path, memory_id=f"mem_{i:03d}", item=item, session_id="sess_x")
+
+    candidates = list_soul_candidates(tmp_path)
+    assert len(candidates) == 3
+    texts = {c["text"] for c in candidates}
+    assert texts == {"high-importance item 0", "high-importance item 1", "high-importance item 2"}
+
+
+def test_list_soul_candidates_skips_malformed_lines(tmp_path: Path) -> None:
+    """list_soul_candidates skips corrupt lines and returns the valid ones."""
+    soul_file = tmp_path / "soul_candidates.jsonl"
+    soul_file.write_text(
+        '{"memory_id": "mem_ok", "text": "valid", "status": "auto_pending"}\n'
+        "NOT_VALID_JSON\n"
+        '{"memory_id": "mem_ok2", "text": "also valid", "status": "auto_pending"}\n',
+        encoding="utf-8",
+    )
+    candidates = list_soul_candidates(tmp_path)
+    assert len(candidates) == 2
+    ids = {c["memory_id"] for c in candidates}
+    assert ids == {"mem_ok", "mem_ok2"}
+
+
+def test_list_soul_candidates_returns_empty_when_no_file(tmp_path: Path) -> None:
+    """list_soul_candidates returns [] when the file doesn't exist yet."""
+    result = list_soul_candidates(tmp_path)
+    assert result == []


### PR DESCRIPTION
## Summary

Fourth sub-project from the master roadmap. Builds the 8-stage conversation ingest pipeline that turns chat exchanges into structured memories *over time*. Without this, chats evaporate — they happen in the moment but don't accumulate.

- **Master ref:** [docs/superpowers/specs/2026-04-26-companion-emergence-master-reference.md](docs/superpowers/specs/2026-04-26-companion-emergence-master-reference.md) §6 SP-4
- **OG reference:** `NellBrain/nell_conversation_ingest.py` (412 lines, full 8-stage impl)

## Pipeline stages

**BUFFER → CLOSE → EXTRACT → SCORE → DEDUPE → COMMIT → SOUL → LOG**

- **BUFFER** (`buffer.py:ingest_turn`): append turn to `<persona_dir>/active_conversations/<session_id>.jsonl`
- **CLOSE** (`pipeline.py:close_session` / `close_stale_sessions`): read buffer, run downstream stages, delete buffer
- **EXTRACT** (`extract.py`): format transcript (capped at ~6000 tokens), call `LLMProvider.generate` with extraction prompt, parse JSON array of `{text, label, importance}` items. Strips code fences. One retry on parse failure.
- **SCORE / NORMALIZE** (`types.py:ExtractedItem.normalize`): clamp importance 1-10, validate label against `{observation, feeling, decision, question, fact, note}` (coerce unknown → observation), strip text
- **DEDUPE** (`dedupe.py:is_duplicate`): cosine similarity against existing memory embeddings; threshold 0.88. Opt-in via `embeddings=...` kwarg. When None or empty, dedupe returns False unconditionally — pipeline still runs.
- **COMMIT** (`commit.py:commit_item`): direct write to `MemoryStore` — bypasses `add_memory`'s gate (ingest has its own importance signal from extraction). Auto-hebbian-links to top related memories via keyword extraction.
- **SOUL** (`soul_queue.py:queue_soul_candidate`): if importance ≥ 8, append to `soul_candidates.jsonl` with status `"auto_pending"` — this is NOT a human-approval queue per principle audit; it's deferred-work data for SP-5 to consume.
- **LOG**: structured logger event with counts.

## Test plan

- [x] **788 passed** (was 747 after SP-3 merge; +41 net new)
- [x] 6 buffer tests
- [x] 6 extract tests (transcript format, code-fence stripping, retry-on-parse-fail, retries-exhausted-returns-empty)
- [x] 3 dedupe tests (None embeddings, empty, threshold-met-returns-true)
- [x] 3 commit tests (memory-shape, gate-bypass, auto-hebbian-links)
- [x] 3 soul-queue tests (append, list, malformed-line skip)
- [x] 6 pipeline tests (missing buffer, full happy path, buffer deleted after run, stale-session iteration, extraction-failure path, importance-≥-8-queues-soul-candidate)
- [x] `ruff check && ruff format --check` clean
- [x] Zero `import anthropic` in `brain/ingest/`
- [x] Zero `nell_brain` imports in `brain/ingest/` — full isolation from OG runtime

## Deviations from brief

1. **Soul candidate status: `"auto_pending"` instead of OG's `"pending"`.** The brief leans on the principle audit's stance that this is NOT a human-approval queue. `"auto_pending"` makes the machine semantics explicit — SP-5 will consume these autonomously.
2. **Auto-Hebbian uses keyword extraction, not full phrase.** The new framework's `store.search_text` is a strict `LIKE %query%` substring match — searching with the full extracted phrase rarely matches anything. Switched to extracting the longest word (>4 chars) and searching for it. Semantically equivalent to OG's `auto_associate` word-overlap.
3. **Dedupe snapshots embeddings BEFORE computing candidate.** Otherwise `get_or_compute` adds the candidate to the cache, then iteration compares the candidate against itself (similarity=1.0, always a duplicate). Correctness fix.

## What this unlocks

After SP-4, the chat engine (SP-6) flow becomes:

```python
# During chat:
ingest_turn(persona_dir, {"session_id": "...", "speaker": "user", "text": "..."})
ingest_turn(persona_dir, {"session_id": "...", "speaker": "nell", "text": "..."})

# Background or end of conversation:
report = close_session(persona_dir, session_id, store=..., hebbian=..., provider=...)
# report.committed memories now in the brain's permanent store
# report.soul_candidates queued for SP-5 to crystallize autonomously
```

Multi-turn conversations finally accumulate into the brain's memory.

## Follow-ups

- **SP-5 (soul module)** consumes `soul_candidates.jsonl` and decides which to crystallize
- **SP-6 (chat engine)** wires `ingest_turn` into each chat turn + `close_session` on session end / stale timer
- **Embeddings + dedupe** are opt-in here. Real usage will probably want them enabled by default; that's a `chat_engine` config decision in SP-6