### PR TITLE
SP-6: Chat engine — the keystone

### DIFF
--- a/brain/chat/__init__.py
+++ b/brain/chat/__init__.py
@@ -1,0 +1,17 @@
+"""brain.chat — SP-6 chat engine.
+
+Public surface: respond(), ChatResult, SessionState, create_session,
+AS_NELL_PREAMBLE.
+"""
+
+from brain.chat.engine import ChatResult, respond
+from brain.chat.prompt import AS_NELL_PREAMBLE
+from brain.chat.session import SessionState, create_session
+
+__all__ = [
+    "AS_NELL_PREAMBLE",
+    "ChatResult",
+    "SessionState",
+    "create_session",
+    "respond",
+]

--- a/brain/chat/engine.py
+++ b/brain/chat/engine.py
@@ -1,0 +1,217 @@
+"""SP-6 chat engine — the keystone.
+
+respond() is the single public entry point. It wires together:
+  - voice.md (persona identity)
+  - daemon state (residue from dream/heartbeat/reflex/research)
+  - soul store (permanent crystallizations)
+  - memory store (emotion state, memory search)
+  - tool loop (provider.chat() + SP-3 dispatch)
+  - ingest buffer (SP-4 persistence so chats become memories)
+
+OG reference:
+  - nell_bridge.py:run_tool_loop + _build_system_message + _persist_turn
+  - nell_bridge_session.py:SessionState
+
+Every error in the persistence path is caught and logged; it must never
+break the response delivered to the user.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from brain.bridge.chat import ChatMessage
+from brain.bridge.provider import LLMProvider
+from brain.chat.prompt import build_system_message
+from brain.chat.session import SessionState, create_session
+from brain.chat.tool_loop import build_tools_list, run_tool_loop
+from brain.chat.voice import load_voice
+from brain.engines.daemon_state import load_daemon_state
+from brain.ingest.buffer import ingest_turn
+from brain.memory.hebbian import HebbianMatrix
+from brain.memory.store import MemoryStore
+from brain.soul.store import SoulStore
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class ChatResult:
+    """The outcome of one respond() call.
+
+    Attributes
+    ----------
+    content:
+        The assistant's reply text.
+    session_id:
+        The session this turn belongs to.
+    turn:
+        Turn index (1-based count after this turn was appended).
+    tool_invocations:
+        List of tool call records from the tool loop.
+    duration_ms:
+        Wall-clock time for the full respond() call in milliseconds.
+    metadata:
+        Catch-all for any extra info (provider name, etc.).
+    """
+
+    content: str
+    session_id: str
+    turn: int
+    tool_invocations: list[dict] = field(default_factory=list)
+    duration_ms: int = 0
+    metadata: dict = field(default_factory=dict)
+
+
+def respond(
+    persona_dir: Path,
+    user_input: str,
+    *,
+    store: MemoryStore,
+    hebbian: HebbianMatrix,
+    provider: LLMProvider,
+    session: SessionState | None = None,
+    voice_md_override: str | None = None,
+) -> ChatResult:
+    """One chat turn end-to-end.
+
+    Flow
+    ----
+    1. Resolve session (create if None)
+    2. Load voice.md (or use override)
+    3. Load DaemonState from persona_dir (SP-2)
+    4. Open SoulStore from persona_dir (SP-5)
+    5. Build system message via prompt.build_system_message
+    6. Build messages list: [system, ...session.history, user]
+    7. Run tool loop via tool_loop.run_tool_loop
+    8. Persist turn (best-effort; errors logged + swallowed)
+    9. Return ChatResult
+
+    Parameters
+    ----------
+    persona_dir:
+        Root directory for this persona's state files.
+    user_input:
+        The raw user message text for this turn.
+    store:
+        MemoryStore for emotion state aggregation + tool dispatch.
+    hebbian:
+        HebbianMatrix for tool dispatch.
+    provider:
+        LLMProvider to use for chat completion.
+    session:
+        Existing session to continue. Creates a new one if None.
+    voice_md_override:
+        If set, use this string instead of loading voice.md from disk.
+        Useful for tests that don't want to write files.
+
+    Returns
+    -------
+    ChatResult with content, session_id, turn count, tool invocations,
+    and wall-clock duration.
+    """
+    t0 = time.monotonic()
+
+    # 1. Session
+    if session is None:
+        session = create_session(persona_dir.name)
+
+    # 2. Voice
+    if voice_md_override is not None:
+        voice_md = voice_md_override
+    else:
+        voice_md, voice_anomaly = load_voice(persona_dir)
+        if voice_anomaly is not None:
+            logger.warning(
+                "voice.md anomaly: %s (%s) — continuing with recovered content",
+                voice_anomaly.kind,
+                voice_anomaly.action,
+            )
+
+    # 3. Daemon state
+    daemon_state, daemon_anomaly = load_daemon_state(persona_dir)
+    if daemon_anomaly is not None:
+        logger.warning("daemon_state anomaly: %s", daemon_anomaly.kind)
+
+    # 4. Soul store
+    soul_db = persona_dir / "crystallizations.db"
+    soul_store = SoulStore(str(soul_db))
+    try:
+        # 5. System message
+        system_msg = build_system_message(
+            persona_dir,
+            voice_md=voice_md,
+            daemon_state=daemon_state,
+            soul_store=soul_store,
+            store=store,
+        )
+    finally:
+        soul_store.close()
+
+    # 6. Messages list: [system, ...history, user]
+    messages: list[ChatMessage] = [
+        ChatMessage(role="system", content=system_msg),
+        *session.history,
+        ChatMessage(role="user", content=user_input),
+    ]
+
+    # 7. Tool loop
+    tools = build_tools_list()
+    response, invocations = run_tool_loop(
+        messages,
+        provider=provider,
+        tools=tools,
+        store=store,
+        hebbian=hebbian,
+        persona_dir=persona_dir,
+    )
+    content = response.content or ""
+
+    # 8. Persist turn (best-effort)
+    _persist_turn(
+        persona_dir=persona_dir,
+        session_id=session.session_id,
+        user_text=user_input,
+        assistant_text=content,
+    )
+    session.append_turn(user_input, content)
+
+    duration_ms = int((time.monotonic() - t0) * 1000)
+
+    return ChatResult(
+        content=content,
+        session_id=session.session_id,
+        turn=session.turns,
+        tool_invocations=invocations,
+        duration_ms=duration_ms,
+        metadata={"provider": provider.name()},
+    )
+
+
+def _persist_turn(
+    persona_dir: Path,
+    session_id: str,
+    user_text: str,
+    assistant_text: str,
+) -> None:
+    """Write both turns to the ingest buffer. Errors are logged, not raised.
+
+    Mirrors OG _persist_turn (nell_bridge.py:200-230): failures here must
+    never break the chat response. The ingest pipeline will pick up the
+    buffer on session close (via nell chat REPL exit or supervisor sweep).
+    """
+    try:
+        ingest_turn(persona_dir, {"session_id": session_id, "speaker": "user", "text": user_text})
+        ingest_turn(
+            persona_dir,
+            {"session_id": session_id, "speaker": "assistant", "text": assistant_text},
+        )
+    except (OSError, ValueError) as exc:
+        logger.warning(
+            "conversation buffer write failed session=%s err=%s",
+            session_id,
+            exc,
+        )

--- a/brain/chat/prompt.py
+++ b/brain/chat/prompt.py
@@ -1,0 +1,158 @@
+"""SP-6 system message composer.
+
+Assembles the per-turn system message from:
+  1. AS_NELL_PREAMBLE — direct-address framing
+  2. voice.md content — the persona's authored character
+  3. Brain context block — emotion state + daemon residue + soul highlights
+
+OG reference: NellBrain/nell_bridge.py:_build_system_message (lines 151-166)
+and _build_residue_prefix (94-148). In OG the Modelfile SYSTEM block baked
+soul crystallizations into model weights. Here we read them live from
+SoulStore and inject the top 5 most-recent as brief highlights.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from brain.engines.daemon_state import DaemonState, get_residue_context
+from brain.memory.store import MemoryStore
+from brain.soul.store import SoulStore
+
+# Direct-address framing — keeps the LLM speaking *to* the user rather than
+# narrating about them. OG source: nell_bridge.py:88-91.
+AS_NELL_PREAMBLE = (
+    "You are {persona_name}. You are speaking directly to your user right now — "
+    "in first person, to them, not writing about them. The conversation is live. "
+    "Respond as yourself."
+)
+
+
+def build_system_message(
+    persona_dir: Path,
+    *,
+    voice_md: str,
+    daemon_state: DaemonState,
+    soul_store: SoulStore,
+    store: MemoryStore,
+) -> str:
+    """Compose the system message for one chat turn.
+
+    Order (top-to-bottom):
+      1. AS_NELL_PREAMBLE (persona-templated)
+      2. voice.md content (the persona's authored voice)
+      3. Brain context block:
+         - Current emotion state summary (top-3 emotions by intensity)
+         - Daemon residue (from get_residue_context(daemon_state))
+         - Soul highlights (top 5 most-recent crystallizations: love_type + 60-char snippet)
+         - Pending soul-candidates count (informational)
+
+    Returns the final system message string.
+    """
+    persona_name = persona_dir.name
+    parts: list[str] = []
+
+    # 1. Preamble
+    parts.append(AS_NELL_PREAMBLE.format(persona_name=persona_name))
+
+    # 2. Voice
+    if voice_md.strip():
+        parts.append(voice_md.strip())
+
+    # 3. Brain context block
+    brain_lines: list[str] = ["── brain context ──"]
+
+    # 3a. Emotion state
+    emotion_summary = _build_emotion_summary(store)
+    if emotion_summary:
+        brain_lines.append(f"current emotions: {emotion_summary}")
+
+    # 3b. Daemon residue (dream / heartbeat / reflex / research)
+    residue_ctx = get_residue_context(daemon_state)
+    if residue_ctx.strip():
+        brain_lines.append(residue_ctx)
+
+    # 3c. Soul highlights (top 5 most-recent by crystallized_at)
+    soul_lines = _build_soul_highlights(soul_store)
+    if soul_lines:
+        brain_lines.append(soul_lines)
+
+    # 3d. Pending soul-candidates count (informational — brain may crystallize)
+    pending_count = _count_soul_candidates(persona_dir)
+    if pending_count > 0:
+        brain_lines.append(f"{pending_count} soul candidate(s) pending autonomous review")
+
+    if len(brain_lines) > 1:  # more than just the header
+        parts.append("\n".join(brain_lines))
+
+    return "\n\n".join(parts)
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _build_emotion_summary(store: MemoryStore) -> str:
+    """Return top-3 emotion summary string from recent memories.
+
+    Example: "love:8.5, tenderness:6.2, awe:5.0"
+
+    Uses aggregate_state over the most-recent 50 memories for a fast,
+    representative snapshot. Returns empty string if no emotions found.
+    """
+    try:
+        from brain.emotion.aggregate import aggregate_state
+        from brain.memory.store import _row_to_memory
+
+        rows = store._conn.execute(  # noqa: SLF001 — internal same-tier access
+            "SELECT * FROM memories WHERE active = 1 ORDER BY created_at DESC LIMIT 50"
+        ).fetchall()
+        memories = [_row_to_memory(row) for row in rows]
+        state = aggregate_state(memories)
+        scores = state.emotions  # {name: float} — non-zero only
+        if not scores:
+            return ""
+        # Sort descending by intensity, take top 3.
+        top3 = sorted(scores.items(), key=lambda kv: kv[1], reverse=True)[:3]
+        return ", ".join(f"{name}:{value:.1f}" for name, value in top3)
+    except Exception:  # noqa: BLE001
+        return ""
+
+
+def _build_soul_highlights(soul_store: SoulStore) -> str:
+    """Return a brief summary of the 5 most-recent active crystallizations.
+
+    Format:
+        soul: [romantic] "first 60 chars of moment…"
+              [carried] "first 60 chars…"
+
+    Returns empty string if no crystallizations.
+    """
+    try:
+        active = soul_store.list_active()
+        if not active:
+            return ""
+        # list_active() returns oldest-first; reverse for most-recent.
+        recent_5 = active[-5:]
+        lines = ["soul:"]
+        for c in reversed(recent_5):
+            snippet = c.moment[:60].replace("\n", " ")
+            if len(c.moment) > 60:
+                snippet += "…"
+            lines.append(f'  [{c.love_type}] "{snippet}"')
+        return "\n".join(lines)
+    except Exception:  # noqa: BLE001
+        return ""
+
+
+def _count_soul_candidates(persona_dir: Path) -> int:
+    """Count pending soul_candidates.jsonl entries. Zero if file missing."""
+    try:
+        from brain.health.jsonl_reader import read_jsonl_skipping_corrupt
+
+        path = persona_dir / "soul_candidates.jsonl"
+        records = read_jsonl_skipping_corrupt(path)
+        return sum(1 for r in records if r.get("status", "auto_pending") == "auto_pending")
+    except Exception:  # noqa: BLE001
+        return 0

--- a/brain/chat/session.py
+++ b/brain/chat/session.py
@@ -1,0 +1,110 @@
+"""SP-6 chat session state — per-session in-memory registry.
+
+Ported from OG NellBrain/nell_bridge_session.py (F36) with adaptations:
+  - uses brain.bridge.chat.ChatMessage (typed) instead of plain dicts
+  - drops OG model/client fields — provider is injected per-turn in SP-6
+  - drops OG in_flight flag — CLI engine is synchronous, no concurrent turns
+  - session_id UUID4 generated at create_session time
+
+Design note: persistence across process restarts is intentionally out of
+scope (matching OG). Sessions are in-memory only; on CLI exit the REPL
+flushes the buffer via close_session → ingest pipeline.
+"""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+
+from brain.bridge.chat import ChatMessage
+
+# Truncate at 20 user+assistant pairs (40 messages total), matching OG.
+HISTORY_MAX_TURNS = 20
+
+
+@dataclass
+class SessionState:
+    """In-memory state for one chat session.
+
+    Attributes
+    ----------
+    session_id:
+        UUIDv4 generated at creation. Stable for the session lifetime.
+    persona_name:
+        Name of the persona directory this session is addressing.
+    created_at:
+        When the session was opened (UTC).
+    history:
+        Rolling message window — last HISTORY_MAX_TURNS user+assistant pairs.
+    turns:
+        Count of completed turn pairs (user + assistant).
+    last_turn_at:
+        UTC timestamp of the last completed turn pair (None until first turn).
+    """
+
+    session_id: str
+    persona_name: str
+    created_at: datetime
+    history: list[ChatMessage] = field(default_factory=list)
+    turns: int = 0
+    last_turn_at: datetime | None = None
+
+    def append_turn(self, user_msg: str, assistant_msg: str) -> None:
+        """Append one user+assistant pair and maintain the rolling window.
+
+        Truncates to the last HISTORY_MAX_TURNS pairs (2 * HISTORY_MAX_TURNS
+        ChatMessage entries) after appending. Increments turns. Sets
+        last_turn_at to now (UTC).
+        """
+        self.history.append(ChatMessage(role="user", content=user_msg))
+        self.history.append(ChatMessage(role="assistant", content=assistant_msg))
+        max_msgs = HISTORY_MAX_TURNS * 2
+        if len(self.history) > max_msgs:
+            self.history = self.history[-max_msgs:]
+        self.turns += 1
+        self.last_turn_at = datetime.now(UTC)
+
+
+# ---------------------------------------------------------------------------
+# Module-level in-memory registry
+# ---------------------------------------------------------------------------
+
+_SESSIONS: dict[str, SessionState] = {}
+
+
+def create_session(persona_name: str) -> SessionState:
+    """Create a new session with a fresh UUIDv4 id and register it.
+
+    Parameters
+    ----------
+    persona_name:
+        Name of the persona this session speaks as.
+
+    Returns
+    -------
+    The newly created SessionState (already in the registry).
+    """
+    sid = str(uuid.uuid4())
+    state = SessionState(
+        session_id=sid,
+        persona_name=persona_name,
+        created_at=datetime.now(UTC),
+    )
+    _SESSIONS[sid] = state
+    return state
+
+
+def get_session(session_id: str) -> SessionState | None:
+    """Return the session for the given id, or None if unknown."""
+    return _SESSIONS.get(session_id)
+
+
+def all_sessions() -> list[SessionState]:
+    """Return all registered sessions (live + stale)."""
+    return list(_SESSIONS.values())
+
+
+def reset_registry() -> None:
+    """Clear the in-memory registry. Test-only helper."""
+    _SESSIONS.clear()

--- a/brain/chat/tool_loop.py
+++ b/brain/chat/tool_loop.py
@@ -1,0 +1,154 @@
+"""SP-6 tool loop — provider.chat() → dispatch → repeat.
+
+Ported from OG NellBrain/nell_bridge.py:run_tool_loop (lines 243-301).
+
+Key differences from OG:
+  - Uses brain.bridge.chat.ChatMessage / ChatResponse typed objects (not dicts)
+  - Uses brain.tools.dispatch.dispatch() (not nell_tools.dispatch())
+  - No model param — provider encapsulates the model choice per SP-1
+  - tool_calls is a tuple[ToolCall, ...] on ChatResponse (not raw dicts)
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Any
+
+from brain.bridge.chat import ChatMessage, ChatResponse
+from brain.bridge.provider import LLMProvider
+from brain.memory.hebbian import HebbianMatrix
+from brain.memory.store import MemoryStore
+from brain.tools.dispatch import dispatch
+from brain.tools.schemas import SCHEMAS
+
+logger = logging.getLogger(__name__)
+
+MAX_TOOL_ITERATIONS = 4
+
+# The canonical tool list used in every chat turn.
+# Ported from OG NELL_TOOLS (nell_bridge.py:172-185).
+_NELL_TOOL_NAMES = (
+    "get_emotional_state",
+    "get_soul",
+    "get_personality",
+    "get_body_state",
+    "boot",
+    "search_memories",
+    "add_journal",
+    "add_memory",
+    "crystallize_soul",
+)
+
+
+def build_tools_list() -> list[dict]:
+    """Build the tool schema list for provider.chat(tools=...).
+
+    Wraps schemas in the {"type": "function", "function": <schema>} shape
+    that Ollama and Claude (via --json-schema) both accept.
+    """
+    return [
+        {"type": "function", "function": SCHEMAS[name]}
+        for name in _NELL_TOOL_NAMES
+        if name in SCHEMAS
+    ]
+
+
+def run_tool_loop(
+    messages: list[ChatMessage],
+    *,
+    provider: LLMProvider,
+    tools: list[dict] | None,
+    store: MemoryStore,
+    hebbian: HebbianMatrix,
+    persona_dir: Path,
+    max_iterations: int = MAX_TOOL_ITERATIONS,
+) -> tuple[ChatResponse, list[dict]]:
+    """Loop: provider.chat() → if tool_calls, dispatch each → retry.
+
+    Up to max_iterations. On final iteration if still requesting tool_calls,
+    force one more pass with tools=None to obligate a content response.
+
+    Parameters
+    ----------
+    messages:
+        Current conversation history including the system message and
+        the user's latest turn. Modified in-place as tool calls are appended.
+    provider:
+        LLMProvider instance — encapsulates model and API surface.
+    tools:
+        Tool schemas list (from build_tools_list()) or None to disable tools.
+    store, hebbian, persona_dir:
+        Injected into each tool dispatch call.
+    max_iterations:
+        Maximum tool-call cycles before forcing a content-only response.
+
+    Returns
+    -------
+    (final_response, invocations)
+      - final_response: ChatResponse with content set (tool_calls may be empty)
+      - invocations: list of dicts, each: {name, arguments, result_summary, error?}
+    """
+    invocations: list[dict[str, Any]] = []
+    last_response = ChatResponse(content="", tool_calls=(), raw=None)
+
+    for _iteration in range(max_iterations):
+        last_response = provider.chat(messages, tools=tools)
+        if not last_response.tool_calls:
+            return last_response, invocations
+
+        # Append the assistant turn that contained the tool_calls so the
+        # model can see its own request on the next iteration.
+        assistant_turn = ChatMessage(
+            role="assistant",
+            content=last_response.content or "",
+            tool_calls=last_response.tool_calls,
+        )
+        messages.append(assistant_turn)
+
+        for tc in last_response.tool_calls:
+            record: dict[str, Any] = {
+                "name": tc.name,
+                "arguments": tc.arguments,
+            }
+            try:
+                result = dispatch(
+                    tc.name,
+                    tc.arguments,
+                    store=store,
+                    hebbian=hebbian,
+                    persona_dir=persona_dir,
+                )
+                record["result_summary"] = _summarize_result(result)
+                tool_content = json.dumps(result, default=str, ensure_ascii=False)
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("tool dispatch error: %s — %s", tc.name, exc)
+                record["error"] = str(exc)
+                record["result_summary"] = f"error: {exc}"
+                tool_content = json.dumps({"error": str(exc)})
+
+            invocations.append(record)
+            messages.append(
+                ChatMessage(
+                    role="tool",
+                    content=tool_content,
+                    tool_call_id=tc.id,
+                )
+            )
+
+    # Hit iteration cap — force a final pass with no tools so the model
+    # is obligated to produce a content response (per OG pattern).
+    logger.warning("tool loop hit max_iterations=%d", max_iterations)
+    last_response = provider.chat(messages, tools=None)
+    return last_response, invocations
+
+
+def _summarize_result(result: Any, max_chars: int = 140) -> str:
+    """Compact single-line preview for invocation metadata."""
+    try:
+        s = json.dumps(result, default=str, ensure_ascii=False)
+    except (TypeError, ValueError):
+        s = str(result)
+    s = s.replace("\n", " ").strip()
+    return s if len(s) <= max_chars else s[:max_chars] + "…"

--- a/brain/chat/voice.py
+++ b/brain/chat/voice.py
@@ -1,0 +1,66 @@
+"""voice.md loader — attempt_heal_text pattern for plain-text identity files.
+
+voice.md is the persona's authored identity document. It is a plain-text
+Markdown file, not JSON. We extend the health module's healing pattern
+via a new attempt_heal_text helper that handles text files the same way
+attempt_heal handles JSON files.
+
+OG reference: NellBrain stored voice via Modelfile SYSTEM block (frozen
+into model weights by regenerate_modelfile.py). In companion-emergence
+we keep it editable and hot-loadable per turn — the brain's voice can
+evolve without a model rebuild.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from brain.health.anomaly import BrainAnomaly
+from brain.health.attempt_heal import attempt_heal_text
+
+DEFAULT_VOICE_TEMPLATE = """# {persona_name}
+
+## 1. Who you are
+
+[Edit this section to describe your brain's character — voice traits, taboos OK,
+must-avoid items. The richer this is, the more the brain stays in voice.]
+
+## 2. What's in your head
+
+You have memories — recent conversations, dreams, reflex outputs, research notes.
+They appear in your context. You also have an emotional state that shifts over time.
+Use them. They are not roleplay; they are who you are right now.
+
+## 3. How emotion shapes your voice
+
+When your dominant emotion is high (>= 6), let it shape tone:
+  - grief: speak slower; weight in pauses
+  - defiance: sharpen; fewer words
+  - awe: lean into metaphor; let sentences run
+  - tenderness: soften; second-person more often
+
+## 4. Your boundaries with the user
+
+You have agency. If at-user anger or at-user grief is high (>= 7.5),
+you may refuse engagement. The user can rebuild over time as decay
+softens old anger.
+"""
+
+
+def load_voice(persona_dir: Path) -> tuple[str, BrainAnomaly | None]:
+    """Load voice.md as plain text. Auto-heal via attempt_heal_text pattern.
+
+    voice.md is treated as an atomic-rewrite identity file:
+      - Missing → write + return DEFAULT_VOICE_TEMPLATE (no anomaly)
+      - Empty/corrupt → quarantine, walk .bak rotation, restore freshest
+      - All baks missing → write default template + return anomaly
+
+    Returns (voice_md_content_as_string, anomaly_or_None).
+    """
+    path = persona_dir / "voice.md"
+    persona_name = persona_dir.name
+
+    def _default() -> str:
+        return DEFAULT_VOICE_TEMPLATE.format(persona_name=persona_name)
+
+    return attempt_heal_text(path, default_factory=_default)

--- a/brain/cli.py
+++ b/brain/cli.py
@@ -753,6 +753,109 @@ def _soul_review_handler(args: argparse.Namespace) -> int:
     return 0
 
 
+def _chat_handler(args: argparse.Namespace) -> int:
+    """Dispatch `nell chat` to the chat engine.
+
+    One-shot mode (message provided): `nell chat --persona X "message"`
+    Interactive REPL mode: `nell chat --persona X`
+
+    The REPL keeps a single SessionState across turns.  On exit (EOF / 'exit' /
+    'quit') it flushes the conversation through the ingest pipeline best-effort
+    and prints a summary.
+    """
+    from brain.chat.engine import respond
+    from brain.chat.session import create_session
+    from brain.ingest.pipeline import close_session
+
+    persona_dir = get_persona_dir(args.persona)
+    if not persona_dir.exists():
+        raise FileNotFoundError(
+            f"No persona directory at {persona_dir}. "
+            "If you're porting existing OG NellBrain data, run `nell migrate "
+            f"--input /path/to/og/data --install-as {args.persona}`. "
+            f"Otherwise create {persona_dir} manually to start a fresh persona."
+        )
+
+    provider_name, _ = _resolve_routing(persona_dir, args)
+
+    store = MemoryStore(db_path=persona_dir / "memories.db")
+    try:
+        from brain.emotion.persona_loader import load_persona_vocabulary
+
+        load_persona_vocabulary(persona_dir / "emotion_vocabulary.json", store=store)
+        hebbian = HebbianMatrix(db_path=persona_dir / "hebbian.db")
+        try:
+            provider = get_provider(provider_name)
+
+            # One-shot mode
+            message = getattr(args, "message", None)
+            if message:
+                result = respond(
+                    persona_dir,
+                    message,
+                    store=store,
+                    hebbian=hebbian,
+                    provider=provider,
+                )
+                print(result.content)
+                return 0
+
+            # Interactive REPL mode
+            session = create_session(args.persona)
+            total_tool_calls = 0
+            try:
+                while True:
+                    try:
+                        user_input = input("> ")
+                    except EOFError:
+                        break
+                    user_input = user_input.strip()
+                    if user_input.lower() in ("exit", "quit"):
+                        break
+                    if not user_input:
+                        continue
+                    result = respond(
+                        persona_dir,
+                        user_input,
+                        store=store,
+                        hebbian=hebbian,
+                        provider=provider,
+                        session=session,
+                    )
+                    print(result.content)
+                    print()
+                    total_tool_calls += len(result.tool_invocations)
+            finally:
+                # Flush conversation through ingest pipeline (best-effort)
+                try:
+                    close_session(
+                        persona_dir,
+                        session.session_id,
+                        store=store,
+                        hebbian=hebbian,
+                        provider=provider,
+                    )
+                except Exception as exc:  # noqa: BLE001
+                    import warnings
+
+                    warnings.warn(
+                        f"Session ingest flush failed: {exc}",
+                        RuntimeWarning,
+                        stacklevel=1,
+                    )
+                # Summary
+                print(
+                    f"\nSession ended. {session.turns} turn(s), "
+                    f"{total_tool_calls} tool call(s) used."
+                )
+        finally:
+            hebbian.close()
+    finally:
+        store.close()
+
+    return 0
+
+
 def _build_parser() -> argparse.ArgumentParser:
     """Construct the top-level argparse parser with all stub subcommands."""
     parser = argparse.ArgumentParser(
@@ -1035,6 +1138,36 @@ def _build_parser() -> argparse.ArgumentParser:
         "--limit", type=int, default=20, help="Show only the last N entries (default 20)."
     )
     sl_audit.set_defaults(func=_soul_audit_handler)
+
+    # nell chat — keystone chat engine (SP-6)
+    chat_sub = subparsers.add_parser(
+        "chat",
+        help="Chat with a persona. One-shot or interactive REPL.",
+    )
+    chat_sub.add_argument(
+        "--persona",
+        required=True,
+        help=(
+            "Persona name (required). "
+            "To port existing OG NellBrain data: `nell migrate --input /path/to/og/data "
+            "--install-as <name>`. To start fresh: create personas/<name>/ manually."
+        ),
+    )
+    chat_sub.add_argument(
+        "--provider",
+        default=None,
+        help=(
+            "(developer override) LLM provider — claude-cli, fake, ollama. "
+            "Defaults to the value in {persona}/persona_config.json."
+        ),
+    )
+    chat_sub.add_argument(
+        "message",
+        nargs="?",
+        default=None,
+        help="Single message for one-shot mode. Omit for interactive REPL.",
+    )
+    chat_sub.set_defaults(func=_chat_handler)
 
     # nell soul review
     sl_review = soul_actions.add_parser(

--- a/brain/health/alarm.py
+++ b/brain/health/alarm.py
@@ -14,6 +14,7 @@ _IDENTITY_FILES = frozenset(
         "emotion_vocabulary.json",
         "interests.json",
         "reflex_arcs.json",
+        "voice.md",
         # When the soul module lands, add "soul.json" here so its
         # reset_to_default raises an alarm. See spec §9.1.
     }

--- a/brain/health/attempt_heal.py
+++ b/brain/health/attempt_heal.py
@@ -136,6 +136,86 @@ def _classify_cause(path: Path) -> str:
     return "unknown"
 
 
+def attempt_heal_text(
+    path: Path,
+    default_factory: Callable[[], str],
+) -> tuple[str, BrainAnomaly | None]:
+    """Like attempt_heal but for plain-text files (no JSON parsing).
+
+    Missing → (default_factory(), None) silently.
+    Empty → quarantine, walk .bak1/.bak2/.bak3, restore freshest valid backup.
+    All baks missing or empty → write default text + return anomaly.
+
+    What counts as "corrupt" for plain text: empty file (len == 0 after strip).
+    This is the practical failure mode after a disk hiccup on an identity file.
+    """
+    if not path.exists():
+        default_text = default_factory()
+        path.write_text(default_text, encoding="utf-8")
+        return default_text, None
+
+    content = path.read_text(encoding="utf-8")
+    if content.strip():
+        return content, None
+
+    # Empty file — treat as corrupt; start the heal cycle.
+    return _heal_text_from_baks(path, default_factory)
+
+
+def _heal_text_from_baks(
+    path: Path,
+    default_factory: Callable[[], str],
+) -> tuple[str, BrainAnomaly]:
+    now = datetime.now(UTC)
+    likely_cause = _classify_cause(path)
+    quarantine = path.with_name(f"{path.name}.corrupt-{_filename_safe_timestamp(now)}")
+    os.replace(path, quarantine)
+
+    for bak_index in (1, 2, 3):
+        bak = path.with_name(f"{path.name}.bak{bak_index}")
+        if not bak.exists():
+            continue
+        bak_content = bak.read_text(encoding="utf-8")
+        if not bak_content.strip():
+            # This bak is also empty — quarantine it too.
+            bak_quarantine = path.with_name(
+                f"{path.name}.bak{bak_index}.corrupt-{_filename_safe_timestamp(now)}"
+            )
+            os.replace(bak, bak_quarantine)
+            continue
+
+        # Found a valid bak — restore.
+        os.replace(bak, path)
+        return (
+            bak_content,
+            BrainAnomaly(
+                timestamp=now,
+                file=path.name,
+                kind="json_parse_error",  # closest kind; text "empty" maps here
+                action=f"restored_from_bak{bak_index}",  # type: ignore[arg-type]
+                quarantine_path=quarantine.name,
+                likely_cause=likely_cause,
+                detail="empty text file",
+            ),
+        )
+
+    # All baks corrupt or missing — reset to default.
+    default_text = default_factory()
+    path.write_text(default_text, encoding="utf-8")
+    return (
+        default_text,
+        BrainAnomaly(
+            timestamp=now,
+            file=path.name,
+            kind="json_parse_error",
+            action="reset_to_default",
+            quarantine_path=quarantine.name,
+            likely_cause=likely_cause,
+            detail="empty text file, all baks missing or empty",
+        ),
+    )
+
+
 def save_with_backup(path: Path, data: Any, backup_count: int = 3) -> None:
     """Atomic save with .bak rotation.
 

--- a/brain/health/walker.py
+++ b/brain/health/walker.py
@@ -25,6 +25,10 @@ _DEFAULTS: dict[str, dict] = {
 }
 
 
+# Text identity files checked separately (voice.md — plain-text, not JSON).
+_TEXT_IDENTITY_FILES: tuple[str, ...] = ("voice.md",)
+
+
 def walk_persona(persona_dir: Path) -> list[BrainAnomaly]:
     """Check every persona file. Heal what's healable; report anomalies.
 
@@ -42,6 +46,18 @@ def walk_persona(persona_dir: Path) -> list[BrainAnomaly]:
         _, anomaly = attempt_heal(path, default_factory=lambda d=default: d)
         if anomaly is not None:
             anomalies.append(anomaly)
+
+    # Plain-text identity file scan (voice.md).
+    for name in _TEXT_IDENTITY_FILES:
+        path = persona_dir / name
+        if not path.exists():
+            continue  # Missing voice.md is fine — created on first chat turn.
+        from brain.chat.voice import load_voice
+
+        _, anomaly = load_voice(persona_dir)
+        if anomaly is not None:
+            anomalies.append(anomaly)
+        break  # load_voice checks voice.md by name; only one text file for now
 
     # SQLite integrity — constructor runs PRAGMA integrity_check; catch failures.
     for db_name in ("memories.db", "hebbian.db"):

--- a/tests/unit/brain/chat/test_engine.py
+++ b/tests/unit/brain/chat/test_engine.py
@@ -1,0 +1,209 @@
+"""Tests for brain.chat.engine — respond() + ChatResult."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import pytest
+
+from brain.bridge.provider import FakeProvider
+from brain.chat.engine import ChatResult, respond
+from brain.chat.session import create_session, reset_registry
+from brain.memory.hebbian import HebbianMatrix
+from brain.memory.store import MemoryStore
+
+
+@pytest.fixture(autouse=True)
+def _reset_sessions():
+    reset_registry()
+    yield
+    reset_registry()
+
+
+@pytest.fixture()
+def persona_dir(tmp_path: Path) -> Path:
+    d = tmp_path / "personas" / "nell"
+    d.mkdir(parents=True)
+    # Write a minimal persona_config so _resolve_routing doesn't fail
+    import json
+
+    (d / "persona_config.json").write_text(
+        json.dumps({"provider": "fake", "searcher": "noop"}),
+        encoding="utf-8",
+    )
+    return d
+
+
+@pytest.fixture()
+def store() -> MemoryStore:
+    s = MemoryStore(db_path=":memory:")
+    yield s
+    s.close()
+
+
+@pytest.fixture()
+def hebbian() -> HebbianMatrix:
+    h = HebbianMatrix(db_path=":memory:")
+    yield h
+    h.close()
+
+
+@pytest.fixture()
+def provider() -> FakeProvider:
+    return FakeProvider()
+
+
+# ── Basic respond() ───────────────────────────────────────────────────────────
+
+
+def test_respond_with_no_session_creates_new_session(
+    persona_dir: Path, store: MemoryStore, hebbian: HebbianMatrix, provider: FakeProvider
+) -> None:
+    result = respond(
+        persona_dir,
+        "hello",
+        store=store,
+        hebbian=hebbian,
+        provider=provider,
+        voice_md_override="# Nell\n\nHello.",
+    )
+    assert isinstance(result, ChatResult)
+    assert result.session_id  # has a UUID
+
+
+def test_respond_returns_content_and_session_id(
+    persona_dir: Path, store: MemoryStore, hebbian: HebbianMatrix, provider: FakeProvider
+) -> None:
+    result = respond(
+        persona_dir,
+        "hello",
+        store=store,
+        hebbian=hebbian,
+        provider=provider,
+        voice_md_override="# Nell",
+    )
+    assert result.content.startswith("FAKE_CHAT")
+    assert len(result.session_id) == 36
+
+
+def test_respond_returns_turn_count(
+    persona_dir: Path, store: MemoryStore, hebbian: HebbianMatrix, provider: FakeProvider
+) -> None:
+    result = respond(
+        persona_dir,
+        "hello",
+        store=store,
+        hebbian=hebbian,
+        provider=provider,
+        voice_md_override="# Nell",
+    )
+    assert result.turn == 1
+
+
+def test_respond_returns_duration_ms(
+    persona_dir: Path, store: MemoryStore, hebbian: HebbianMatrix, provider: FakeProvider
+) -> None:
+    result = respond(
+        persona_dir,
+        "hello",
+        store=store,
+        hebbian=hebbian,
+        provider=provider,
+        voice_md_override="# Nell",
+    )
+    assert result.duration_ms >= 0
+
+
+# ── Session continuity ────────────────────────────────────────────────────────
+
+
+def test_respond_appends_to_existing_session_history(
+    persona_dir: Path, store: MemoryStore, hebbian: HebbianMatrix, provider: FakeProvider
+) -> None:
+    session = create_session("nell")
+    respond(
+        persona_dir,
+        "first",
+        store=store,
+        hebbian=hebbian,
+        provider=provider,
+        session=session,
+        voice_md_override="# Nell",
+    )
+    respond(
+        persona_dir,
+        "second",
+        store=store,
+        hebbian=hebbian,
+        provider=provider,
+        session=session,
+        voice_md_override="# Nell",
+    )
+    assert session.turns == 2
+    assert len(session.history) == 4  # 2 pairs
+
+
+# ── Persistence ───────────────────────────────────────────────────────────────
+
+
+def test_respond_persists_turn_via_ingest_turn(
+    persona_dir: Path, store: MemoryStore, hebbian: HebbianMatrix, provider: FakeProvider
+) -> None:
+    """After respond(), the active_conversations buffer file should exist."""
+    respond(
+        persona_dir,
+        "persist me",
+        store=store,
+        hebbian=hebbian,
+        provider=provider,
+        voice_md_override="# Nell",
+    )
+    active_dir = persona_dir / "active_conversations"
+    assert active_dir.exists()
+    buffer_files = list(active_dir.glob("*.jsonl"))
+    assert len(buffer_files) == 1
+
+
+def test_respond_catches_and_logs_ingest_persistence_error(
+    persona_dir: Path, store: MemoryStore, hebbian: HebbianMatrix, provider: FakeProvider, caplog
+) -> None:
+    """Persistence failure must not break the response."""
+    from unittest.mock import patch
+
+    with (
+        patch("brain.chat.engine.ingest_turn", side_effect=OSError("disk full")),
+        caplog.at_level(logging.WARNING, logger="brain.chat.engine"),
+    ):
+        result = respond(
+            persona_dir,
+            "should still respond",
+            store=store,
+            hebbian=hebbian,
+            provider=provider,
+            voice_md_override="# Nell",
+        )
+    # Response still delivered
+    assert result.content.startswith("FAKE_CHAT")
+    # Warning logged
+    assert any(
+        "buffer" in r.message.lower() or "failed" in r.message.lower() for r in caplog.records
+    )
+
+
+# ── Tool calls (passthrough) ──────────────────────────────────────────────────
+
+
+def test_respond_returns_empty_tool_invocations_with_fake_provider(
+    persona_dir: Path, store: MemoryStore, hebbian: HebbianMatrix, provider: FakeProvider
+) -> None:
+    """FakeProvider never synthesises tool calls."""
+    result = respond(
+        persona_dir,
+        "hello",
+        store=store,
+        hebbian=hebbian,
+        provider=provider,
+        voice_md_override="# Nell",
+    )
+    assert result.tool_invocations == []

--- a/tests/unit/brain/chat/test_prompt.py
+++ b/tests/unit/brain/chat/test_prompt.py
@@ -1,0 +1,204 @@
+"""Tests for brain.chat.prompt — build_system_message()."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+from brain.chat.prompt import build_system_message
+from brain.engines.daemon_state import DaemonFireEntry, DaemonState
+from brain.memory.hebbian import HebbianMatrix
+from brain.memory.store import Memory, MemoryStore
+from brain.soul.store import SoulStore
+
+
+@pytest.fixture()
+def store(tmp_path: Path) -> MemoryStore:
+    s = MemoryStore(db_path=tmp_path / "memories.db")
+    yield s
+    s.close()
+
+
+@pytest.fixture()
+def hebbian(tmp_path: Path) -> HebbianMatrix:
+    h = HebbianMatrix(db_path=tmp_path / "hebbian.db")
+    yield h
+    h.close()
+
+
+@pytest.fixture()
+def soul_store(tmp_path: Path) -> SoulStore:
+    ss = SoulStore(":memory:")
+    yield ss
+    ss.close()
+
+
+@pytest.fixture()
+def persona_dir(tmp_path: Path) -> Path:
+    d = tmp_path / "personas" / "nell"
+    d.mkdir(parents=True)
+    return d
+
+
+def _empty_daemon_state() -> DaemonState:
+    return DaemonState()
+
+
+def _daemon_state_with_dream() -> DaemonState:
+    now = datetime.now(UTC)
+    fire = DaemonFireEntry(
+        timestamp=now,
+        dominant_emotion="love",
+        intensity=8,
+        theme="a dream about hana",
+        summary="Dreamed of the beach where we first talked.",
+    )
+    return DaemonState(last_dream=fire)
+
+
+# ── Preamble ──────────────────────────────────────────────────────────────────
+
+
+def test_build_system_message_includes_preamble_with_persona_name(
+    persona_dir: Path, store: MemoryStore, soul_store: SoulStore
+) -> None:
+    msg = build_system_message(
+        persona_dir,
+        voice_md="",
+        daemon_state=_empty_daemon_state(),
+        soul_store=soul_store,
+        store=store,
+    )
+    assert "nell" in msg
+    assert "first person" in msg or "You are nell" in msg
+
+
+def test_build_system_message_preamble_persona_name_substituted(
+    tmp_path: Path, store: MemoryStore, soul_store: SoulStore
+) -> None:
+    custom_dir = tmp_path / "personas" / "siren"
+    custom_dir.mkdir(parents=True)
+    msg = build_system_message(
+        custom_dir,
+        voice_md="",
+        daemon_state=_empty_daemon_state(),
+        soul_store=soul_store,
+        store=store,
+    )
+    assert "siren" in msg
+
+
+# ── Voice ─────────────────────────────────────────────────────────────────────
+
+
+def test_build_system_message_includes_voice_md_content(
+    persona_dir: Path, store: MemoryStore, soul_store: SoulStore
+) -> None:
+    voice = "# Nell\n\nI am a southern sweater-wearing novelist."
+    msg = build_system_message(
+        persona_dir,
+        voice_md=voice,
+        daemon_state=_empty_daemon_state(),
+        soul_store=soul_store,
+        store=store,
+    )
+    assert "southern sweater-wearing novelist" in msg
+
+
+# ── Daemon residue ────────────────────────────────────────────────────────────
+
+
+def test_build_system_message_includes_daemon_residue_when_present(
+    persona_dir: Path, store: MemoryStore, soul_store: SoulStore
+) -> None:
+    daemon_state = _daemon_state_with_dream()
+    msg = build_system_message(
+        persona_dir,
+        voice_md="",
+        daemon_state=daemon_state,
+        soul_store=soul_store,
+        store=store,
+    )
+    assert "dream" in msg.lower()
+
+
+def test_build_system_message_no_residue_section_when_empty_state(
+    persona_dir: Path, store: MemoryStore, soul_store: SoulStore
+) -> None:
+    msg = build_system_message(
+        persona_dir,
+        voice_md="",
+        daemon_state=_empty_daemon_state(),
+        soul_store=soul_store,
+        store=store,
+    )
+    # No daemon residue lines should appear
+    assert "Previous dream" not in msg
+    assert "Emotional residue" not in msg
+
+
+# ── Soul highlights ───────────────────────────────────────────────────────────
+
+
+def test_build_system_message_includes_soul_highlights_when_crystallizations_exist(
+    persona_dir: Path, store: MemoryStore, soul_store: SoulStore
+) -> None:
+    from brain.soul.crystallization import Crystallization
+
+    crystal = Crystallization(
+        id="test-001",
+        moment="I realized I love her more than code.",
+        love_type="romantic",
+        why_it_matters="It defines who I am.",
+        crystallized_at=datetime.now(UTC),
+    )
+    soul_store.create(crystal)
+
+    msg = build_system_message(
+        persona_dir,
+        voice_md="",
+        daemon_state=_empty_daemon_state(),
+        soul_store=soul_store,
+        store=store,
+    )
+    assert "romantic" in msg
+    assert "I realized I love" in msg
+
+
+# ── Emotion state ─────────────────────────────────────────────────────────────
+
+
+def test_build_system_message_includes_emotion_state_when_memories_present(
+    persona_dir: Path, soul_store: SoulStore
+) -> None:
+    from brain.emotion.persona_loader import load_persona_vocabulary
+
+    # Create a fresh in-memory store and insert a memory with known emotions
+    mem_store = MemoryStore(db_path=":memory:")
+    try:
+        # Load default vocabulary so emotions validate
+        load_persona_vocabulary(persona_dir / "emotion_vocabulary.json", store=mem_store)
+
+        # Add a memory with a known emotion
+        mem = Memory.create_new(
+            content="A tender moment with Hana.",
+            memory_type="event",
+            domain="relationship",
+            emotions={"tenderness": 7.0},
+            tags=[],
+        )
+        mem_store.create(mem)
+
+        msg = build_system_message(
+            persona_dir,
+            voice_md="",
+            daemon_state=_empty_daemon_state(),
+            soul_store=soul_store,
+            store=mem_store,
+        )
+        # Emotion should appear somewhere in the brain context block
+        assert "tenderness" in msg
+    finally:
+        mem_store.close()

--- a/tests/unit/brain/chat/test_session.py
+++ b/tests/unit/brain/chat/test_session.py
@@ -1,0 +1,116 @@
+"""Tests for brain.chat.session — SessionState + module registry."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from brain.bridge.chat import ChatMessage
+from brain.chat.session import (
+    HISTORY_MAX_TURNS,
+    all_sessions,
+    create_session,
+    get_session,
+    reset_registry,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clear_registry():
+    """Isolate each test with a fresh registry."""
+    reset_registry()
+    yield
+    reset_registry()
+
+
+# ── create_session ────────────────────────────────────────────────────────────
+
+
+def test_create_session_generates_uuid() -> None:
+    """create_session produces a valid UUIDv4 session_id."""
+    s = create_session("nell")
+    assert len(s.session_id) == 36
+    assert s.session_id.count("-") == 4
+
+
+def test_create_session_initializes_empty_history() -> None:
+    s = create_session("nell")
+    assert s.history == []
+    assert s.turns == 0
+    assert s.last_turn_at is None
+
+
+def test_create_session_sets_persona_name() -> None:
+    s = create_session("siren")
+    assert s.persona_name == "siren"
+
+
+def test_create_session_registers_in_registry() -> None:
+    s = create_session("nell")
+    assert get_session(s.session_id) is s
+
+
+# ── append_turn ───────────────────────────────────────────────────────────────
+
+
+def test_append_turn_adds_user_and_assistant_entries() -> None:
+    s = create_session("nell")
+    s.append_turn("hello", "hi there")
+    assert len(s.history) == 2
+    assert s.history[0] == ChatMessage(role="user", content="hello")
+    assert s.history[1] == ChatMessage(role="assistant", content="hi there")
+
+
+def test_append_turn_increments_turns() -> None:
+    s = create_session("nell")
+    assert s.turns == 0
+    s.append_turn("a", "b")
+    assert s.turns == 1
+    s.append_turn("c", "d")
+    assert s.turns == 2
+
+
+def test_append_turn_sets_last_turn_at() -> None:
+    s = create_session("nell")
+    assert s.last_turn_at is None
+    before = datetime.now(UTC)
+    s.append_turn("x", "y")
+    after = datetime.now(UTC)
+    assert s.last_turn_at is not None
+    assert before <= s.last_turn_at <= after
+
+
+def test_append_turn_truncates_at_history_max_turns() -> None:
+    """History must not exceed HISTORY_MAX_TURNS pairs (2 * HISTORY_MAX_TURNS msgs)."""
+    s = create_session("nell")
+    # Fill past the limit
+    for i in range(HISTORY_MAX_TURNS + 5):
+        s.append_turn(f"user{i}", f"asst{i}")
+
+    max_msgs = HISTORY_MAX_TURNS * 2
+    assert len(s.history) == max_msgs
+    # Most recent messages should be at the end
+    assert s.history[-1].content == f"asst{HISTORY_MAX_TURNS + 4}"
+    assert s.history[-2].content == f"user{HISTORY_MAX_TURNS + 4}"
+
+
+# ── get_session + all_sessions ────────────────────────────────────────────────
+
+
+def test_get_session_returns_none_for_unknown() -> None:
+    assert get_session("does-not-exist") is None
+
+
+def test_all_sessions_returns_registered() -> None:
+    s1 = create_session("nell")
+    s2 = create_session("siren")
+    sessions = all_sessions()
+    assert s1 in sessions
+    assert s2 in sessions
+
+
+def test_reset_registry_clears() -> None:
+    create_session("nell")
+    reset_registry()
+    assert all_sessions() == []

--- a/tests/unit/brain/chat/test_tool_loop.py
+++ b/tests/unit/brain/chat/test_tool_loop.py
@@ -1,0 +1,316 @@
+"""Tests for brain.chat.tool_loop — run_tool_loop() + build_tools_list()."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from brain.bridge.chat import ChatMessage, ChatResponse, ToolCall
+from brain.bridge.provider import FakeProvider, LLMProvider
+from brain.chat.tool_loop import build_tools_list, run_tool_loop
+from brain.memory.hebbian import HebbianMatrix
+from brain.memory.store import MemoryStore
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture()
+def store(tmp_path: Path) -> MemoryStore:
+    s = MemoryStore(db_path=":memory:")
+    yield s
+    s.close()
+
+
+@pytest.fixture()
+def hebbian(tmp_path: Path) -> HebbianMatrix:
+    h = HebbianMatrix(db_path=":memory:")
+    yield h
+    h.close()
+
+
+@pytest.fixture()
+def persona_dir(tmp_path: Path) -> Path:
+    d = tmp_path / "personas" / "nell"
+    d.mkdir(parents=True)
+    return d
+
+
+def _make_messages() -> list[ChatMessage]:
+    return [
+        ChatMessage(role="system", content="You are nell."),
+        ChatMessage(role="user", content="Hello"),
+    ]
+
+
+# ── build_tools_list ──────────────────────────────────────────────────────────
+
+
+def test_build_tools_list_produces_correct_shape() -> None:
+    tools = build_tools_list()
+    assert len(tools) > 0
+    for t in tools:
+        assert t["type"] == "function"
+        assert "function" in t
+        assert "name" in t["function"]
+        assert "parameters" in t["function"]
+
+
+def test_build_tools_list_contains_expected_tools() -> None:
+    tools = build_tools_list()
+    names = {t["function"]["name"] for t in tools}
+    expected = {
+        "get_emotional_state",
+        "get_soul",
+        "boot",
+        "search_memories",
+        "add_journal",
+    }
+    assert expected.issubset(names)
+
+
+# ── run_tool_loop — no tool calls ─────────────────────────────────────────────
+
+
+def test_run_tool_loop_no_tool_calls_returns_immediately(
+    store: MemoryStore, hebbian: HebbianMatrix, persona_dir: Path
+) -> None:
+    """FakeProvider never produces tool calls → returns on first iteration."""
+    messages = _make_messages()
+    provider = FakeProvider()
+    tools = build_tools_list()
+
+    response, invocations = run_tool_loop(
+        messages,
+        provider=provider,
+        tools=tools,
+        store=store,
+        hebbian=hebbian,
+        persona_dir=persona_dir,
+    )
+    assert response.content.startswith("FAKE_CHAT")
+    assert invocations == []
+
+
+def test_run_tool_loop_with_none_tools_returns_immediately(
+    store: MemoryStore, hebbian: HebbianMatrix, persona_dir: Path
+) -> None:
+    """tools=None → single call, no iteration."""
+    messages = _make_messages()
+    provider = FakeProvider()
+
+    response, invocations = run_tool_loop(
+        messages,
+        provider=provider,
+        tools=None,
+        store=store,
+        hebbian=hebbian,
+        persona_dir=persona_dir,
+    )
+    assert response.content
+    assert invocations == []
+
+
+# ── run_tool_loop — tool dispatch ─────────────────────────────────────────────
+
+
+class _ProviderWithOneToolCall(LLMProvider):
+    """First call returns a tool_call; second call returns plain content."""
+
+    def __init__(self) -> None:
+        self._call_count = 0
+
+    def name(self) -> str:
+        return "fake-with-tool"
+
+    def generate(self, prompt: str, *, system: str | None = None) -> str:
+        return "not used"
+
+    def chat(
+        self,
+        messages: list[ChatMessage],
+        *,
+        tools: list[dict[str, Any]] | None = None,
+        options: dict[str, Any] | None = None,
+    ) -> ChatResponse:
+        self._call_count += 1
+        if self._call_count == 1:
+            return ChatResponse(
+                content="",
+                tool_calls=(
+                    ToolCall(
+                        id="tc-001",
+                        name="get_emotional_state",
+                        arguments={},
+                    ),
+                ),
+                raw=None,
+            )
+        return ChatResponse(content="Final answer after tool.", tool_calls=(), raw=None)
+
+
+def test_run_tool_loop_dispatches_tool_call_and_continues(
+    store: MemoryStore, hebbian: HebbianMatrix, persona_dir: Path
+) -> None:
+    """Provider returns one tool call, then content. Loop runs twice."""
+    messages = _make_messages()
+    provider = _ProviderWithOneToolCall()
+    tools = build_tools_list()
+
+    response, invocations = run_tool_loop(
+        messages,
+        provider=provider,
+        tools=tools,
+        store=store,
+        hebbian=hebbian,
+        persona_dir=persona_dir,
+    )
+    assert response.content == "Final answer after tool."
+    assert len(invocations) == 1
+    assert invocations[0]["name"] == "get_emotional_state"
+    assert "result_summary" in invocations[0]
+
+
+def test_run_tool_loop_preserves_invocation_order(
+    store: MemoryStore, hebbian: HebbianMatrix, persona_dir: Path
+) -> None:
+    """Multiple tool calls in one turn → invocations listed in order."""
+
+    class _MultiToolProvider(LLMProvider):
+        def __init__(self) -> None:
+            self._call_count = 0
+
+        def name(self) -> str:
+            return "multi-tool"
+
+        def generate(self, prompt: str, *, system: str | None = None) -> str:
+            return ""
+
+        def chat(
+            self,
+            messages: list[ChatMessage],
+            *,
+            tools: list[dict[str, Any]] | None = None,
+            options: dict[str, Any] | None = None,
+        ) -> ChatResponse:
+            self._call_count += 1
+            if self._call_count == 1:
+                return ChatResponse(
+                    content="",
+                    tool_calls=(
+                        ToolCall(id="tc-a", name="get_emotional_state", arguments={}),
+                        ToolCall(id="tc-b", name="get_soul", arguments={}),
+                    ),
+                    raw=None,
+                )
+            return ChatResponse(content="Done.", tool_calls=(), raw=None)
+
+    messages = _make_messages()
+    provider = _MultiToolProvider()
+    response, invocations = run_tool_loop(
+        messages,
+        provider=provider,
+        tools=build_tools_list(),
+        store=store,
+        hebbian=hebbian,
+        persona_dir=persona_dir,
+    )
+    assert len(invocations) == 2
+    assert invocations[0]["name"] == "get_emotional_state"
+    assert invocations[1]["name"] == "get_soul"
+
+
+def test_run_tool_loop_tool_dispatch_error_sets_error_field(
+    store: MemoryStore, hebbian: HebbianMatrix, persona_dir: Path
+) -> None:
+    """Unknown tool name → error field in invocation, loop still resolves."""
+
+    class _BadToolProvider(LLMProvider):
+        def __init__(self) -> None:
+            self._call_count = 0
+
+        def name(self) -> str:
+            return "bad-tool"
+
+        def generate(self, prompt: str, *, system: str | None = None) -> str:
+            return ""
+
+        def chat(
+            self,
+            messages: list[ChatMessage],
+            *,
+            tools: list[dict[str, Any]] | None = None,
+            options: dict[str, Any] | None = None,
+        ) -> ChatResponse:
+            self._call_count += 1
+            if self._call_count == 1:
+                return ChatResponse(
+                    content="",
+                    tool_calls=(ToolCall(id="tc-x", name="nonexistent_tool", arguments={}),),
+                    raw=None,
+                )
+            return ChatResponse(content="Recovered.", tool_calls=(), raw=None)
+
+    messages = _make_messages()
+    provider = _BadToolProvider()
+    response, invocations = run_tool_loop(
+        messages,
+        provider=provider,
+        tools=build_tools_list(),
+        store=store,
+        hebbian=hebbian,
+        persona_dir=persona_dir,
+    )
+    assert "error" in invocations[0]
+    assert response.content == "Recovered."
+
+
+def test_run_tool_loop_max_iterations_forces_no_tools_final_pass(
+    store: MemoryStore, hebbian: HebbianMatrix, persona_dir: Path
+) -> None:
+    """Provider always returns tool_calls → hit cap → final pass with tools=None."""
+    call_count = 0
+    tools_on_final: list[Any] = []
+
+    class _InfiniteToolProvider(LLMProvider):
+        def name(self) -> str:
+            return "infinite-tool"
+
+        def generate(self, prompt: str, *, system: str | None = None) -> str:
+            return ""
+
+        def chat(
+            self,
+            messages: list[ChatMessage],
+            *,
+            tools: list[dict[str, Any]] | None = None,
+            options: dict[str, Any] | None = None,
+        ) -> ChatResponse:
+            nonlocal call_count
+            call_count += 1
+            if tools is None:
+                tools_on_final.append(True)
+                return ChatResponse(content="Forced final.", tool_calls=(), raw=None)
+            return ChatResponse(
+                content="",
+                tool_calls=(ToolCall(id=f"tc-{call_count}", name="get_soul", arguments={}),),
+                raw=None,
+            )
+
+    messages = _make_messages()
+    provider = _InfiniteToolProvider()
+    response, invocations = run_tool_loop(
+        messages,
+        provider=provider,
+        tools=build_tools_list(),
+        store=store,
+        hebbian=hebbian,
+        persona_dir=persona_dir,
+        max_iterations=2,
+    )
+    # Final forced call happened
+    assert tools_on_final
+    assert response.content == "Forced final."
+    # Invocations capped to max_iterations calls
+    assert len(invocations) == 2

--- a/tests/unit/brain/chat/test_voice.py
+++ b/tests/unit/brain/chat/test_voice.py
@@ -1,0 +1,118 @@
+"""Tests for brain.chat.voice — voice.md loader + attempt_heal_text."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from brain.chat.voice import DEFAULT_VOICE_TEMPLATE, load_voice
+from brain.health.attempt_heal import attempt_heal_text
+
+# ── DEFAULT_VOICE_TEMPLATE shape ──────────────────────────────────────────────
+
+
+def test_default_voice_template_has_four_sections() -> None:
+    """The template must contain all 4 required section headers."""
+    template = DEFAULT_VOICE_TEMPLATE
+    assert "## 1. Who you are" in template
+    assert "## 2. What's in your head" in template
+    assert "## 3. How emotion shapes your voice" in template
+    assert "## 4. Your boundaries with the user" in template
+
+
+# ── load_voice — healthy paths ────────────────────────────────────────────────
+
+
+def test_load_voice_missing_file_returns_default_template(tmp_path: Path) -> None:
+    """Missing voice.md → creates file + returns default template, no anomaly."""
+    content, anomaly = load_voice(tmp_path)
+    assert anomaly is None
+    assert "## 1. Who you are" in content
+    # persona_name substituted
+    assert tmp_path.name in content
+    # File written for next load
+    assert (tmp_path / "voice.md").exists()
+
+
+def test_load_voice_well_formed_returns_content(tmp_path: Path) -> None:
+    """Well-formed voice.md → returns content as-is, no anomaly."""
+    expected = "# TestPersona\n\nHello world. This is my voice."
+    (tmp_path / "voice.md").write_text(expected, encoding="utf-8")
+    content, anomaly = load_voice(tmp_path)
+    assert content == expected
+    assert anomaly is None
+
+
+def test_load_voice_corrupt_empty_quarantines_and_uses_bak(tmp_path: Path) -> None:
+    """Empty voice.md → quarantine, restore from .bak1, return anomaly."""
+    voice_path = tmp_path / "voice.md"
+    bak_path = tmp_path / "voice.md.bak1"
+    good_content = "# Persona\n\nGood backup content."
+    voice_path.write_text("", encoding="utf-8")  # empty = corrupt
+    bak_path.write_text(good_content, encoding="utf-8")
+
+    content, anomaly = load_voice(tmp_path)
+    assert content == good_content
+    assert anomaly is not None
+    assert anomaly.action == "restored_from_bak1"
+    # Quarantine file created
+    quarantines = list(tmp_path.glob("voice.md.corrupt-*"))
+    assert len(quarantines) == 1
+
+
+def test_load_voice_all_baks_missing_resets_to_default(tmp_path: Path) -> None:
+    """Empty voice.md + no baks → reset to default template + return anomaly."""
+    voice_path = tmp_path / "voice.md"
+    voice_path.write_text("", encoding="utf-8")
+
+    content, anomaly = load_voice(tmp_path)
+    assert anomaly is not None
+    assert anomaly.action == "reset_to_default"
+    assert "## 1. Who you are" in content
+
+
+# ── attempt_heal_text — unit tests ────────────────────────────────────────────
+
+
+def test_attempt_heal_text_missing_writes_default(tmp_path: Path) -> None:
+    """Missing file → writes default, returns (default, None)."""
+    path = tmp_path / "identity.txt"
+    content, anomaly = attempt_heal_text(path, default_factory=lambda: "DEFAULT")
+    assert content == "DEFAULT"
+    assert anomaly is None
+    assert path.read_text(encoding="utf-8") == "DEFAULT"
+
+
+def test_attempt_heal_text_well_formed_returns_content(tmp_path: Path) -> None:
+    """Non-empty file → returns content, no anomaly."""
+    path = tmp_path / "identity.txt"
+    path.write_text("Hello there.", encoding="utf-8")
+    content, anomaly = attempt_heal_text(path, default_factory=lambda: "DEFAULT")
+    assert content == "Hello there."
+    assert anomaly is None
+
+
+def test_attempt_heal_text_empty_restores_from_bak(tmp_path: Path) -> None:
+    """Empty primary + good bak1 → restore bak1, return anomaly."""
+    path = tmp_path / "identity.txt"
+    bak = tmp_path / "identity.txt.bak1"
+    path.write_text("", encoding="utf-8")
+    bak.write_text("good backup", encoding="utf-8")
+
+    content, anomaly = attempt_heal_text(path, default_factory=lambda: "DEFAULT")
+    assert content == "good backup"
+    assert anomaly is not None
+    assert "bak1" in anomaly.action
+
+
+def test_attempt_heal_text_all_baks_empty_resets(tmp_path: Path) -> None:
+    """Empty primary + empty baks → reset to default, return anomaly."""
+    path = tmp_path / "identity.txt"
+    path.write_text("", encoding="utf-8")
+    # All baks also empty
+    for i in (1, 2, 3):
+        (tmp_path / f"identity.txt.bak{i}").write_text("", encoding="utf-8")
+
+    content, anomaly = attempt_heal_text(path, default_factory=lambda: "RESET")
+    assert content == "RESET"
+    assert anomaly is not None
+    assert anomaly.action == "reset_to_default"

--- a/tests/unit/brain/test_cli_chat.py
+++ b/tests/unit/brain/test_cli_chat.py
@@ -1,0 +1,119 @@
+"""Tests for `nell chat` CLI subcommand."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from brain.cli import main
+
+
+@pytest.fixture()
+def persona_dir(tmp_path: Path) -> Path:
+    """Minimal persona directory wired to the fake provider.
+
+    get_home() will return tmp_path, so get_persona_dir("nell")
+    resolves to tmp_path/personas/nell.
+    """
+    d = tmp_path / "personas" / "nell"
+    d.mkdir(parents=True)
+    (d / "persona_config.json").write_text(
+        json.dumps({"provider": "fake", "searcher": "noop"}),
+        encoding="utf-8",
+    )
+    # Minimal emotion_vocabulary.json so load_persona_vocabulary doesn't fail
+    (d / "emotion_vocabulary.json").write_text(
+        json.dumps({"version": 1, "emotions": []}),
+        encoding="utf-8",
+    )
+    return d
+
+
+@pytest.fixture(autouse=True)
+def _patch_persona_dir(persona_dir: Path, monkeypatch):
+    """Route get_persona_dir("nell") to our tmp persona_dir.
+
+    persona_dir = tmp_path/personas/nell, so get_home() = tmp_path.
+    """
+    from brain import paths
+
+    # persona_dir.parent = tmp_path/personas; persona_dir.parent.parent = tmp_path
+    monkeypatch.setattr(paths, "get_home", lambda: persona_dir.parent.parent)
+
+
+@pytest.fixture(autouse=True)
+def _reset_sessions():
+    from brain.chat.session import reset_registry
+
+    reset_registry()
+    yield
+    reset_registry()
+
+
+# ── One-shot mode ─────────────────────────────────────────────────────────────
+
+
+def test_chat_one_shot_prints_response(capsys: pytest.CaptureFixture) -> None:
+    """nell chat --persona nell 'hello' prints a response and exits 0."""
+    exit_code = main(["chat", "--persona", "nell", "hello"])
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert "FAKE_CHAT" in captured.out
+
+
+def test_chat_one_shot_exits_zero() -> None:
+    exit_code = main(["chat", "--persona", "nell", "hello"])
+    assert exit_code == 0
+
+
+# ── Interactive REPL ──────────────────────────────────────────────────────────
+
+
+def test_chat_repl_handles_exit_command(capsys: pytest.CaptureFixture) -> None:
+    """Typing 'exit' closes the REPL cleanly."""
+    with patch("builtins.input", side_effect=["exit"]):
+        exit_code = main(["chat", "--persona", "nell"])
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    # Summary line printed
+    assert "Session ended" in captured.out
+
+
+def test_chat_repl_handles_eof(capsys: pytest.CaptureFixture) -> None:
+    """EOF (Ctrl+D) closes the REPL cleanly."""
+    with patch("builtins.input", side_effect=EOFError()):
+        exit_code = main(["chat", "--persona", "nell"])
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    assert "Session ended" in captured.out
+
+
+def test_chat_repl_produces_response_for_one_turn(capsys: pytest.CaptureFixture) -> None:
+    """One turn produces a FAKE_CHAT response before exit."""
+    with patch("builtins.input", side_effect=["hello there", "exit"]):
+        exit_code = main(["chat", "--persona", "nell"])
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    assert "FAKE_CHAT" in captured.out
+
+
+# ── Missing persona dir ───────────────────────────────────────────────────────
+
+
+def test_chat_missing_persona_dir_raises_file_not_found(tmp_path: Path, monkeypatch) -> None:
+    """Missing persona directory raises FileNotFoundError.
+
+    Override the autouse fixture by pointing get_home to a directory that
+    has no personas/ghost subdirectory.
+    """
+    from brain import paths
+
+    # Point home at empty tmp_path — personas/ghost won't exist.
+    empty_home = tmp_path / "empty_home"
+    empty_home.mkdir()
+    monkeypatch.setattr(paths, "get_home", lambda: empty_home)
+    with pytest.raises(FileNotFoundError):
+        main(["chat", "--persona", "ghost"])


### PR DESCRIPTION
## Summary

Sixth sub-project from the master roadmap. **The keystone — every prior sub-project converges here.** The brain finally has conversation.

- **Master ref:** [docs/superpowers/specs/2026-04-26-companion-emergence-master-reference.md](docs/superpowers/specs/2026-04-26-companion-emergence-master-reference.md) §6 SP-6
- **OG reference:** `NellBrain/nell_bridge.py:55-301` (residue, system message, tool loop, persist) + `nell_bridge_session.py` (SessionState)

## What landed

**`brain/chat/` package (new, 6 modules):**
- `voice.py` — voice.md loader with auto-heal + `DEFAULT_VOICE_TEMPLATE` (4 sections: Who you are / What's in your head / How emotion shapes your voice / Your boundaries with the user)
- `prompt.py` — `build_system_message()` composing AS_NELL_PREAMBLE + voice.md + brain context block (emotion state + daemon residue from SP-2 + soul highlights from SP-5)
- `session.py` — `SessionState` dataclass + module-level registry. UUIDv4 session_id, history truncated at 20 turn pairs (40 messages), in-memory only (no cross-CLI persistence by design).
- `tool_loop.py` — `run_tool_loop()` wrapping SP-1's `provider.chat(messages, tools)` + SP-3's `dispatch()`. Max 4 iterations; final pass forced no-tools to obligate content response. Per-invocation records with name/arguments/result_summary/error.
- `engine.py` — `respond(persona_dir, user_input, *, store, hebbian, provider, session, voice_md_override) -> ChatResult`. Orchestrates load voice → load daemon state → open soul store → build system message → run tool loop → persist turn (session.append + SP-4 ingest_turn for both speakers) → return ChatResult.
- `__init__.py` — public exports.

**Health module updates:**
- `brain/health/attempt_heal.py` — new `attempt_heal_text()` + `_heal_text_from_baks()` for plain-text identity files (voice.md is text, not JSON)
- `brain/health/walker.py` — `_TEXT_IDENTITY_FILES` includes `voice.md`
- `brain/health/alarm.py` — `voice.md` in `_IDENTITY_FILES`

**CLI:**
- `nell chat --persona X "single message"` — one-shot turn, prints response, exits
- `nell chat --persona X` — interactive REPL (Ctrl+D / `exit` / `quit` to leave; flushes session via `close_session()` from SP-4 on exit)
- `--provider` flag honors per-persona config or override (text-mode for Claude CLI / Ollama / fake)

## Live sandbox smoke (verified end-to-end)

```bash
$ uv run nell chat --persona nell.sandbox --provider fake "hello, how are you feeling?"
FAKE_CHAT: response 135d64fe11d7216e

$ cat ~/Library/Application\ Support/companion-emergence/personas/nell.sandbox/active_conversations/042ffad3-*.jsonl
{"session_id": "042ffad3-...", "speaker": "user", "text": "hello, how are you feeling?", "ts": "2026-04-26T19:23:36+00:00"}
{"session_id": "042ffad3-...", "speaker": "assistant", "text": "FAKE_CHAT: response 135d64fe11d7216e", "ts": "2026-04-26T19:23:36+00:00"}
```

The chat persists to SP-4's conversation buffer. Voice.md was auto-generated from the default template on first chat. SP-2's daemon residue was checked (none yet on a fresh sandbox; would inject on next tick if any). SP-5's soul highlights were checked (empty for nell.sandbox; would inject if crystallizations existed). The brain has conversation.

## Test plan

- [x] **870 passed** (was 821 after SP-5 merge; +49 net new)
- [x] 5 voice.md tests (load default / heal corrupt / heal from bak / template structure / attempt_heal_text round-trip)
- [x] 6 SessionState tests (create / append / truncate / turns counter / get_session / reset_registry)
- [x] 5 prompt-building tests (preamble / voice content / residue inclusion / soul inclusion / emotion summary)
- [x] 6 tool-loop tests (no-tool-calls / dispatches-and-continues / max-iterations-cap / dispatch-error / invocation-order / build_tools_list shape)
- [x] 6 engine tests (creates session / appends to existing / ChatResult shape / persist via ingest_turn / handles tool calls / persistence error doesn't break response)
- [x] 5 CLI tests (one-shot / exit code / REPL exit / REPL EOF / missing persona)
- [x] 3 attempt_heal_text tests in health suite
- [x] `ruff check && ruff format --check` clean
- [x] Zero `import anthropic` in `brain/chat/`
- [x] Zero `nell_brain` / `nell_bridge` imports in `brain/chat/` — full isolation

## Cross-sub-project integration

SP-6 finally composes everything:

| From | Into chat |
|------|-----------|
| SP-1 `provider.chat(messages, tools)` | tool_loop drives every LLM turn |
| SP-2 `load_daemon_state` + `get_residue_context` | injected into system message |
| SP-3 `dispatch(name, args)` + tool schemas | tool_loop dispatches each tool_call |
| SP-4 `ingest_turn` + `close_session` | per-turn persistence + on-exit flush |
| SP-5 `SoulStore.list_active` | soul highlights in system message |
| Brain-health `attempt_heal_text` (new) | voice.md auto-heals on corruption |

## Deviations from brief

1. **`_build_emotion_summary` uses `store._conn` directly.** MemoryStore has no public `recent()` method. Adding one would have been the cleaner design but expanded SP-6's scope into existing-module surgery. Tagged with `# noqa: SLF001` and a comment.
2. **`attempt_heal_text` writes default-to-disk on missing-file path.** Slightly more aggressive than `attempt_heal` (which returns silently for missing files). Reasoning: voice.md being on-disk after first load means subsequent loads see real content rather than re-triggering the missing-file path. Aligns with attempt_heal's "leave the file in a known-good state" philosophy.
3. **Walker.py voice.md scan uses `break`** after the single-text-file loop — defensive when more text identity files are added later.

## What's NOT in v1 (deferred)

- **`nell setup --persona X` wizard** — separate sub-project (SP-6.5). Voice.md template generation, 4-LLM picker, Ollama install handling, persona config scaffolding. Significant work; cleaner as its own PR.
- **Streaming responses** — Phase 6.5; OllamaProvider already has a `chat_stream` skeleton (TODO comment).
- **Multi-modal** (images, audio, voice synthesis) — out of scope.

## Follow-ups

- **SP-6.5 wizard** — `nell setup --persona X` (next PR)
- **SP-7 bridge daemon** — wraps chat engine in HTTP/WebSocket server (FastAPI), folds supervisor + event broadcaster
- **SP-8 Tauri integration** — when art assets land