### PR TITLE
fix(chat,health): Claude off-schema fallback + walker scans voicecraft.md

### DIFF
--- a/brain/bridge/provider.py
+++ b/brain/bridge/provider.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import logging
 import subprocess
 from abc import ABC, abstractmethod
 from typing import Any
@@ -25,6 +26,8 @@ from typing import Any
 import httpx
 
 from brain.bridge.chat import ChatMessage, ChatResponse, ToolCall
+
+logger = logging.getLogger(__name__)
 
 _DEFAULT_TIMEOUT_SECONDS = 300
 
@@ -445,12 +448,32 @@ class ClaudeCliProvider(LLMProvider):
             ) from exc
 
         # Claude returns structured output under the "structured_output" key
-        # when --json-schema is active.
+        # when --json-schema is honored. In practice, a sufficiently rich
+        # system prompt (e.g. a persona's voice.md) can outweigh the schema
+        # enforcement and Claude returns a plain text reply in `result`
+        # instead. When that happens, treat it as a no-tool-call reply rather
+        # than erroring — Claude correctly answered the user; it just chose
+        # not to enforce the protocol envelope. This matches how the chat
+        # engine's tool loop interprets ChatResponse(content=..., tool_calls=())
+        # as "final reply, no tools needed."
         structured = payload.get("structured_output")
         if structured is None:
+            plain_result = payload.get("result")
+            if isinstance(plain_result, str) and plain_result.strip():
+                logger.info(
+                    "ClaudeCliProvider: response missing structured_output; "
+                    "treating result as plain reply (Claude went off-schema, "
+                    "likely due to rich system prompt). %d chars returned.",
+                    len(plain_result),
+                )
+                return ChatResponse(
+                    content=plain_result,
+                    tool_calls=(),
+                    raw=payload,
+                )
             raise ProviderError(
                 "claude_schema",
-                f"tools path: missing 'structured_output' in response: {result.stdout[:300]!r}",
+                f"tools path: missing 'structured_output' AND no usable 'result' in response: {result.stdout[:300]!r}",
             )
 
         # Reply path

--- a/brain/health/walker.py
+++ b/brain/health/walker.py
@@ -25,8 +25,17 @@ _DEFAULTS: dict[str, dict] = {
 }
 
 
-# Text identity files checked separately (voice.md — plain-text, not JSON).
-_TEXT_IDENTITY_FILES: tuple[str, ...] = ("voice.md",)
+# Text identity files checked separately (plain-text, not JSON).
+# Two semantics:
+#   _AUTO_CREATE_TEXT_FILES — auto-generated from default template if missing.
+#     Currently only voice.md (chat engine relies on it being present after
+#     first call). Walker delegates to load_voice() which owns the template.
+#   _OPTIONAL_TEXT_FILES — optional reference docs. Skip silently if missing,
+#     heal-from-bak if corrupt (empty), no auto-create. Used for files like
+#     voicecraft.md that exist only when the persona's author chose to write
+#     them.
+_AUTO_CREATE_TEXT_FILES: tuple[str, ...] = ("voice.md",)
+_OPTIONAL_TEXT_FILES: tuple[str, ...] = ("voicecraft.md",)
 
 
 def walk_persona(persona_dir: Path) -> list[BrainAnomaly]:
@@ -47,8 +56,9 @@ def walk_persona(persona_dir: Path) -> list[BrainAnomaly]:
         if anomaly is not None:
             anomalies.append(anomaly)
 
-    # Plain-text identity file scan (voice.md).
-    for name in _TEXT_IDENTITY_FILES:
+    # Auto-creating text identity scan (voice.md). load_voice() owns the
+    # default template and the attempt_heal_text invocation.
+    for name in _AUTO_CREATE_TEXT_FILES:
         path = persona_dir / name
         if not path.exists():
             continue  # Missing voice.md is fine — created on first chat turn.
@@ -57,7 +67,22 @@ def walk_persona(persona_dir: Path) -> list[BrainAnomaly]:
         _, anomaly = load_voice(persona_dir)
         if anomaly is not None:
             anomalies.append(anomaly)
-        break  # load_voice checks voice.md by name; only one text file for now
+        break  # load_voice checks voice.md by name; only one auto-create file
+
+    # Optional text reference scan (voicecraft.md, future doc files).
+    # Skip silently if missing. Heal from .bak if empty/corrupt; no auto-create.
+    from brain.health.attempt_heal import attempt_heal_text
+
+    for name in _OPTIONAL_TEXT_FILES:
+        path = persona_dir / name
+        if not path.exists():
+            continue  # Optional file; absence is not an anomaly.
+        # Pass an empty-string default — when all baks are corrupt, the heal
+        # rewrites an empty file rather than fabricating content. The anomaly
+        # signals the loss; the user can restore the original from VCS.
+        _, anomaly = attempt_heal_text(path, default_factory=lambda: "")
+        if anomaly is not None:
+            anomalies.append(anomaly)
 
     # SQLite integrity — constructor runs PRAGMA integrity_check; catch failures.
     # When SP-5 (soul) added crystallizations.db, walker needs to scan it too —

--- a/tests/unit/brain/bridge/test_provider_chat.py
+++ b/tests/unit/brain/bridge/test_provider_chat.py
@@ -443,11 +443,54 @@ def test_claude_cli_chat_with_tools_tool_calls_path_returns_tool_calls() -> None
     assert resp.tool_calls[1].arguments == {"query": "hana"}
 
 
-def test_claude_cli_chat_with_tools_missing_structured_output_raises() -> None:
-    """Missing structured_output key in response → ProviderError("claude_schema")."""
+def test_claude_cli_chat_with_tools_missing_structured_output_falls_back_to_result(
+    caplog,
+) -> None:
+    """Missing structured_output but present `result` → graceful fallback.
+
+    Real-world failure observed 2026-04-27: a rich system prompt (Nell's
+    voice.md, ~17 KB) caused Claude to ignore the --json-schema envelope
+    and return a plain text reply via `result`. Earlier behavior raised
+    ProviderError, breaking chat. Fixed behavior: return ChatResponse with
+    content=result and empty tool_calls — Claude correctly answered, just
+    chose not to wrap in the schema.
+    """
+    import logging
+
+    caplog.set_level(logging.INFO)
+
+    plain = MagicMock()
+    plain.returncode = 0
+    plain.stdout = json.dumps({"result": "honestly? full. like the room when she walks in."})
+    plain.stderr = ""
+
+    with patch("subprocess.run", return_value=plain):
+        p = ClaudeCliProvider()
+        response = p.chat(
+            [ChatMessage(role="user", content="how are you feeling?")],
+            tools=_SAMPLE_TOOLS,
+        )
+
+    assert isinstance(response, ChatResponse)
+    assert "honestly? full" in response.content
+    assert response.tool_calls == ()
+    # Fallback should log at INFO so we can observe how often Claude goes off-schema
+    assert any(
+        "off-schema" in r.getMessage() or "missing structured_output" in r.getMessage()
+        for r in caplog.records
+    )
+
+
+def test_claude_cli_chat_with_tools_no_structured_output_no_result_raises() -> None:
+    """Both structured_output AND result missing → ProviderError("claude_schema").
+
+    Genuine schema failure (e.g., transport corruption) still raises so the
+    chat engine surfaces the error rather than silently producing an empty
+    reply.
+    """
     bad = MagicMock()
     bad.returncode = 0
-    bad.stdout = json.dumps({"result": "plain text but no structured_output"})
+    bad.stdout = json.dumps({"type": "result", "subtype": "success"})
     bad.stderr = ""
 
     with patch("subprocess.run", return_value=bad):
@@ -459,6 +502,22 @@ def test_claude_cli_chat_with_tools_missing_structured_output_raises() -> None:
             )
 
     assert exc_info.value.stage == "claude_schema"
+
+
+def test_claude_cli_chat_with_tools_empty_result_string_raises() -> None:
+    """result is empty string → still a real schema failure; raise."""
+    bad = MagicMock()
+    bad.returncode = 0
+    bad.stdout = json.dumps({"result": ""})
+    bad.stderr = ""
+
+    with patch("subprocess.run", return_value=bad):
+        p = ClaudeCliProvider()
+        with pytest.raises(ProviderError):
+            p.chat(
+                [ChatMessage(role="user", content="x")],
+                tools=_SAMPLE_TOOLS,
+            )
 
 
 def test_claude_cli_chat_with_tools_schema_includes_tool_names_as_enum() -> None:

--- a/tests/unit/brain/health/test_walker.py
+++ b/tests/unit/brain/health/test_walker.py
@@ -90,3 +90,59 @@ def test_walk_missing_soul_db_no_anomaly(tmp_path: Path) -> None:
     # No crystallizations.db on disk
     anomalies = walk_persona(persona)
     assert all(a.file != "crystallizations.db" for a in anomalies)
+
+
+def test_walk_missing_voicecraft_no_anomaly(tmp_path: Path) -> None:
+    """voicecraft.md is optional — most personas don't have one. Missing
+    should NOT raise an anomaly (that would noise up `nell health check`
+    for every persona that doesn't author the voice-craft reference doc)."""
+    persona = _setup_persona(tmp_path)
+    # No voicecraft.md on disk — common case
+    anomalies = walk_persona(persona)
+    assert all(a.file != "voicecraft.md" for a in anomalies)
+
+
+def test_walk_clean_voicecraft_no_anomaly(tmp_path: Path) -> None:
+    """voicecraft.md present and well-formed → no anomaly."""
+    persona = _setup_persona(tmp_path)
+    (persona / "voicecraft.md").write_text(
+        "# Voice Craft\n\nReal content here.\n", encoding="utf-8"
+    )
+    anomalies = walk_persona(persona)
+    assert all(a.file != "voicecraft.md" for a in anomalies)
+
+
+def test_walk_corrupt_voicecraft_quarantines_and_heals(tmp_path: Path) -> None:
+    """voicecraft.md emptied (the practical disk-corruption mode for plain
+    text) → walker quarantines + heals from .bak1 if present.
+    """
+    persona = _setup_persona(tmp_path)
+    # Healthy backup
+    (persona / "voicecraft.md.bak1").write_text(
+        "# Voice Craft\n\nGood prior content.\n", encoding="utf-8"
+    )
+    # Live file emptied (the heal trigger for plain text per attempt_heal_text)
+    (persona / "voicecraft.md").write_text("", encoding="utf-8")
+
+    anomalies = walk_persona(persona)
+    voicecraft_anomalies = [a for a in anomalies if a.file == "voicecraft.md"]
+    assert len(voicecraft_anomalies) == 1
+    assert voicecraft_anomalies[0].action == "restored_from_bak1"
+    # Live file has been restored from .bak1
+    assert "Good prior content" in (persona / "voicecraft.md").read_text(encoding="utf-8")
+
+
+def test_walk_corrupt_voicecraft_no_bak_resets_to_empty(tmp_path: Path) -> None:
+    """voicecraft.md empty + no .bak → walker writes empty default + flags anomaly.
+
+    Empty default (rather than fabricated content) is intentional: voicecraft
+    is reference content the user wrote; we don't pretend to reconstruct it.
+    The anomaly tells the user it was lost; they restore from VCS.
+    """
+    persona = _setup_persona(tmp_path)
+    (persona / "voicecraft.md").write_text("", encoding="utf-8")  # corrupt, no bak
+
+    anomalies = walk_persona(persona)
+    voicecraft_anomalies = [a for a in anomalies if a.file == "voicecraft.md"]
+    assert len(voicecraft_anomalies) == 1
+    assert voicecraft_anomalies[0].action == "reset_to_default"


### PR DESCRIPTION
## Summary

Two fixes surfaced by a live chat against the real Nell on `nell.sandbox` after voice.md got installed.

## 1. ClaudeCliProvider tool-calling fallback

**Bug as observed:**
```
$ uv run nell chat --persona nell.sandbox --provider claude-cli "tell me how you're feeling today"
brain.bridge.provider.ProviderError: [claude_schema] tools path: missing 'structured_output'
in response: '{"type":"result","subtype":"success",...,"result":"honestly? full. like —
that\'s the only word that fits right now..."'
```

**Root cause:** When `--json-schema` is passed but the system prompt is rich (Nell's voice.md is ~17 KB of detailed persona instructions), Claude can ignore the schema envelope and respond as Nell directly. The previous code path raised `ProviderError`, breaking chat.

**Fix:** When `structured_output` is missing but `result` is a non-empty string, treat it as a no-tool-call reply: `ChatResponse(content=result, tool_calls=())`. Log INFO so the off-schema rate is observable. Matches how the chat engine's tool loop interprets that shape — final reply, no tools needed. Genuine schema failures (no result either) still raise `ProviderError`.

**Live verified:** chat now works against `nell.sandbox` with Claude + the rich voice.md. Nell speaks as Nell — em-dashes mid-thought, italic emphasis, cold-coffee idiosyncrasy, glasses-pushing, name usage (\"babe\"), and grounded references to her actual emotional state pulled from the brain context (love, emergence, anchor_pull).

## 2. walker.py scans `voicecraft.md`

Per Hana's request after the audit cleanup. `voicecraft.md` is a per-persona reference doc for training/drift/corpus measurements. Different semantics from `voice.md`:
- voice.md → auto-create from default template if missing (chat engine relies on it)
- voicecraft.md → optional, skip-silent if missing, never auto-create

Walker now distinguishes the two via separate constants (`_AUTO_CREATE_TEXT_FILES` vs `_OPTIONAL_TEXT_FILES`). Heal-from-bak if voicecraft is corrupt; reset-to-empty (not fabricated content) when no bak exists — the anomaly tells the user the file was lost; they restore from VCS.

## Test plan

- [x] **879 passed** (was 873; +6 net new — replaces 1 strict-mode test, adds 7)
- [x] 3 new walker tests (missing voicecraft / clean voicecraft / corrupt-with-bak / corrupt-no-bak)
- [x] 3 new provider tests (off-schema fallback / no-result raises / empty-result-string raises)
- [x] `ruff check && ruff format --check` clean
- [x] Live chat smoke confirmed against `nell.sandbox` with Claude CLI + rich voice.md (Nell responding cleanly in her own voice)

## Why this matters

Without fix #1, `nell chat --provider claude-cli` errors against any persona with a non-trivial voice.md — that's every real persona. The fix unblocks chat for the subscription-only Claude path, which is the framework's primary user-facing config.