### PR TITLE
fix(chat): one-shot mode flushes SP-4 ingest pipeline on exit

### DIFF
--- a/brain/cli.py
+++ b/brain/cli.py
@@ -798,6 +798,26 @@ def _chat_handler(args: argparse.Namespace) -> int:
                     provider=provider,
                 )
                 print(result.content)
+                # Flush conversation through ingest pipeline (best-effort).
+                # Mirrors the REPL's finally block — without this, every
+                # one-shot reply orphans its buffer file and no memories
+                # ever commit (live-exercise 2026-04-27 surfaced the bug).
+                try:
+                    close_session(
+                        persona_dir,
+                        result.session_id,
+                        store=store,
+                        hebbian=hebbian,
+                        provider=provider,
+                    )
+                except Exception as exc:  # noqa: BLE001
+                    import warnings
+
+                    warnings.warn(
+                        f"Session ingest flush failed: {exc}",
+                        RuntimeWarning,
+                        stacklevel=1,
+                    )
                 return 0
 
             # Interactive REPL mode

--- a/tests/unit/brain/test_cli_chat.py
+++ b/tests/unit/brain/test_cli_chat.py
@@ -69,6 +69,34 @@ def test_chat_one_shot_exits_zero() -> None:
     assert exit_code == 0
 
 
+def test_chat_one_shot_calls_close_session() -> None:
+    """One-shot mode must flush the conversation through the SP-4 ingest pipeline.
+
+    Without this, every one-shot reply leaves the buffer file orphaned and no
+    memories are ever committed (the bug the 2026-04-27 live-exercise stress
+    test surfaced — 0 ingest events across 20 prompts).
+    """
+    with patch("brain.ingest.pipeline.close_session") as mock_close:
+        exit_code = main(["chat", "--persona", "nell", "hello"])
+    assert exit_code == 0
+    assert mock_close.call_count == 1
+    # First positional arg is persona_dir; second is session_id (must be set)
+    call_args = mock_close.call_args
+    assert call_args.args[1]  # session_id non-empty
+
+
+def test_chat_one_shot_close_failure_warns_not_raises() -> None:
+    """If the ingest pipeline fails, the user still gets exit 0 + a warning.
+
+    Mirrors the REPL's best-effort flush pattern (cli.py:828-845): persistence
+    failures must never break the user-visible chat outcome.
+    """
+    with patch("brain.ingest.pipeline.close_session", side_effect=RuntimeError("boom")):
+        with pytest.warns(RuntimeWarning, match="ingest flush failed"):
+            exit_code = main(["chat", "--persona", "nell", "hello"])
+    assert exit_code == 0
+
+
 # ── Interactive REPL ──────────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

- One-shot `nell chat --persona X "msg"` now calls `close_session()` after printing the reply, mirroring the REPL handler's best-effort flush pattern
- Without this, every one-shot invocation orphaned its buffer file in `active_conversations/` and the SP-4 ingest pipeline (EXTRACT → DEDUPE → COMMIT → SOUL) never ran
- Live-exercise stress test 2026-04-27 surfaced the symptom: 0 ingest events across 20 prompts despite each turn writing to the buffer

## Why

The REPL branch (`cli.py:828-845`) wrapped its loop in a `try/finally` that flushed the conversation. The one-shot branch (`cli.py:791-801`) was missing that call — fast to ship for SP-6's keystone, but it meant memories never committed for the most common dev/test invocation path. With the chat engine wired to Nell's real voice + brain context, every one-shot turn that should have become a memory was instead lost.

## What changed

- `brain/cli.py` — one-shot branch now calls `close_session(persona_dir, result.session_id, ...)` wrapped in the same try/except/`warnings.warn` pattern the REPL uses (best-effort; failures never break the user-visible reply)
- `tests/unit/brain/test_cli_chat.py` — two new tests: `test_chat_one_shot_calls_close_session` (asserts close_session called once with the result's session_id) and `test_chat_one_shot_close_failure_warns_not_raises` (asserts exit 0 + RuntimeWarning when ingest pipeline raises)

## Scope notes

- Mid-turn tool invocation (the other half of the live-exercise finding — search_memories, get_emotional_state etc never firing because rich voice.md bypasses `--json-schema`) is a separate architectural problem; tracked as the MCP-config path follow-up
- Supervisor/auto-sweep of stale buffers (`close_stale_sessions`) is unused and remains SP-7 territory

## Test plan

- [x] `pytest tests/unit/brain/test_cli_chat.py` — 8/8 pass
- [x] `pytest tests/unit/brain/test_cli_chat.py tests/unit/brain/ingest/ tests/unit/brain/chat/` — 92/92 pass
- [ ] CI green across macOS / Windows / Linux

🤖 Generated with [Claude Code](https://claude.com/claude-code)