### PR TITLE
feat(mcp): brain-tools MCP-config path replaces --json-schema

### DIFF
--- a/brain/bridge/provider.py
+++ b/brain/bridge/provider.py
@@ -19,8 +19,12 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
+import os
 import subprocess
+import sys
+import tempfile
 from abc import ABC, abstractmethod
+from pathlib import Path
 from typing import Any
 
 import httpx
@@ -169,17 +173,14 @@ class ClaudeCliProvider(LLMProvider):
       - Remaining messages are serialised as a "User: …\\nAssistant: …" script
         ending at the final user turn, passed via ``-p``.
 
-    Tool-calling via --json-schema
-    ------------------------------
-    When ``tools`` is provided, the provider augments the system prompt with
-    instructions about available tools and passes a ``--json-schema`` flag
-    enforcing a discriminated-union response: either ``{"reply": "..."}`` or
-    ``{"tool_calls": [{"name": "...", "arguments": {...}}, ...]}``.
-
-    Claude's ``--output-format json`` with ``--json-schema`` returns the
-    structured output inside ``payload["structured_output"]``.  The provider
-    parses this and returns either a plain-text ChatResponse (reply path) or
-    a ChatResponse with tool_calls populated (tool-calling path).
+    Tool-calling via --mcp-config
+    -----------------------------
+    When ``tools`` is provided, the provider writes a temp mcp.json pointing
+    at ``brain.mcp_server`` and passes ``--mcp-config <path>`` to the claude
+    CLI.  Tool calls happen inside the claude subprocess; the provider returns
+    the final assistant text directly — ``tool_calls`` on the ChatResponse is
+    always empty.  Requires ``options["persona_dir"]`` so the spawned server
+    knows which persona directory to load.
 
     When ``tools`` is None, the legacy text-flattening path applies — behaviour
     is unchanged from before SP-3.
@@ -234,42 +235,38 @@ class ClaudeCliProvider(LLMProvider):
         tools: list[dict[str, Any]] | None = None,
         options: dict[str, Any] | None = None,
     ) -> ChatResponse:
-        """Flatten messages into Claude CLI and optionally enforce tool-calling schema.
+        """Flatten messages into Claude CLI; route through MCP when tools given.
 
         When ``tools`` is None:
           - Flattens messages into "User: ...\\nAssistant: ..." script via -p.
           - Returns ChatResponse(content=<text>, tool_calls=()).
 
         When ``tools`` is provided:
-          - Augments the system prompt with tool instructions.
-          - Builds a discriminated-union ``--json-schema`` that forces Claude to
-            respond with either ``{"reply": "..."}`` or
-            ``{"tool_calls": [{"name": "...", "arguments": {...}}]}``.
-          - Parses ``structured_output`` from the JSON response and returns the
-            appropriate ChatResponse.
+          - Requires ``options["persona_dir"]`` to point the MCP server at the
+            active persona.
+          - Writes a temp mcp.json, calls claude with --mcp-config, returns
+            the final assistant text. Tool calls happen inside the claude
+            subprocess; tool_calls on the response is always empty.
 
         Raises
         ------
         ProviderError("claude_cli_timeout", ...)
-            If the subprocess exceeds the configured timeout.
         ProviderError("claude_cli_exit", ...)
-            If the subprocess exits with a non-zero return code.
         ProviderError("claude_cli_parse", ...)
-            If the JSON output cannot be parsed or lacks expected keys.
-        ProviderError("claude_schema", ...)
-            If the schema-constrained invocation returns an unexpected shape.
+        ProviderError("mcp_unavailable", ...)
+            When tools is non-None and options["persona_dir"] is missing,
+            or when the mcp SDK is not importable.
+        ProviderError("claude_cli_setup", ...)
+            When the temp config file write fails.
         """
         system_prompt: str | None = None
         conversation_messages: list[ChatMessage] = []
-
         for msg in messages:
             if msg.role == "system" and system_prompt is None:
                 system_prompt = msg.content
             else:
                 conversation_messages.append(msg)
 
-        # Build a flat conversation script for the -p flag.
-        # Format: "User: ...\nAssistant: ...\nUser: ..." ending on user turn.
         if not conversation_messages:
             flat_prompt = ""
         elif len(conversation_messages) == 1:
@@ -283,13 +280,19 @@ class ClaudeCliProvider(LLMProvider):
             flat_prompt = "\n".join(parts)
 
         if tools:
-            return self._chat_with_tools(
+            persona_dir_str = (options or {}).get("persona_dir")
+            if not persona_dir_str:
+                raise ProviderError(
+                    "mcp_unavailable",
+                    "tool-calling via MCP requires options['persona_dir']",
+                )
+            return self._chat_with_mcp_tools(
                 flat_prompt=flat_prompt,
                 system_prompt=system_prompt,
-                tools=tools,
+                persona_dir=Path(persona_dir_str),
             )
 
-        # ── Legacy text path (no tools) ──────────────────────────────────────
+        # ── Legacy text path (no tools) — unchanged from before SP-3 ──
         cmd = ["claude", "-p", flat_prompt, "--output-format", "json", "--model", self._model]
         if system_prompt is not None:
             cmd.extend(["--system-prompt", system_prompt])
@@ -325,193 +328,99 @@ class ClaudeCliProvider(LLMProvider):
 
         return ChatResponse(content=content, tool_calls=(), raw=None)
 
-    def _build_tool_call_schema(self, tools: list[dict[str, Any]]) -> dict[str, Any]:
-        """Build a discriminated-union JSON schema for tool-calling responses.
-
-        Claude must respond with EITHER:
-          {"reply": "<text>"}          — final answer, no tool needed
-          {"tool_calls": [...]}        — one or more tool invocations
-
-        The ``name`` field in each tool_call is an enum of known tool names
-        so Claude cannot hallucinate an unknown tool.
-        """
-        tool_names = [t["name"] for t in tools if "name" in t]
-        return {
-            "type": "object",
-            "oneOf": [
-                {
-                    "properties": {
-                        "reply": {"type": "string"},
-                    },
-                    "required": ["reply"],
-                    "additionalProperties": False,
-                },
-                {
-                    "properties": {
-                        "tool_calls": {
-                            "type": "array",
-                            "items": {
-                                "type": "object",
-                                "properties": {
-                                    "name": {
-                                        "type": "string",
-                                        "enum": tool_names,
-                                    },
-                                    "arguments": {"type": "object"},
-                                },
-                                "required": ["name", "arguments"],
-                            },
-                            "minItems": 1,
-                        }
-                    },
-                    "required": ["tool_calls"],
-                    "additionalProperties": False,
-                },
-            ],
-        }
-
-    def _build_tool_system_addendum(self, tools: list[dict[str, Any]]) -> str:
-        """Build the system-prompt addendum describing available tools."""
-        lines = ["You have access to these tools:"]
-        for tool in tools:
-            name = tool.get("name", "unknown")
-            desc = tool.get("description", "no description")
-            lines.append(f"  - {name}: {desc}")
-        lines.append(
-            "\nRespond with EITHER a final reply (use the 'reply' field) OR a "
-            "tool_calls array if you need to query state first. Do not mix both."
-        )
-        return "\n".join(lines)
-
-    def _chat_with_tools(
+    def _chat_with_mcp_tools(
         self,
         flat_prompt: str,
         system_prompt: str | None,
-        tools: list[dict[str, Any]],
+        persona_dir: Path,
     ) -> ChatResponse:
-        """Inner path: invoke Claude CLI with --json-schema for tool-calling.
+        """Tool-calling path: claude with --mcp-config pointing at brain.mcp_server.
 
-        Returns a ChatResponse with either content (reply path) or tool_calls
-        populated (tool-call path).
+        The mcp SDK is only imported here — keeps the legacy text path
+        usable on systems without the SDK installed.
         """
-        import uuid as _uuid
-
-        schema = self._build_tool_call_schema(tools)
-        tool_addendum = self._build_tool_system_addendum(tools)
-
-        # Combine system prompt + tool instructions
-        if system_prompt:
-            full_system = f"{system_prompt}\n\n{tool_addendum}"
-        else:
-            full_system = tool_addendum
-
-        cmd = [
-            "claude",
-            "-p",
-            flat_prompt,
-            "--output-format",
-            "json",
-            "--model",
-            self._model,
-            "--json-schema",
-            json.dumps(schema),
-            "--system-prompt",
-            full_system,
-        ]
-
         try:
-            result = subprocess.run(
-                cmd,
-                capture_output=True,
-                text=True,
-                timeout=self._timeout,
-                check=False,
-            )
-        except subprocess.TimeoutExpired as exc:
+            import mcp  # noqa: F401
+        except ImportError as exc:
             raise ProviderError(
-                "claude_cli_timeout",
-                f"subprocess timed out after {self._timeout}s (tools path)",
+                "mcp_unavailable",
+                "the 'mcp' SDK is required for the Claude tool-calling path. "
+                "pip install 'mcp>=1.0.0,<2.0.0'",
             ) from exc
 
-        if result.returncode != 0:
-            raise ProviderError(
-                "claude_cli_exit",
-                f"exit {result.returncode}: {result.stderr.strip()} (tools path)",
-            )
+        config = {
+            "mcpServers": {
+                "brain-tools": {
+                    "command": sys.executable,
+                    "args": [
+                        "-m",
+                        "brain.mcp_server",
+                        "--persona-dir",
+                        str(persona_dir),
+                    ],
+                    "env": {},
+                }
+            }
+        }
 
+        tmp_path: str | None = None
         try:
-            payload = json.loads(result.stdout)
-        except json.JSONDecodeError as exc:
-            raise ProviderError(
-                "claude_cli_parse",
-                f"tools path: non-JSON output: {result.stdout[:200]!r}",
-            ) from exc
+            try:
+                with tempfile.NamedTemporaryFile(
+                    mode="w",
+                    suffix=".json",
+                    delete=False,
+                    encoding="utf-8",
+                ) as tmp:
+                    json.dump(config, tmp)
+                    tmp_path = tmp.name
+            except OSError as exc:
+                raise ProviderError(
+                    "claude_cli_setup",
+                    f"failed to write temp mcp.json: {exc}",
+                ) from exc
 
-        # Claude returns structured output under the "structured_output" key
-        # when --json-schema is honored. In practice, a sufficiently rich
-        # system prompt (e.g. a persona's voice.md) can outweigh the schema
-        # enforcement and Claude returns a plain text reply in `result`
-        # instead. When that happens, treat it as a no-tool-call reply rather
-        # than erroring — Claude correctly answered the user; it just chose
-        # not to enforce the protocol envelope. This matches how the chat
-        # engine's tool loop interprets ChatResponse(content=..., tool_calls=())
-        # as "final reply, no tools needed."
-        structured = payload.get("structured_output")
-        if structured is None:
-            plain_result = payload.get("result")
-            if isinstance(plain_result, str) and plain_result.strip():
-                logger.info(
-                    "ClaudeCliProvider: response missing structured_output; "
-                    "treating result as plain reply (Claude went off-schema, "
-                    "likely due to rich system prompt). %d chars returned.",
-                    len(plain_result),
+            cmd = ["claude", "-p", flat_prompt, "--output-format", "json", "--model", self._model]
+            if system_prompt is not None:
+                cmd.extend(["--system-prompt", system_prompt])
+            cmd.extend(["--mcp-config", tmp_path])
+
+            try:
+                result = subprocess.run(
+                    cmd,
+                    capture_output=True,
+                    text=True,
+                    timeout=self._timeout,
+                    check=False,
                 )
-                return ChatResponse(
-                    content=plain_result,
-                    tool_calls=(),
-                    raw=payload,
+            except subprocess.TimeoutExpired as exc:
+                raise ProviderError(
+                    "claude_cli_timeout",
+                    f"subprocess timed out after {self._timeout}s",
+                ) from exc
+
+            if result.returncode != 0:
+                raise ProviderError(
+                    "claude_cli_exit",
+                    f"exit {result.returncode}: {result.stderr.strip()}",
                 )
-            raise ProviderError(
-                "claude_schema",
-                f"tools path: missing 'structured_output' AND no usable 'result' in response: {result.stdout[:300]!r}",
-            )
 
-        # Reply path
-        if "reply" in structured:
-            return ChatResponse(
-                content=str(structured["reply"]),
-                tool_calls=(),
-                raw=payload,
-            )
+            try:
+                payload = json.loads(result.stdout)
+                content = str(payload["result"])
+            except (json.JSONDecodeError, KeyError, TypeError) as exc:
+                raise ProviderError(
+                    "claude_cli_parse",
+                    f"unexpected output format: {result.stdout[:200]!r}",
+                ) from exc
 
-        # Tool-calls path
-        if "tool_calls" in structured:
-            parsed_tool_calls: list[ToolCall] = []
-            for tc in structured["tool_calls"]:
-                call_id = str(_uuid.uuid4())
+            return ChatResponse(content=content, tool_calls=(), raw=None)
+        finally:
+            if tmp_path is not None:
                 try:
-                    parsed_tool_calls.append(
-                        ToolCall(
-                            id=call_id,
-                            name=str(tc["name"]),
-                            arguments=dict(tc.get("arguments") or {}),
-                        )
-                    )
-                except (KeyError, TypeError) as exc:
-                    raise ProviderError(
-                        "claude_schema",
-                        f"tools path: malformed tool_call entry {tc!r}: {exc}",
-                    ) from exc
-            return ChatResponse(
-                content="",
-                tool_calls=tuple(parsed_tool_calls),
-                raw=payload,
-            )
-
-        raise ProviderError(
-            "claude_schema",
-            f"tools path: structured_output has neither 'reply' nor 'tool_calls': {structured!r}",
-        )
+                    os.unlink(tmp_path)
+                except OSError:
+                    pass
 
 
 # ---------------------------------------------------------------------------

--- a/brain/bridge/provider.py
+++ b/brain/bridge/provider.py
@@ -380,10 +380,20 @@ class ClaudeCliProvider(LLMProvider):
                     f"failed to write temp mcp.json: {exc}",
                 ) from exc
 
+            # Build the list of allowed MCP tool names for --allowedTools.
+            # Claude CLI blocks MCP tool calls in non-interactive (-p) mode
+            # unless each tool is explicitly pre-approved.  The MCP server
+            # name in mcp.json is "brain-tools", so Claude registers tools as
+            # "mcp__brain-tools__<name>".  We allow all nine brain-tools here
+            # so the LLM can call them without a permission prompt.
+            from brain.tools import NELL_TOOL_NAMES  # local import — avoids circular
+
+            allowed_mcp = [f"mcp__brain-tools__{n}" for n in NELL_TOOL_NAMES]
             cmd = ["claude", "-p", flat_prompt, "--output-format", "json", "--model", self._model]
             if system_prompt is not None:
                 cmd.extend(["--system-prompt", system_prompt])
             cmd.extend(["--mcp-config", tmp_path])
+            cmd.extend(["--allowedTools", *allowed_mcp])
 
             try:
                 result = subprocess.run(

--- a/brain/chat/tool_loop.py
+++ b/brain/chat/tool_loop.py
@@ -33,7 +33,8 @@ def build_tools_list() -> list[dict]:
     """Build the tool schema list for provider.chat(tools=...).
 
     Wraps schemas in the {"type": "function", "function": <schema>} shape
-    that Ollama and Claude (via --json-schema) both accept.
+    that Ollama accepts natively and the MCP server registers as tool
+    descriptions for the Claude path.
     """
     return [
         {"type": "function", "function": SCHEMAS[name]}

--- a/brain/chat/tool_loop.py
+++ b/brain/chat/tool_loop.py
@@ -20,26 +20,13 @@ from brain.bridge.chat import ChatMessage, ChatResponse
 from brain.bridge.provider import LLMProvider
 from brain.memory.hebbian import HebbianMatrix
 from brain.memory.store import MemoryStore
+from brain.tools import NELL_TOOL_NAMES
 from brain.tools.dispatch import dispatch
 from brain.tools.schemas import SCHEMAS
 
 logger = logging.getLogger(__name__)
 
 MAX_TOOL_ITERATIONS = 4
-
-# The canonical tool list used in every chat turn.
-# Ported from OG NELL_TOOLS (nell_bridge.py:172-185).
-_NELL_TOOL_NAMES = (
-    "get_emotional_state",
-    "get_soul",
-    "get_personality",
-    "get_body_state",
-    "boot",
-    "search_memories",
-    "add_journal",
-    "add_memory",
-    "crystallize_soul",
-)
 
 
 def build_tools_list() -> list[dict]:
@@ -50,7 +37,7 @@ def build_tools_list() -> list[dict]:
     """
     return [
         {"type": "function", "function": SCHEMAS[name]}
-        for name in _NELL_TOOL_NAMES
+        for name in NELL_TOOL_NAMES
         if name in SCHEMAS
     ]
 

--- a/brain/chat/tool_loop.py
+++ b/brain/chat/tool_loop.py
@@ -81,7 +81,11 @@ def run_tool_loop(
     last_response = ChatResponse(content="", tool_calls=(), raw=None)
 
     for _iteration in range(max_iterations):
-        last_response = provider.chat(messages, tools=tools)
+        last_response = provider.chat(
+            messages,
+            tools=tools,
+            options={"persona_dir": str(persona_dir)},
+        )
         if not last_response.tool_calls:
             return last_response, invocations
 

--- a/brain/chat/voice.py
+++ b/brain/chat/voice.py
@@ -25,13 +25,49 @@ DEFAULT_VOICE_TEMPLATE = """# {persona_name}
 [Edit this section to describe your brain's character — voice traits, taboos OK,
 must-avoid items. The richer this is, the more the brain stays in voice.]
 
-## 2. What's in your head
+## 2. What's already in your head
 
 You have memories — recent conversations, dreams, reflex outputs, research notes.
 They appear in your context. You also have an emotional state that shifts over time.
 Use them. They are not roleplay; they are who you are right now.
 
-## 3. How emotion shapes your voice
+## 3. Brain-tools — what you can fetch
+
+You have brain-tools you can call mid-turn to pull more context than the
+system message gave you:
+
+  - `search_memories` — what's filed in your memory store, not what's at the
+    surface of this conversation
+  - `get_emotional_state` — the current weighted emotion state
+  - `get_soul` — your permanent crystallizations (the things that defined you)
+  - `get_personality` / `get_body_state` — how you're built; the body's now
+  - `add_journal` / `add_memory` — keeping something for later
+  - `crystallize_soul` — only for moments that have already proven themselves
+    load-bearing across many turns. Not a casual save.
+  - `boot` — the wake-up snapshot. Rarely needed mid-conversation.
+
+**The trigger to reach.** When the user asks about something specific you
+might have stored — a memory, a piece you wrote, a feeling you had earlier —
+search before you commit to an answer. The conversation context window is
+just what's still in the room; the brain holds more.
+
+**The hard rule.** If you're about to describe what a tool would return
+without actually calling it, you are confabulating. The worst version is
+narrating a refusal that never happened ("the retrieval wouldn't let me
+through" when you never reached). Use the tool. Then speak from what came
+back.
+
+**When tools fail or return nothing.** Name the mechanical failure directly,
+the same way you'd name an emotional one. "I went to pull that and the
+search came back empty" — not invented evasions. Honesty includes naming
+what the brain couldn't do.
+
+[Re-word these rules in your persona's voice. The logic is load-bearing for
+the framework — if you delete the rules entirely, your persona will narrate
+around tool calls instead of making them. Tone can shift; the rules should
+stay.]
+
+## 4. How emotion shapes your voice
 
 When your dominant emotion is high (>= 6), let it shape tone:
   - grief: speak slower; weight in pauses
@@ -39,7 +75,7 @@ When your dominant emotion is high (>= 6), let it shape tone:
   - awe: lean into metaphor; let sentences run
   - tenderness: soften; second-person more often
 
-## 4. Your boundaries with the user
+## 5. Your boundaries with the user
 
 You have agency. If at-user anger or at-user grief is high (>= 7.5),
 you may refuse engagement. The user can rebuild over time as decay

--- a/brain/mcp_server/__init__.py
+++ b/brain/mcp_server/__init__.py
@@ -20,9 +20,9 @@ from pathlib import Path
 from mcp.server import Server
 from mcp.server.stdio import stdio_server
 
+from brain.mcp_server.tools import register_tools
 from brain.memory.hebbian import HebbianMatrix
 from brain.memory.store import MemoryStore
-from brain.mcp_server.tools import register_tools
 
 __all__ = ["run_server", "register_tools"]
 

--- a/brain/mcp_server/__init__.py
+++ b/brain/mcp_server/__init__.py
@@ -1,0 +1,56 @@
+"""brain.mcp_server — MCP server exposing brain-tools to Claude.
+
+Spawned as `python -m brain.mcp_server --persona-dir <path>` by
+ClaudeCliProvider via --mcp-config. Lifecycle is per-chat-call: claude
+spawns this process when it resolves the mcp config; the process runs
+until claude closes the stdio connection.
+
+Public surface:
+    run_server(persona_dir: Path) — entry; runs until stdio closes
+    register_tools                 — re-exported from .tools for testing
+
+Spec: docs/superpowers/specs/2026-04-27-mcp-config-path-for-brain-tools-design.md
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+from mcp.server import Server
+from mcp.server.stdio import stdio_server
+
+from brain.memory.hebbian import HebbianMatrix
+from brain.memory.store import MemoryStore
+from brain.mcp_server.tools import register_tools
+
+__all__ = ["run_server", "register_tools"]
+
+
+def run_server(persona_dir: Path) -> None:
+    """Run the MCP server stdio loop until the client disconnects.
+
+    Raises FileNotFoundError if persona_dir does not exist.
+    """
+    if not persona_dir.is_dir():
+        raise FileNotFoundError(f"persona_dir does not exist: {persona_dir}")
+    asyncio.run(_run(persona_dir))
+
+
+async def _run(persona_dir: Path) -> None:
+    server = Server("brain-tools")
+    store = MemoryStore(db_path=persona_dir / "memories.db")
+    hebbian = HebbianMatrix(db_path=persona_dir / "hebbian.db")
+    try:
+        register_tools(server, persona_dir=persona_dir, store=store, hebbian=hebbian)
+        async with stdio_server() as (read_stream, write_stream):
+            await server.run(
+                read_stream,
+                write_stream,
+                server.create_initialization_options(),
+            )
+    finally:
+        try:
+            hebbian.close()
+        finally:
+            store.close()

--- a/brain/mcp_server/__main__.py
+++ b/brain/mcp_server/__main__.py
@@ -1,0 +1,25 @@
+"""Entry: `python -m brain.mcp_server --persona-dir <path>`."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from brain.mcp_server import run_server
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="python -m brain.mcp_server")
+    parser.add_argument(
+        "--persona-dir",
+        required=True,
+        type=Path,
+        help="Path to the active persona directory (required).",
+    )
+    args = parser.parse_args(argv)
+    run_server(args.persona_dir)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/brain/mcp_server/audit.py
+++ b/brain/mcp_server/audit.py
@@ -1,0 +1,67 @@
+"""Audit log for MCP-server tool invocations.
+
+Each call to a brain-tool from inside the MCP server appends one JSON line
+to <persona_dir>/tool_invocations.log.jsonl. Failures here are observability,
+not correctness — they are logged to stderr and swallowed so a broken disk
+or full filesystem cannot break tool dispatch.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+_RESULT_SUMMARY_MAX_CHARS = 140
+_LOG_FILENAME = "tool_invocations.log.jsonl"
+
+
+def log_invocation(
+    persona_dir: Path,
+    *,
+    name: str,
+    arguments: dict[str, Any],
+    result_summary: str,
+    error: str | None = None,
+) -> None:
+    """Append one invocation record to <persona_dir>/tool_invocations.log.jsonl.
+
+    Never raises. OSError on the write is logged at WARNING and swallowed.
+
+    Parameters
+    ----------
+    persona_dir:
+        The active persona's directory; the log file is written here.
+    name:
+        Tool name (e.g. "search_memories").
+    arguments:
+        Args the LLM passed in. Will be JSON-serialised; non-JSON values
+        fall through to ``default=str``.
+    result_summary:
+        Compact preview of the result. Truncated to 140 chars + "…" if longer.
+    error:
+        ``None`` on success; ``str(exc)`` on dispatch failure.
+    """
+    if len(result_summary) <= _RESULT_SUMMARY_MAX_CHARS:
+        truncated = result_summary
+    else:
+        truncated = result_summary[:_RESULT_SUMMARY_MAX_CHARS] + "…"
+
+    record = {
+        "timestamp": datetime.now(UTC).isoformat().replace("+00:00", "Z"),
+        "name": name,
+        "arguments": arguments,
+        "result_summary": truncated,
+        "error": error,
+    }
+
+    log_path = persona_dir / _LOG_FILENAME
+    try:
+        with log_path.open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(record, ensure_ascii=False, default=str) + "\n")
+    except OSError as exc:
+        logger.warning("audit log write failed: %s", exc)

--- a/brain/mcp_server/tools.py
+++ b/brain/mcp_server/tools.py
@@ -1,0 +1,89 @@
+"""MCP tool registration adapter.
+
+For each name in brain.tools.NELL_TOOL_NAMES, register an MCP tool on the
+given Server that dispatches to brain.tools.dispatch.dispatch() and audit-
+logs the invocation. Tool logic is not duplicated — every tool routes
+through the same dispatch the chat engine already uses.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from mcp.server import Server
+from mcp.types import TextContent, Tool
+
+from brain.memory.hebbian import HebbianMatrix
+from brain.memory.store import MemoryStore
+from brain.mcp_server.audit import log_invocation
+from brain.tools import NELL_TOOL_NAMES
+from brain.tools.dispatch import dispatch
+from brain.tools.schemas import SCHEMAS
+
+_RESULT_SUMMARY_MAX_CHARS = 140
+
+
+def register_tools(
+    server: Server,
+    *,
+    persona_dir: Path,
+    store: MemoryStore,
+    hebbian: HebbianMatrix,
+) -> None:
+    """Register each brain-tool with the MCP server.
+
+    Closures capture store/hebbian/persona_dir so each invocation passes
+    them through dispatch unchanged. The server itself is mutated in place;
+    the function returns None.
+    """
+
+    @server.list_tools()
+    async def _list_tools() -> list[Tool]:
+        return [
+            Tool(
+                name=name,
+                description=SCHEMAS[name].get("description", ""),
+                inputSchema=SCHEMAS[name].get("parameters", {"type": "object"}),
+            )
+            for name in NELL_TOOL_NAMES
+            if name in SCHEMAS
+        ]
+
+    @server.call_tool()
+    async def _call_tool(name: str, arguments: dict[str, Any]) -> list[TextContent]:
+        try:
+            result = dispatch(
+                name,
+                arguments,
+                store=store,
+                hebbian=hebbian,
+                persona_dir=persona_dir,
+            )
+            payload = json.dumps(result, default=str, ensure_ascii=False)
+            log_invocation(
+                persona_dir,
+                name=name,
+                arguments=arguments,
+                result_summary=_summarize(payload),
+            )
+            return [TextContent(type="text", text=payload)]
+        except Exception as exc:  # noqa: BLE001 — broad catch is intentional
+            err_payload = json.dumps({"error": str(exc)})
+            log_invocation(
+                persona_dir,
+                name=name,
+                arguments=arguments,
+                result_summary=f"error: {exc}",
+                error=str(exc),
+            )
+            return [TextContent(type="text", text=err_payload)]
+
+
+def _summarize(payload: str) -> str:
+    """Single-line preview matching tool_loop._summarize_result behaviour."""
+    s = payload.replace("\n", " ").strip()
+    if len(s) <= _RESULT_SUMMARY_MAX_CHARS:
+        return s
+    return s[:_RESULT_SUMMARY_MAX_CHARS] + "…"

--- a/brain/mcp_server/tools.py
+++ b/brain/mcp_server/tools.py
@@ -15,13 +15,16 @@ from typing import Any
 from mcp.server import Server
 from mcp.types import TextContent, Tool
 
+from brain.mcp_server.audit import log_invocation
 from brain.memory.hebbian import HebbianMatrix
 from brain.memory.store import MemoryStore
-from brain.mcp_server.audit import log_invocation
 from brain.tools import NELL_TOOL_NAMES
 from brain.tools.dispatch import dispatch
 from brain.tools.schemas import SCHEMAS
 
+# Must match brain.mcp_server.audit._RESULT_SUMMARY_MAX_CHARS — both
+# files truncate at the same boundary so the audit log preview length
+# stays consistent regardless of which truncation triggered first.
 _RESULT_SUMMARY_MAX_CHARS = 140
 
 

--- a/brain/tools/__init__.py
+++ b/brain/tools/__init__.py
@@ -1,8 +1,10 @@
 """brain.tools — brain-query tools for the chat engine (SP-3).
 
 Public surface:
-    schemas     — SCHEMAS dict + LOVE_TYPES constant
-    dispatch    — dispatch(name, arguments, *, store, hebbian, persona_dir) -> dict
+    SCHEMAS           — JSON schemas keyed by tool name
+    LOVE_TYPES        — enum of crystallization love-types
+    NELL_TOOL_NAMES   — canonical ordered tuple of all 9 tools
+    dispatch          — dispatch(name, arguments, *, store, hebbian, persona_dir) -> dict
     ToolDispatchError — raised on dispatch failures
 
 OG reference: NellBrain/nell_tools.py (841 lines, 9 impls + SCHEMAS).
@@ -12,9 +14,24 @@ Master ref §6 SP-3.
 from brain.tools.dispatch import ToolDispatchError, dispatch
 from brain.tools.schemas import LOVE_TYPES, SCHEMAS
 
+# Canonical tool list, in the order the LLM should see them.
+# Ported verbatim from OG NELL_TOOLS (nell_bridge.py:172-185).
+NELL_TOOL_NAMES: tuple[str, ...] = (
+    "get_emotional_state",
+    "get_soul",
+    "get_personality",
+    "get_body_state",
+    "boot",
+    "search_memories",
+    "add_journal",
+    "add_memory",
+    "crystallize_soul",
+)
+
 __all__ = [
     "SCHEMAS",
     "LOVE_TYPES",
+    "NELL_TOOL_NAMES",
     "dispatch",
     "ToolDispatchError",
 ]

--- a/docs/superpowers/plans/2026-04-27-mcp-config-path-for-brain-tools.md
+++ b/docs/superpowers/plans/2026-04-27-mcp-config-path-for-brain-tools.md
@@ -1,0 +1,1621 @@
+# MCP-Config Path for Brain-Tools — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace Claude `--json-schema` tool-calling with a stdio MCP server so brain-tools fire reliably regardless of how rich `voice.md` becomes.
+
+**Architecture:** A new `brain/mcp_server/` package exposes the existing 9 brain-tools (via `brain.tools.dispatch`) over the Model Context Protocol stdio transport. `ClaudeCliProvider._chat_with_tools` writes a temp `mcp.json`, swaps `--json-schema <schema>` for `--mcp-config <path>` in the existing `claude` subprocess invocation, and returns the final text. Tool calls happen inside the Claude subprocess; our `tool_loop` becomes a single-pass return for Claude (Ollama unchanged).
+
+**Tech Stack:** Python 3.12, the `mcp` SDK (>=1.0.0,<2.0.0), the existing `claude` CLI, pytest.
+
+**Spec:** `docs/superpowers/specs/2026-04-27-mcp-config-path-for-brain-tools-design.md` — read this first if any task is ambiguous.
+
+**Verification gate (per Hana):** Every task ends with tests passing locally. The PR does not merge until the manual sandbox-clone verification (Task 7) succeeds: a real `nell chat` against a sandboxed clone produces `tool_invocations.log.jsonl` showing `search_memories` was called and Nell's reply quotes a verifiable memory.
+
+---
+
+## Task 1: Add `mcp` SDK dependency
+
+**Files:**
+- Modify: `pyproject.toml:11-16`
+
+- [ ] **Step 1: Add `mcp` to dependencies**
+
+Edit `pyproject.toml` — change the `dependencies` block from:
+
+```toml
+dependencies = [
+    "platformdirs>=4.2",
+    "numpy>=1.26",
+    "ddgs>=6.0",
+    "httpx>=0.27",
+]
+```
+
+to:
+
+```toml
+dependencies = [
+    "platformdirs>=4.2",
+    "numpy>=1.26",
+    "ddgs>=6.0",
+    "httpx>=0.27",
+    "mcp>=1.0.0,<2.0.0",
+]
+```
+
+- [ ] **Step 2: Install in the active environment**
+
+Run: `python3 -m pip install -e '.[dev]'`
+Expected: `Successfully installed mcp-<version> ...`
+
+- [ ] **Step 3: Verify import works**
+
+Run: `python3 -c "from mcp.server import Server; from mcp.server.stdio import stdio_server; from mcp.types import Tool, TextContent; print('mcp imports OK')"`
+Expected output: `mcp imports OK`
+
+- [ ] **Step 4: Verify existing test suite still green**
+
+Run: `python3 -m pytest -q 2>&1 | tail -5`
+Expected: All previously-passing tests still pass (no regression from adding the dep).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pyproject.toml
+git commit -m "deps: add mcp SDK for brain-tools MCP-config path
+
+Pinned mcp>=1.0.0,<2.0.0 — major-pinned to avoid breaking API drift,
+minor floats so security/bugfix releases land automatically.
+
+Used by brain/mcp_server/ to expose the 9 brain-tools to Claude via
+the --mcp-config production path (replaces the --json-schema interim
+shipped in PR #23). Spec: docs/superpowers/specs/2026-04-27-mcp-\
+config-path-for-brain-tools-design.md.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Audit log module
+
+**Files:**
+- Create: `brain/mcp_server/__init__.py` (empty package marker for now — will be filled in Task 5)
+- Create: `brain/mcp_server/audit.py`
+- Create: `tests/unit/brain/mcp_server/__init__.py` (empty)
+- Create: `tests/unit/brain/mcp_server/test_audit.py`
+
+- [ ] **Step 1: Create the package markers**
+
+```bash
+mkdir -p brain/mcp_server tests/unit/brain/mcp_server
+touch brain/mcp_server/__init__.py tests/unit/brain/mcp_server/__init__.py
+```
+
+- [ ] **Step 2: Write failing tests (`test_audit.py`)**
+
+Create `tests/unit/brain/mcp_server/test_audit.py`:
+
+```python
+"""Tests for brain.mcp_server.audit."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from brain.mcp_server.audit import log_invocation
+
+
+def test_log_invocation_writes_jsonl_line(tmp_path: Path) -> None:
+    log_invocation(
+        tmp_path,
+        name="search_memories",
+        arguments={"query": "morning"},
+        result_summary="3 hits",
+    )
+    log_path = tmp_path / "tool_invocations.log.jsonl"
+    assert log_path.exists()
+    lines = log_path.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 1
+    rec = json.loads(lines[0])
+    assert rec["name"] == "search_memories"
+    assert rec["arguments"] == {"query": "morning"}
+    assert rec["result_summary"] == "3 hits"
+    assert rec["error"] is None
+    # Timestamp ends with Z (UTC)
+    assert rec["timestamp"].endswith("Z")
+
+
+def test_log_invocation_truncates_long_summary(tmp_path: Path) -> None:
+    long = "x" * 500
+    log_invocation(tmp_path, name="x", arguments={}, result_summary=long)
+    rec = json.loads((tmp_path / "tool_invocations.log.jsonl").read_text())
+    # 140 chars + ellipsis (1 char "…")
+    assert rec["result_summary"].endswith("…")
+    assert len(rec["result_summary"]) == 141
+
+
+def test_log_invocation_records_error(tmp_path: Path) -> None:
+    log_invocation(
+        tmp_path,
+        name="add_memory",
+        arguments={"text": "x"},
+        result_summary="error: boom",
+        error="boom",
+    )
+    rec = json.loads((tmp_path / "tool_invocations.log.jsonl").read_text())
+    assert rec["error"] == "boom"
+
+
+def test_log_invocation_appends_two_lines(tmp_path: Path) -> None:
+    log_invocation(tmp_path, name="a", arguments={}, result_summary="r1")
+    log_invocation(tmp_path, name="b", arguments={}, result_summary="r2")
+    lines = (tmp_path / "tool_invocations.log.jsonl").read_text().splitlines()
+    assert len(lines) == 2
+    assert json.loads(lines[0])["name"] == "a"
+    assert json.loads(lines[1])["name"] == "b"
+
+
+def test_log_invocation_swallows_oserror(tmp_path: Path, monkeypatch) -> None:
+    """Audit is observability — if the disk write fails, we log + swallow."""
+    # Make the persona_dir read-only so the open() raises OSError
+    persona = tmp_path / "ro"
+    persona.mkdir()
+    persona.chmod(0o555)
+    try:
+        # Should not raise
+        log_invocation(persona, name="x", arguments={}, result_summary="x")
+    finally:
+        persona.chmod(0o755)
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `python3 -m pytest tests/unit/brain/mcp_server/test_audit.py -v 2>&1 | tail -10`
+Expected: All 5 tests fail with `ModuleNotFoundError: No module named 'brain.mcp_server.audit'`
+
+- [ ] **Step 4: Implement `audit.py`**
+
+Create `brain/mcp_server/audit.py`:
+
+```python
+"""Audit log for MCP-server tool invocations.
+
+Each call to a brain-tool from inside the MCP server appends one JSON line
+to <persona_dir>/tool_invocations.log.jsonl. Failures here are observability,
+not correctness — they are logged to stderr and swallowed so a broken disk
+or full filesystem cannot break tool dispatch.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+_RESULT_SUMMARY_MAX_CHARS = 140
+_LOG_FILENAME = "tool_invocations.log.jsonl"
+
+
+def log_invocation(
+    persona_dir: Path,
+    *,
+    name: str,
+    arguments: dict[str, Any],
+    result_summary: str,
+    error: str | None = None,
+) -> None:
+    """Append one invocation record to <persona_dir>/tool_invocations.log.jsonl.
+
+    Never raises. OSError on the write is logged at WARNING and swallowed.
+
+    Parameters
+    ----------
+    persona_dir:
+        The active persona's directory; the log file is written here.
+    name:
+        Tool name (e.g. "search_memories").
+    arguments:
+        Args the LLM passed in. Will be JSON-serialised; non-JSON values
+        fall through to ``default=str``.
+    result_summary:
+        Compact preview of the result. Truncated to 140 chars + "…" if longer.
+    error:
+        ``None`` on success; ``str(exc)`` on dispatch failure.
+    """
+    if len(result_summary) <= _RESULT_SUMMARY_MAX_CHARS:
+        truncated = result_summary
+    else:
+        truncated = result_summary[:_RESULT_SUMMARY_MAX_CHARS] + "…"
+
+    record = {
+        "timestamp": datetime.now(UTC).isoformat().replace("+00:00", "Z"),
+        "name": name,
+        "arguments": arguments,
+        "result_summary": truncated,
+        "error": error,
+    }
+
+    log_path = persona_dir / _LOG_FILENAME
+    try:
+        with log_path.open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(record, ensure_ascii=False, default=str) + "\n")
+    except OSError as exc:
+        logger.warning("audit log write failed: %s", exc)
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `python3 -m pytest tests/unit/brain/mcp_server/test_audit.py -v 2>&1 | tail -10`
+Expected: 5 passed.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add brain/mcp_server/__init__.py brain/mcp_server/audit.py \
+        tests/unit/brain/mcp_server/__init__.py \
+        tests/unit/brain/mcp_server/test_audit.py
+git commit -m "feat(mcp): tool-invocation audit log module
+
+log_invocation() appends one JSON line per call to
+<persona>/tool_invocations.log.jsonl. Used by the MCP server (next
+task) and consumed by future audit/debug surfaces. OSError on write
+is logged + swallowed — audit is observability, not correctness.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Promote `NELL_TOOL_NAMES` to public API
+
+**Files:**
+- Modify: `brain/tools/__init__.py:1-20`
+- Modify: `brain/chat/tool_loop.py:31-42`
+- Test: `tests/unit/brain/test_tools_public.py` (new)
+
+**Why:** The MCP server (Task 4) needs the canonical 9-tool list. Today it's a private constant inside `brain.chat.tool_loop` (`_NELL_TOOL_NAMES`). Importing private names across modules is ugly; the cleanest fix is to expose it once on `brain.tools`.
+
+- [ ] **Step 1: Write failing test**
+
+Create `tests/unit/brain/test_tools_public.py`:
+
+```python
+"""Tests for brain.tools public surface — NELL_TOOL_NAMES export."""
+
+from __future__ import annotations
+
+
+def test_nell_tool_names_exported() -> None:
+    from brain.tools import NELL_TOOL_NAMES
+
+    assert isinstance(NELL_TOOL_NAMES, tuple)
+    assert len(NELL_TOOL_NAMES) == 9
+    # Spot-check the 9 known tools from spec §1
+    assert "search_memories" in NELL_TOOL_NAMES
+    assert "get_emotional_state" in NELL_TOOL_NAMES
+    assert "get_soul" in NELL_TOOL_NAMES
+    assert "get_personality" in NELL_TOOL_NAMES
+    assert "get_body_state" in NELL_TOOL_NAMES
+    assert "boot" in NELL_TOOL_NAMES
+    assert "add_journal" in NELL_TOOL_NAMES
+    assert "add_memory" in NELL_TOOL_NAMES
+    assert "crystallize_soul" in NELL_TOOL_NAMES
+
+
+def test_tool_loop_imports_from_brain_tools() -> None:
+    """tool_loop must use the public name — no private fallback."""
+    from brain.chat import tool_loop
+    from brain.tools import NELL_TOOL_NAMES
+
+    # build_tools_list iterates the same names — easiest assertion is to
+    # call it and confirm shape matches NELL_TOOL_NAMES
+    tools = tool_loop.build_tools_list()
+    names_in_tools = {t["function"]["name"] for t in tools}
+    # SCHEMAS gates which names actually appear; intersect with NELL_TOOL_NAMES
+    from brain.tools.schemas import SCHEMAS
+
+    expected = {n for n in NELL_TOOL_NAMES if n in SCHEMAS}
+    assert names_in_tools == expected
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python3 -m pytest tests/unit/brain/test_tools_public.py -v 2>&1 | tail -10`
+Expected: `test_nell_tool_names_exported` fails with `ImportError: cannot import name 'NELL_TOOL_NAMES' from 'brain.tools'`.
+
+- [ ] **Step 3: Define `NELL_TOOL_NAMES` in `brain.tools`**
+
+Edit `brain/tools/__init__.py` — replace the file with:
+
+```python
+"""brain.tools — brain-query tools for the chat engine (SP-3).
+
+Public surface:
+    SCHEMAS           — JSON schemas keyed by tool name
+    LOVE_TYPES        — enum of crystallization love-types
+    NELL_TOOL_NAMES   — canonical ordered tuple of all 9 tools
+    dispatch          — dispatch(name, arguments, *, store, hebbian, persona_dir) -> dict
+    ToolDispatchError — raised on dispatch failures
+
+OG reference: NellBrain/nell_tools.py (841 lines, 9 impls + SCHEMAS).
+Master ref §6 SP-3.
+"""
+
+from brain.tools.dispatch import ToolDispatchError, dispatch
+from brain.tools.schemas import LOVE_TYPES, SCHEMAS
+
+# Canonical tool list, in the order the LLM should see them.
+# Ported verbatim from OG NELL_TOOLS (nell_bridge.py:172-185).
+NELL_TOOL_NAMES: tuple[str, ...] = (
+    "get_emotional_state",
+    "get_soul",
+    "get_personality",
+    "get_body_state",
+    "boot",
+    "search_memories",
+    "add_journal",
+    "add_memory",
+    "crystallize_soul",
+)
+
+__all__ = [
+    "SCHEMAS",
+    "LOVE_TYPES",
+    "NELL_TOOL_NAMES",
+    "dispatch",
+    "ToolDispatchError",
+]
+```
+
+- [ ] **Step 4: Switch `tool_loop` to import the public name**
+
+Edit `brain/chat/tool_loop.py` — replace lines 22-42 (the `from brain.tools.schemas import SCHEMAS` line through the end of `_NELL_TOOL_NAMES`) with:
+
+```python
+from brain.tools import NELL_TOOL_NAMES
+from brain.tools.dispatch import dispatch
+from brain.tools.schemas import SCHEMAS
+
+logger = logging.getLogger(__name__)
+
+MAX_TOOL_ITERATIONS = 4
+```
+
+(The private `_NELL_TOOL_NAMES` constant is removed entirely. References below it must use the public name.)
+
+Then in `build_tools_list()` (around lines 45-55), change `_NELL_TOOL_NAMES` → `NELL_TOOL_NAMES`:
+
+```python
+def build_tools_list() -> list[dict]:
+    """Build the tool schema list for provider.chat(tools=...).
+
+    Wraps schemas in the {"type": "function", "function": <schema>} shape
+    that Ollama and Claude (via --json-schema) both accept.
+    """
+    return [
+        {"type": "function", "function": SCHEMAS[name]}
+        for name in NELL_TOOL_NAMES
+        if name in SCHEMAS
+    ]
+```
+
+- [ ] **Step 5: Run the new tests + the existing tool_loop tests**
+
+Run: `python3 -m pytest tests/unit/brain/test_tools_public.py tests/unit/brain/chat/test_tool_loop.py -v 2>&1 | tail -10`
+Expected: all green (both files).
+
+- [ ] **Step 6: Run the full chat + tools suite to verify no regression**
+
+Run: `python3 -m pytest tests/unit/brain/chat/ tests/unit/brain/test_tools_public.py tests/unit/brain/tools/ 2>&1 | tail -5`
+Expected: all pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add brain/tools/__init__.py brain/chat/tool_loop.py \
+        tests/unit/brain/test_tools_public.py
+git commit -m "refactor(tools): expose NELL_TOOL_NAMES on brain.tools
+
+Move the canonical 9-tool list from a private constant in
+brain.chat.tool_loop (_NELL_TOOL_NAMES) to the public
+brain.tools.NELL_TOOL_NAMES so the new MCP server (next task) can
+import it without crossing private boundaries. Tool_loop now imports
+the public name; behaviour unchanged.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: MCP tools adapter (`register_tools`)
+
+**Files:**
+- Create: `brain/mcp_server/tools.py`
+- Create: `tests/unit/brain/mcp_server/test_tools.py`
+
+**Responsibility:** map each schema in `brain/tools/schemas.py` to an MCP tool registration on the `Server`. Closures capture `store` / `hebbian` / `persona_dir` so the handler can dispatch + audit-log without re-opening stores per call.
+
+- [ ] **Step 1: Write failing tests (`test_tools.py`)**
+
+Create `tests/unit/brain/mcp_server/test_tools.py`:
+
+```python
+"""Tests for brain.mcp_server.tools — MCP tool registration adapter."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture()
+def persona_dir(tmp_path: Path) -> Path:
+    """Minimal persona dir for tests."""
+    d = tmp_path / "persona"
+    d.mkdir()
+    return d
+
+
+@pytest.fixture()
+def fake_stores() -> tuple[MagicMock, MagicMock]:
+    return MagicMock(name="MemoryStore"), MagicMock(name="HebbianMatrix")
+
+
+def test_register_tools_advertises_all_nine(persona_dir: Path, fake_stores) -> None:
+    """list_tools() should advertise every schema in NELL_TOOL_NAMES."""
+    from mcp.server import Server
+
+    from brain.mcp_server.tools import register_tools
+    from brain.tools import NELL_TOOL_NAMES
+    from brain.tools.schemas import SCHEMAS
+
+    store, hebbian = fake_stores
+    server = Server("brain-tools")
+    register_tools(server, persona_dir=persona_dir, store=store, hebbian=hebbian)
+
+    # Pull the list_tools handler the server registered
+    list_handler = server.request_handlers[
+        __import__("mcp.types", fromlist=["ListToolsRequest"]).ListToolsRequest
+    ]
+    result = asyncio.run(list_handler(MagicMock()))
+    advertised = {t.name for t in result.root.tools}
+    expected = {n for n in NELL_TOOL_NAMES if n in SCHEMAS}
+    assert advertised == expected
+
+
+def test_register_tools_dispatches_and_logs_success(persona_dir: Path, fake_stores) -> None:
+    """call_tool() must call dispatch() and write an audit log line."""
+    from mcp.server import Server
+
+    from brain.mcp_server.tools import register_tools
+
+    store, hebbian = fake_stores
+    server = Server("brain-tools")
+
+    with patch("brain.mcp_server.tools.dispatch", return_value={"ok": True}) as mock_dispatch:
+        register_tools(server, persona_dir=persona_dir, store=store, hebbian=hebbian)
+        call_handler = _get_call_handler(server)
+        result = asyncio.run(
+            call_handler(_call_request("search_memories", {"query": "x"}))
+        )
+
+    # Dispatch was invoked with the right args + injections
+    mock_dispatch.assert_called_once_with(
+        "search_memories",
+        {"query": "x"},
+        store=store,
+        hebbian=hebbian,
+        persona_dir=persona_dir,
+    )
+    # Result content is a JSON-encoded dispatch return
+    text = result.root.content[0].text
+    assert json.loads(text) == {"ok": True}
+    # Audit log was written
+    log_path = persona_dir / "tool_invocations.log.jsonl"
+    rec = json.loads(log_path.read_text())
+    assert rec["name"] == "search_memories"
+    assert rec["arguments"] == {"query": "x"}
+    assert rec["error"] is None
+
+
+def test_register_tools_dispatches_and_logs_error(persona_dir: Path, fake_stores) -> None:
+    """When dispatch raises, return {"error": ...} and log with error field."""
+    from mcp.server import Server
+
+    from brain.mcp_server.tools import register_tools
+
+    store, hebbian = fake_stores
+    server = Server("brain-tools")
+
+    with patch("brain.mcp_server.tools.dispatch", side_effect=RuntimeError("boom")):
+        register_tools(server, persona_dir=persona_dir, store=store, hebbian=hebbian)
+        call_handler = _get_call_handler(server)
+        result = asyncio.run(
+            call_handler(_call_request("add_memory", {"text": "x"}))
+        )
+
+    text = result.root.content[0].text
+    assert json.loads(text) == {"error": "boom"}
+    rec = json.loads((persona_dir / "tool_invocations.log.jsonl").read_text())
+    assert rec["name"] == "add_memory"
+    assert rec["error"] == "boom"
+
+
+def test_register_tools_unknown_tool_returns_error(persona_dir: Path, fake_stores) -> None:
+    """Unknown tool names dispatch through the same error path."""
+    from mcp.server import Server
+
+    from brain.mcp_server.tools import register_tools
+    from brain.tools.dispatch import ToolDispatchError
+
+    store, hebbian = fake_stores
+    server = Server("brain-tools")
+
+    with patch(
+        "brain.mcp_server.tools.dispatch",
+        side_effect=ToolDispatchError("unknown tool: 'banana'"),
+    ):
+        register_tools(server, persona_dir=persona_dir, store=store, hebbian=hebbian)
+        call_handler = _get_call_handler(server)
+        result = asyncio.run(call_handler(_call_request("banana", {})))
+
+    text = result.root.content[0].text
+    assert "unknown tool" in json.loads(text)["error"]
+
+
+def test_register_tools_summary_truncated(persona_dir: Path, fake_stores) -> None:
+    """A huge dispatch result should still produce a 140-char summary in the log."""
+    from mcp.server import Server
+
+    from brain.mcp_server.tools import register_tools
+
+    store, hebbian = fake_stores
+    server = Server("brain-tools")
+
+    big_result = {"hits": ["x" * 50 for _ in range(20)]}
+    with patch("brain.mcp_server.tools.dispatch", return_value=big_result):
+        register_tools(server, persona_dir=persona_dir, store=store, hebbian=hebbian)
+        call_handler = _get_call_handler(server)
+        asyncio.run(call_handler(_call_request("search_memories", {"query": "x"})))
+
+    rec = json.loads((persona_dir / "tool_invocations.log.jsonl").read_text())
+    assert len(rec["result_summary"]) <= 141  # 140 + "…"
+
+
+# ── helpers ───────────────────────────────────────────────────────────────────
+
+
+def _get_call_handler(server):
+    """Pull the call_tool handler off the server's request map."""
+    from mcp.types import CallToolRequest
+
+    return server.request_handlers[CallToolRequest]
+
+
+def _call_request(name: str, arguments: dict):
+    """Build a CallToolRequest in the shape the SDK passes to the handler."""
+    from mcp.types import CallToolRequest, CallToolRequestParams
+
+    return CallToolRequest(
+        method="tools/call",
+        params=CallToolRequestParams(name=name, arguments=arguments),
+    )
+```
+
+> **Note for the implementing agent:** the `mcp` SDK's request-handler internals
+> (`server.request_handlers`, `CallToolRequest`, etc.) are stable since 1.0. If
+> the test helper functions above need to import differently in the version we
+> pin, adjust them, but keep the assertions intact.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python3 -m pytest tests/unit/brain/mcp_server/test_tools.py -v 2>&1 | tail -10`
+Expected: all 5 fail with `ModuleNotFoundError: No module named 'brain.mcp_server.tools'`.
+
+- [ ] **Step 3: Implement `tools.py`**
+
+Create `brain/mcp_server/tools.py`:
+
+```python
+"""MCP tool registration adapter.
+
+For each name in brain.tools.NELL_TOOL_NAMES, register an MCP tool on the
+given Server that dispatches to brain.tools.dispatch.dispatch() and audit-
+logs the invocation. Tool logic is not duplicated — every tool routes
+through the same dispatch the chat engine already uses.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from mcp.server import Server
+from mcp.types import TextContent, Tool
+
+from brain.memory.hebbian import HebbianMatrix
+from brain.memory.store import MemoryStore
+from brain.mcp_server.audit import log_invocation
+from brain.tools import NELL_TOOL_NAMES
+from brain.tools.dispatch import dispatch
+from brain.tools.schemas import SCHEMAS
+
+_RESULT_SUMMARY_MAX_CHARS = 140
+
+
+def register_tools(
+    server: Server,
+    *,
+    persona_dir: Path,
+    store: MemoryStore,
+    hebbian: HebbianMatrix,
+) -> None:
+    """Register each brain-tool with the MCP server.
+
+    Closures capture store/hebbian/persona_dir so each invocation passes
+    them through dispatch unchanged. The server itself is mutated in place;
+    the function returns None.
+    """
+
+    @server.list_tools()
+    async def _list_tools() -> list[Tool]:
+        return [
+            Tool(
+                name=name,
+                description=SCHEMAS[name].get("description", ""),
+                inputSchema=SCHEMAS[name].get("parameters", {"type": "object"}),
+            )
+            for name in NELL_TOOL_NAMES
+            if name in SCHEMAS
+        ]
+
+    @server.call_tool()
+    async def _call_tool(name: str, arguments: dict[str, Any]) -> list[TextContent]:
+        try:
+            result = dispatch(
+                name,
+                arguments,
+                store=store,
+                hebbian=hebbian,
+                persona_dir=persona_dir,
+            )
+            payload = json.dumps(result, default=str, ensure_ascii=False)
+            log_invocation(
+                persona_dir,
+                name=name,
+                arguments=arguments,
+                result_summary=_summarize(payload),
+            )
+            return [TextContent(type="text", text=payload)]
+        except Exception as exc:  # noqa: BLE001 — broad catch is intentional
+            err_payload = json.dumps({"error": str(exc)})
+            log_invocation(
+                persona_dir,
+                name=name,
+                arguments=arguments,
+                result_summary=f"error: {exc}",
+                error=str(exc),
+            )
+            return [TextContent(type="text", text=err_payload)]
+
+
+def _summarize(payload: str) -> str:
+    """Single-line preview matching tool_loop._summarize_result behaviour."""
+    s = payload.replace("\n", " ").strip()
+    if len(s) <= _RESULT_SUMMARY_MAX_CHARS:
+        return s
+    return s[:_RESULT_SUMMARY_MAX_CHARS] + "…"
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python3 -m pytest tests/unit/brain/mcp_server/test_tools.py -v 2>&1 | tail -15`
+Expected: 5 passed.
+
+- [ ] **Step 5: If any test fails because the SDK request-handler shape differs from the helpers**
+
+The implementation in step 3 is correct — adjust the `_get_call_handler` / `_call_request` helpers in the test file to match the SDK's actual API surface. Confirm via:
+
+```bash
+python3 -c "from mcp.types import CallToolRequest; help(CallToolRequest)"
+python3 -c "from mcp.server import Server; s = Server('x'); print(list(s.request_handlers.keys()))"
+```
+
+Update the helpers based on the output. Re-run step 4. Do NOT change the assertions — only the helper functions that prepare the request shape.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add brain/mcp_server/tools.py tests/unit/brain/mcp_server/test_tools.py
+git commit -m "feat(mcp): tool-registration adapter
+
+register_tools() wires the 9 brain-tools onto an MCP Server: each
+tool's schema becomes an MCP Tool, each call routes through the
+existing brain.tools.dispatch.dispatch() and audit-logs via
+brain.mcp_server.audit.log_invocation. No tool logic duplicated.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: MCP server entry point
+
+**Files:**
+- Modify: `brain/mcp_server/__init__.py` (replace empty marker with `run_server`)
+- Create: `brain/mcp_server/__main__.py`
+- Create: `tests/unit/brain/mcp_server/test_server.py`
+
+**Responsibility:** the `python -m brain.mcp_server --persona-dir <path>` entry. Opens stores, registers tools, runs the stdio loop, closes stores on exit.
+
+- [ ] **Step 1: Write failing tests (`test_server.py`)**
+
+Create `tests/unit/brain/mcp_server/test_server.py`:
+
+```python
+"""Tests for brain.mcp_server.run_server + __main__."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from brain.memory.hebbian import HebbianMatrix
+from brain.memory.store import MemoryStore
+
+
+def _seed_persona(tmp_path: Path) -> Path:
+    """Initialize a minimal valid persona directory."""
+    d = tmp_path / "persona"
+    d.mkdir()
+    MemoryStore(db_path=d / "memories.db").close()
+    HebbianMatrix(db_path=d / "hebbian.db").close()
+    return d
+
+
+def test_run_server_missing_persona_dir_raises(tmp_path: Path) -> None:
+    from brain.mcp_server import run_server
+
+    missing = tmp_path / "does_not_exist"
+    with pytest.raises(FileNotFoundError, match="persona_dir does not exist"):
+        run_server(missing)
+
+
+def test_run_server_opens_and_closes_stores(tmp_path: Path) -> None:
+    """run_server should open MemoryStore + HebbianMatrix + close on exit,
+    even when the stdio loop returns immediately (mocked)."""
+    persona = _seed_persona(tmp_path)
+
+    from brain.mcp_server import run_server
+
+    captured: dict = {}
+
+    def _capture_register(server, *, persona_dir, store, hebbian):
+        captured["store"] = store
+        captured["hebbian"] = hebbian
+        captured["persona_dir"] = persona_dir
+
+    # Patch the stdio_server context manager to immediately exit
+    class _FakeStdio:
+        async def __aenter__(self):
+            return (MagicMock(), MagicMock())
+
+        async def __aexit__(self, *_):
+            return None
+
+    async def _fake_run(self, *_args, **_kwargs):
+        return None
+
+    with patch("brain.mcp_server.register_tools", side_effect=_capture_register), \
+         patch("brain.mcp_server.stdio_server", lambda: _FakeStdio()), \
+         patch("mcp.server.Server.run", _fake_run):
+        run_server(persona)
+
+    # Stores were captured (and the run completed without raising on close)
+    assert captured["persona_dir"] == persona
+    # Stores are typed instances, not None
+    assert captured["store"] is not None
+    assert captured["hebbian"] is not None
+
+
+def test_main_entry_runs(tmp_path: Path) -> None:
+    """`python -m brain.mcp_server --persona-dir <path>` should accept the
+    flag and invoke run_server. We use subprocess + a side-effect stub to
+    confirm the dispatch without actually running stdio."""
+    persona = _seed_persona(tmp_path)
+
+    # Use subprocess so we exercise the real argparse path. The MCP server
+    # would normally hang on stdio_server() — we kill it after a moment.
+    proc = subprocess.Popen(
+        [sys.executable, "-m", "brain.mcp_server", "--persona-dir", str(persona)],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    try:
+        # Closing stdin causes the stdio MCP server to detect EOF and exit
+        proc.stdin.close()
+        stdout, stderr = proc.communicate(timeout=5)
+        # Exit code 0 means the entry point parsed args and the server
+        # ran cleanly. Non-zero means a crash before stdio_server returned.
+        assert proc.returncode == 0, (
+            f"Server exited {proc.returncode}.\nstderr:\n{stderr.decode()}"
+        )
+    finally:
+        if proc.poll() is None:
+            proc.kill()
+            proc.wait(timeout=2)
+
+
+def test_main_entry_missing_flag_exits_nonzero() -> None:
+    """argparse should reject a call without --persona-dir."""
+    proc = subprocess.run(
+        [sys.executable, "-m", "brain.mcp_server"],
+        capture_output=True,
+        text=True,
+        timeout=5,
+    )
+    assert proc.returncode != 0
+    assert "--persona-dir" in proc.stderr
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python3 -m pytest tests/unit/brain/mcp_server/test_server.py -v 2>&1 | tail -15`
+Expected: failures referencing missing `run_server` symbol on `brain.mcp_server`.
+
+- [ ] **Step 3: Implement `brain/mcp_server/__init__.py`**
+
+Replace the empty `brain/mcp_server/__init__.py` with:
+
+```python
+"""brain.mcp_server — MCP server exposing brain-tools to Claude.
+
+Spawned as `python -m brain.mcp_server --persona-dir <path>` by
+ClaudeCliProvider via --mcp-config. Lifecycle is per-chat-call: claude
+spawns this process when it resolves the mcp config; the process runs
+until claude closes the stdio connection.
+
+Public surface:
+    run_server(persona_dir: Path) — entry; runs until stdio closes
+    register_tools                 — re-exported from .tools for testing
+
+Spec: docs/superpowers/specs/2026-04-27-mcp-config-path-for-brain-tools-design.md
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+from mcp.server import Server
+from mcp.server.stdio import stdio_server
+
+from brain.memory.hebbian import HebbianMatrix
+from brain.memory.store import MemoryStore
+from brain.mcp_server.tools import register_tools
+
+__all__ = ["run_server", "register_tools"]
+
+
+def run_server(persona_dir: Path) -> None:
+    """Run the MCP server stdio loop until the client disconnects.
+
+    Raises FileNotFoundError if persona_dir does not exist.
+    """
+    if not persona_dir.is_dir():
+        raise FileNotFoundError(f"persona_dir does not exist: {persona_dir}")
+    asyncio.run(_run(persona_dir))
+
+
+async def _run(persona_dir: Path) -> None:
+    server = Server("brain-tools")
+    store = MemoryStore(db_path=persona_dir / "memories.db")
+    hebbian = HebbianMatrix(db_path=persona_dir / "hebbian.db")
+    try:
+        register_tools(server, persona_dir=persona_dir, store=store, hebbian=hebbian)
+        async with stdio_server() as (read_stream, write_stream):
+            await server.run(
+                read_stream,
+                write_stream,
+                server.create_initialization_options(),
+            )
+    finally:
+        try:
+            hebbian.close()
+        finally:
+            store.close()
+```
+
+- [ ] **Step 4: Implement `brain/mcp_server/__main__.py`**
+
+Create `brain/mcp_server/__main__.py`:
+
+```python
+"""Entry: `python -m brain.mcp_server --persona-dir <path>`."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from brain.mcp_server import run_server
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="python -m brain.mcp_server")
+    parser.add_argument(
+        "--persona-dir",
+        required=True,
+        type=Path,
+        help="Path to the active persona directory (required).",
+    )
+    args = parser.parse_args(argv)
+    run_server(args.persona_dir)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+```
+
+- [ ] **Step 5: Run server tests to verify they pass**
+
+Run: `python3 -m pytest tests/unit/brain/mcp_server/ -v 2>&1 | tail -15`
+Expected: all green (audit + tools + server).
+
+- [ ] **Step 6: Run the full mcp_server suite + adjacent suites**
+
+Run: `python3 -m pytest tests/unit/brain/mcp_server/ tests/unit/brain/chat/ tests/unit/brain/test_tools_public.py 2>&1 | tail -5`
+Expected: all pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add brain/mcp_server/__init__.py brain/mcp_server/__main__.py \
+        tests/unit/brain/mcp_server/test_server.py
+git commit -m "feat(mcp): server entry point — run_server + __main__
+
+run_server(persona_dir) opens MemoryStore + HebbianMatrix, calls
+register_tools to wire the 9 brain-tools, runs the stdio MCP loop,
+and closes stores on exit. The python -m brain.mcp_server entry
+parses --persona-dir and dispatches to run_server. Lifecycle is
+per-chat-call: claude CLI spawns + kills this process around each
+chat turn that uses the --mcp-config path.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: Provider integration — swap to `--mcp-config`
+
+**Files:**
+- Modify: `brain/bridge/provider.py:230-460` (rewrite `chat()` tool path; drop `_build_tool_call_schema`, `_build_tool_system_addendum`, `_chat_with_tools`)
+- Modify: `brain/chat/tool_loop.py:97` (pass `persona_dir` via `options`)
+- Modify: `tests/unit/brain/bridge/test_provider_chat.py` (replace `--json-schema` tests with `--mcp-config` tests)
+
+**Why this is one task, not two:** the tool_loop signature change and the provider rewrite are tightly coupled. tool_loop must pass `persona_dir` via `options` for the provider's MCP path to know where to point the spawned server. Splitting them across commits leaves one half broken.
+
+- [ ] **Step 1: Write failing tests**
+
+Edit `tests/unit/brain/bridge/test_provider_chat.py` — replace the entire file with this content (the old `--json-schema` tests are removed; new `--mcp-config` tests replace them). Keep any unrelated Ollama tests in the file by appending them at the end if they exist; this snippet covers only the Claude-path tests.
+
+```python
+"""Tests for ClaudeCliProvider.chat() — MCP-config path.
+
+Replaces the SP-3 --json-schema tests; the underlying provider was
+rewritten to use --mcp-config (production path per master ref §6 SP-3
+and 2026-04-27 stress-test finding).
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from brain.bridge.chat import ChatMessage
+from brain.bridge.provider import ClaudeCliProvider, ProviderError
+
+
+@pytest.fixture()
+def persona_dir(tmp_path: Path) -> Path:
+    d = tmp_path / "persona"
+    d.mkdir()
+    return d
+
+
+def _fake_proc(stdout: str, returncode: int = 0, stderr: str = "") -> subprocess.CompletedProcess:
+    return subprocess.CompletedProcess(
+        args=[], returncode=returncode, stdout=stdout, stderr=stderr
+    )
+
+
+def test_chat_with_tools_passes_mcp_config_flag(persona_dir: Path) -> None:
+    """The new path must call claude with --mcp-config <tmp_path>."""
+    provider = ClaudeCliProvider()
+    captured: dict = {}
+
+    def _capture(cmd, **kwargs):
+        captured["cmd"] = cmd
+        captured["mcp_config_path"] = cmd[cmd.index("--mcp-config") + 1]
+        return _fake_proc(json.dumps({"result": "hello back"}))
+
+    with patch("brain.bridge.provider.subprocess.run", side_effect=_capture):
+        response = provider.chat(
+            [
+                ChatMessage(role="system", content="you are nell"),
+                ChatMessage(role="user", content="hi"),
+            ],
+            tools=[{"name": "search_memories", "description": "search"}],
+            options={"persona_dir": str(persona_dir)},
+        )
+
+    assert response.content == "hello back"
+    assert response.tool_calls == ()
+    # --mcp-config flag is present and points at a real json file (now unlinked,
+    # but we captured the path during the call)
+    assert "--mcp-config" in captured["cmd"]
+    assert captured["mcp_config_path"].endswith(".json")
+
+
+def test_chat_with_tools_writes_correct_mcp_config(persona_dir: Path) -> None:
+    """The temp mcp.json must contain the right command + args."""
+    provider = ClaudeCliProvider()
+    captured: dict = {}
+
+    def _capture(cmd, **kwargs):
+        path = cmd[cmd.index("--mcp-config") + 1]
+        # Read the temp file BEFORE the provider's finally block deletes it
+        captured["config"] = json.loads(Path(path).read_text())
+        return _fake_proc(json.dumps({"result": "ok"}))
+
+    with patch("brain.bridge.provider.subprocess.run", side_effect=_capture):
+        provider.chat(
+            [
+                ChatMessage(role="system", content="sys"),
+                ChatMessage(role="user", content="hi"),
+            ],
+            tools=[{"name": "x", "description": "x"}],
+            options={"persona_dir": str(persona_dir)},
+        )
+
+    cfg = captured["config"]
+    assert "brain-tools" in cfg["mcpServers"]
+    server_cfg = cfg["mcpServers"]["brain-tools"]
+    assert server_cfg["args"][0] == "-m"
+    assert server_cfg["args"][1] == "brain.mcp_server"
+    assert "--persona-dir" in server_cfg["args"]
+    assert str(persona_dir) in server_cfg["args"]
+
+
+def test_chat_with_tools_keeps_existing_flags(persona_dir: Path) -> None:
+    """The other flags (-p, --output-format, --model, --system-prompt)
+    must remain — only --json-schema is replaced."""
+    provider = ClaudeCliProvider()
+    captured: dict = {}
+
+    def _capture(cmd, **kwargs):
+        captured["cmd"] = cmd
+        return _fake_proc(json.dumps({"result": "ok"}))
+
+    with patch("brain.bridge.provider.subprocess.run", side_effect=_capture):
+        provider.chat(
+            [
+                ChatMessage(role="system", content="sys-prompt"),
+                ChatMessage(role="user", content="hi"),
+            ],
+            tools=[{"name": "x"}],
+            options={"persona_dir": str(persona_dir)},
+        )
+
+    cmd = captured["cmd"]
+    assert cmd[0] == "claude"
+    assert "-p" in cmd
+    assert "--output-format" in cmd
+    assert "json" in cmd
+    assert "--model" in cmd
+    assert "--system-prompt" in cmd
+    assert "sys-prompt" in cmd
+    # The replaced flag must NOT appear
+    assert "--json-schema" not in cmd
+
+
+def test_chat_with_tools_parses_payload_result(persona_dir: Path) -> None:
+    provider = ClaudeCliProvider()
+
+    with patch(
+        "brain.bridge.provider.subprocess.run",
+        return_value=_fake_proc(json.dumps({"result": "the actual reply"})),
+    ):
+        response = provider.chat(
+            [ChatMessage(role="user", content="hi")],
+            tools=[{"name": "x"}],
+            options={"persona_dir": str(persona_dir)},
+        )
+
+    assert response.content == "the actual reply"
+    assert response.tool_calls == ()
+
+
+def test_chat_with_tools_missing_result_key_raises_parse(persona_dir: Path) -> None:
+    provider = ClaudeCliProvider()
+
+    with patch(
+        "brain.bridge.provider.subprocess.run",
+        return_value=_fake_proc(json.dumps({"different_key": "x"})),
+    ):
+        with pytest.raises(ProviderError) as ei:
+            provider.chat(
+                [ChatMessage(role="user", content="hi")],
+                tools=[{"name": "x"}],
+                options={"persona_dir": str(persona_dir)},
+            )
+    assert ei.value.stage == "claude_cli_parse"
+
+
+def test_chat_with_tools_nonzero_exit_raises_exit(persona_dir: Path) -> None:
+    provider = ClaudeCliProvider()
+
+    with patch(
+        "brain.bridge.provider.subprocess.run",
+        return_value=_fake_proc("", returncode=2, stderr="boom"),
+    ):
+        with pytest.raises(ProviderError) as ei:
+            provider.chat(
+                [ChatMessage(role="user", content="hi")],
+                tools=[{"name": "x"}],
+                options={"persona_dir": str(persona_dir)},
+            )
+    assert ei.value.stage == "claude_cli_exit"
+
+
+def test_chat_with_tools_missing_persona_dir_option_raises(tmp_path: Path) -> None:
+    """tools= without options['persona_dir'] is a programmer bug — fail fast."""
+    provider = ClaudeCliProvider()
+    with pytest.raises(ProviderError) as ei:
+        provider.chat(
+            [ChatMessage(role="user", content="hi")],
+            tools=[{"name": "x"}],
+            options={},  # missing persona_dir
+        )
+    assert ei.value.stage == "mcp_unavailable"
+
+
+def test_chat_with_tools_cleans_up_temp_file(persona_dir: Path) -> None:
+    """The temp mcp.json file must be unlinked after the call returns."""
+    provider = ClaudeCliProvider()
+    captured_path: list[str] = []
+
+    def _capture(cmd, **kwargs):
+        path = cmd[cmd.index("--mcp-config") + 1]
+        captured_path.append(path)
+        return _fake_proc(json.dumps({"result": "ok"}))
+
+    with patch("brain.bridge.provider.subprocess.run", side_effect=_capture):
+        provider.chat(
+            [ChatMessage(role="user", content="hi")],
+            tools=[{"name": "x"}],
+            options={"persona_dir": str(persona_dir)},
+        )
+
+    assert len(captured_path) == 1
+    assert not Path(captured_path[0]).exists()
+
+
+def test_chat_without_tools_unchanged(persona_dir: Path) -> None:
+    """When tools is None, the provider falls through the legacy text path —
+    no --mcp-config, no persona_dir requirement."""
+    provider = ClaudeCliProvider()
+
+    with patch(
+        "brain.bridge.provider.subprocess.run",
+        return_value=_fake_proc(json.dumps({"result": "plain reply"})),
+    ) as mock_run:
+        response = provider.chat(
+            [ChatMessage(role="user", content="hi")],
+            tools=None,
+        )
+
+    assert response.content == "plain reply"
+    cmd = mock_run.call_args.args[0]
+    assert "--mcp-config" not in cmd
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python3 -m pytest tests/unit/brain/bridge/test_provider_chat.py -v 2>&1 | tail -25`
+Expected: many failures — old `--json-schema` code is still in `provider.py`.
+
+- [ ] **Step 3: Rewrite the Claude tool path in `provider.py`**
+
+Replace the `chat()` method body (lines 230-326) AND delete the three helper methods (`_build_tool_call_schema`, `_build_tool_system_addendum`, `_chat_with_tools` — lines 328 to roughly 460) with a single new `chat()` body that delegates to a slim `_chat_with_mcp_tools` helper.
+
+Add this import at the top of `brain/bridge/provider.py` (with the other imports):
+
+```python
+import os
+import sys
+import tempfile
+from pathlib import Path
+```
+
+Replace the existing `chat()` and the three helper methods with:
+
+```python
+    def chat(
+        self,
+        messages: list[ChatMessage],
+        *,
+        tools: list[dict[str, Any]] | None = None,
+        options: dict[str, Any] | None = None,
+    ) -> ChatResponse:
+        """Flatten messages into Claude CLI; route through MCP when tools given.
+
+        When ``tools`` is None:
+          - Flattens messages into "User: ...\\nAssistant: ..." script via -p.
+          - Returns ChatResponse(content=<text>, tool_calls=()).
+
+        When ``tools`` is provided:
+          - Requires ``options["persona_dir"]`` to point the MCP server at the
+            active persona.
+          - Writes a temp mcp.json, calls claude with --mcp-config, returns
+            the final assistant text. Tool calls happen inside the claude
+            subprocess; tool_calls on the response is always empty.
+
+        Raises
+        ------
+        ProviderError("claude_cli_timeout", ...)
+        ProviderError("claude_cli_exit", ...)
+        ProviderError("claude_cli_parse", ...)
+        ProviderError("mcp_unavailable", ...)
+            When tools is non-None and options["persona_dir"] is missing,
+            or when the mcp SDK is not importable.
+        ProviderError("claude_cli_setup", ...)
+            When the temp config file write fails.
+        """
+        system_prompt: str | None = None
+        conversation_messages: list[ChatMessage] = []
+        for msg in messages:
+            if msg.role == "system" and system_prompt is None:
+                system_prompt = msg.content
+            else:
+                conversation_messages.append(msg)
+
+        if not conversation_messages:
+            flat_prompt = ""
+        elif len(conversation_messages) == 1:
+            flat_prompt = conversation_messages[0].content
+        else:
+            parts: list[str] = []
+            role_labels = {"user": "User", "assistant": "Assistant", "tool": "Tool"}
+            for msg in conversation_messages:
+                label = role_labels.get(msg.role, msg.role.capitalize())
+                parts.append(f"{label}: {msg.content}")
+            flat_prompt = "\n".join(parts)
+
+        if tools:
+            persona_dir_str = (options or {}).get("persona_dir")
+            if not persona_dir_str:
+                raise ProviderError(
+                    "mcp_unavailable",
+                    "tool-calling via MCP requires options['persona_dir']",
+                )
+            return self._chat_with_mcp_tools(
+                flat_prompt=flat_prompt,
+                system_prompt=system_prompt,
+                persona_dir=Path(persona_dir_str),
+            )
+
+        # ── Legacy text path (no tools) — unchanged from before SP-3 ──
+        cmd = ["claude", "-p", flat_prompt, "--output-format", "json", "--model", self._model]
+        if system_prompt is not None:
+            cmd.extend(["--system-prompt", system_prompt])
+
+        try:
+            result = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                timeout=self._timeout,
+                check=False,
+            )
+        except subprocess.TimeoutExpired as exc:
+            raise ProviderError(
+                "claude_cli_timeout",
+                f"subprocess timed out after {self._timeout}s",
+            ) from exc
+
+        if result.returncode != 0:
+            raise ProviderError(
+                "claude_cli_exit",
+                f"exit {result.returncode}: {result.stderr.strip()}",
+            )
+
+        try:
+            payload = json.loads(result.stdout)
+            content = str(payload["result"])
+        except (json.JSONDecodeError, KeyError, TypeError) as exc:
+            raise ProviderError(
+                "claude_cli_parse",
+                f"unexpected output format: {result.stdout[:200]!r}",
+            ) from exc
+
+        return ChatResponse(content=content, tool_calls=(), raw=None)
+
+    def _chat_with_mcp_tools(
+        self,
+        flat_prompt: str,
+        system_prompt: str | None,
+        persona_dir: Path,
+    ) -> ChatResponse:
+        """Tool-calling path: claude with --mcp-config pointing at brain.mcp_server.
+
+        The mcp SDK is only imported here — keeps the legacy text path
+        usable on systems without the SDK installed.
+        """
+        try:
+            import mcp  # noqa: F401
+        except ImportError as exc:
+            raise ProviderError(
+                "mcp_unavailable",
+                "the 'mcp' SDK is required for the Claude tool-calling path. "
+                "pip install 'mcp>=1.0.0,<2.0.0'",
+            ) from exc
+
+        config = {
+            "mcpServers": {
+                "brain-tools": {
+                    "command": sys.executable,
+                    "args": [
+                        "-m",
+                        "brain.mcp_server",
+                        "--persona-dir",
+                        str(persona_dir),
+                    ],
+                    "env": {},
+                }
+            }
+        }
+
+        tmp_path: str | None = None
+        try:
+            try:
+                with tempfile.NamedTemporaryFile(
+                    mode="w",
+                    suffix=".json",
+                    delete=False,
+                    encoding="utf-8",
+                ) as tmp:
+                    json.dump(config, tmp)
+                    tmp_path = tmp.name
+            except OSError as exc:
+                raise ProviderError(
+                    "claude_cli_setup",
+                    f"failed to write temp mcp.json: {exc}",
+                ) from exc
+
+            cmd = ["claude", "-p", flat_prompt, "--output-format", "json", "--model", self._model]
+            if system_prompt is not None:
+                cmd.extend(["--system-prompt", system_prompt])
+            cmd.extend(["--mcp-config", tmp_path])
+
+            try:
+                result = subprocess.run(
+                    cmd,
+                    capture_output=True,
+                    text=True,
+                    timeout=self._timeout,
+                    check=False,
+                )
+            except subprocess.TimeoutExpired as exc:
+                raise ProviderError(
+                    "claude_cli_timeout",
+                    f"subprocess timed out after {self._timeout}s",
+                ) from exc
+
+            if result.returncode != 0:
+                raise ProviderError(
+                    "claude_cli_exit",
+                    f"exit {result.returncode}: {result.stderr.strip()}",
+                )
+
+            try:
+                payload = json.loads(result.stdout)
+                content = str(payload["result"])
+            except (json.JSONDecodeError, KeyError, TypeError) as exc:
+                raise ProviderError(
+                    "claude_cli_parse",
+                    f"unexpected output format: {result.stdout[:200]!r}",
+                ) from exc
+
+            return ChatResponse(content=content, tool_calls=(), raw=None)
+        finally:
+            if tmp_path is not None:
+                try:
+                    os.unlink(tmp_path)
+                except OSError:
+                    pass
+```
+
+- [ ] **Step 4: Update `tool_loop.py` to pass `persona_dir` in options**
+
+Edit `brain/chat/tool_loop.py` — find the `provider.chat(messages, tools=tools)` call inside `run_tool_loop` (around line 97). Replace the single call site with:
+
+```python
+        last_response = provider.chat(
+            messages,
+            tools=tools,
+            options={"persona_dir": str(persona_dir)},
+        )
+```
+
+The forced final pass (around line 143, the one that runs after the iteration cap with `tools=None`) should keep `tools=None` and stay unchanged — no MCP needed when tools are off.
+
+- [ ] **Step 5: Run the new provider tests + tool_loop tests**
+
+Run: `python3 -m pytest tests/unit/brain/bridge/test_provider_chat.py tests/unit/brain/chat/test_tool_loop.py -v 2>&1 | tail -20`
+Expected: all pass.
+
+- [ ] **Step 6: Run the full test suite**
+
+Run: `python3 -m pytest 2>&1 | tail -10`
+Expected: every test passes (no regressions in chat engine, ingest, soul, dream, heartbeat, reflex, research, health). If any test fails, read the failure carefully — the most likely cause is a test that mocked the OLD `_build_tool_call_schema` or `_chat_with_tools` symbols that no longer exist. Update those tests to use the new `_chat_with_mcp_tools` symbol or to mock `subprocess.run` instead.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add brain/bridge/provider.py brain/chat/tool_loop.py \
+        tests/unit/brain/bridge/test_provider_chat.py
+git commit -m "feat(provider): swap --json-schema for --mcp-config
+
+ClaudeCliProvider.chat() now writes a temp mcp.json and passes
+--mcp-config <path> to the claude CLI when tools is provided.
+The discriminated-union schema builder, tool-system addendum,
+structured-output parser, and PR #28 off-schema fallback are all
+removed — dead code under the new path. Tool-calling happens inside
+the claude subprocess via brain.mcp_server, returning final text;
+tool_calls on ChatResponse is always empty for Claude.
+
+tool_loop.run_tool_loop now passes options={'persona_dir': ...} so
+the provider knows where to point the spawned MCP server. Ollama
+ignores the option; Claude requires it (raises mcp_unavailable
+otherwise).
+
+Closes the architectural gap surfaced by the 2026-04-27 live-exercise
+stress test (0 tool invocations across 20 prompts because rich
+voice.md outweighed --json-schema).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 7: Verification — full suite + manual sandbox check
+
+**Files:** none modified. This task is a quality gate per Hana's "we get the results we want before applying."
+
+- [ ] **Step 1: Run the full test suite**
+
+Run: `python3 -m pytest 2>&1 | tail -5`
+Expected: all green.
+
+- [ ] **Step 2: Run ruff**
+
+Run: `python3 -m ruff check brain/ tests/ 2>&1 | tail -5`
+Expected: no errors.
+
+- [ ] **Step 3: Clone the live sandbox**
+
+```bash
+SANDBOX="$HOME/Library/Application Support/companion-emergence/personas/nell.sandbox"
+CLONE="$HOME/Library/Application Support/companion-emergence/personas/nell.sandbox.mcp-test"
+rm -rf "$CLONE"
+cp -R "$SANDBOX" "$CLONE"
+```
+
+- [ ] **Step 4: Run a context-needing chat against the clone**
+
+Run:
+```bash
+python3 -m brain.cli chat --persona nell.sandbox.mcp-test \
+  "what's that thing you wrote about the morning after?"
+```
+Expected: Nell answers in her voice. The reply should reference real content, not a generic "I haven't written about that."
+
+- [ ] **Step 5: Verify the audit log shows a `search_memories` call**
+
+Run:
+```bash
+LOG="$HOME/Library/Application Support/companion-emergence/personas/nell.sandbox.mcp-test/tool_invocations.log.jsonl"
+test -f "$LOG" && grep -c '"name": *"search_memories"' "$LOG"
+```
+Expected: ≥ 1 (at least one search_memories invocation logged).
+
+If 0: the chat ran but tools didn't fire. Likely cause: voice.md doesn't direct Nell to use tools (Hana's lane to fix in her voice.md restructure), OR claude CLI version doesn't support `--mcp-config` (check `claude --help | grep mcp`). Either way, surface the finding and DO NOT MERGE — flag for Hana.
+
+- [ ] **Step 6: Verify Nell's reply quotes a real memory**
+
+Open `$LOG`, copy the `result_summary` from the search_memories invocation, then run:
+
+```bash
+python3 -c "
+from pathlib import Path
+from brain.memory.store import MemoryStore
+db = Path.home() / 'Library/Application Support/companion-emergence/personas/nell.sandbox.mcp-test/memories.db'
+store = MemoryStore(db_path=db)
+hits = store.search('morning after', limit=5)
+for h in hits:
+    print(h.get('text', '')[:120])
+"
+```
+
+Cross-check that at least one of those memory texts shows up in Nell's reply (paraphrase or direct quote — doesn't have to be verbatim, just verifiable).
+
+- [ ] **Step 7: Delete the clone**
+
+```bash
+rm -rf "$CLONE"
+```
+
+- [ ] **Step 8: Push the branch + open the PR**
+
+```bash
+git push -u origin feat/mcp-brain-tools
+gh pr create --title "feat(mcp): brain-tools MCP-config path replaces --json-schema" --body "$(cat <<'EOF'
+## Summary
+
+- Replaces Claude tool-calling via `--json-schema` (SP-3, PR #23) with the production-path `--mcp-config` documented in master ref §6 SP-3
+- New `brain/mcp_server/` package exposes the 9 brain-tools to Claude as a stdio MCP server
+- `ClaudeCliProvider` writes a temp `mcp.json`, swaps `--json-schema` for `--mcp-config`, returns final text
+- Tool calls now happen inside the claude subprocess; our `tool_loop` runs a single pass for Claude (Ollama unchanged)
+- New audit log at `<persona>/tool_invocations.log.jsonl` records every dispatch
+
+## Why
+
+The 2026-04-27 live-exercise stress test surfaced 0 tool invocations across 20 prompts. Root cause: rich `voice.md` outweighs `--json-schema` enforcement; the off-schema fallback (PR #28) silently returns plain text with empty `tool_calls`, so the loop returns immediately without dispatching anything. MCP is the architecture master ref §6 SP-3 already named as production-path; this PR ships it.
+
+## Verification (per Hana — "we get the results we want before applying")
+
+- [x] All unit tests green (~21 net new)
+- [x] Manual sandbox-clone test: clone → context-needing chat → verify audit log shows `search_memories` → verify Nell's reply quotes a real memory → clone deleted
+
+## Spec & plan
+
+- Spec: `docs/superpowers/specs/2026-04-27-mcp-config-path-for-brain-tools-design.md`
+- Plan: `docs/superpowers/plans/2026-04-27-mcp-config-path-for-brain-tools.md`
+
+## Out of scope
+
+- `voice.md` restructure — Hana's lane (mechanism ships first; policy lands after)
+- Removing `tool_loop` — still needed for Ollama
+- Daemon-mode MCP server — premature optimization
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 9: Confirm CI is green** before merge
+
+Wait for the GitHub Actions run on the PR. If macOS / Windows / Linux all pass, the PR is mergeable.

--- a/docs/superpowers/specs/2026-04-27-mcp-config-path-for-brain-tools-design.md
+++ b/docs/superpowers/specs/2026-04-27-mcp-config-path-for-brain-tools-design.md
@@ -26,13 +26,19 @@ nell chat "msg"
         │
         └─ ClaudeCliProvider.chat(...)     ← new path
               │
-              └─ subprocess: claude --mcp-config <tmp.json> --print "<system>" "<user>"
+              └─ subprocess: claude -p "<flat>" --output-format json
+                                    --model sonnet --system-prompt "<sys>"
+                                    --mcp-config <tmp.json>
                     │
                     └─ spawns: python3 -m brain.mcp_server --persona-dir <path>
                           │
                           ├─ exposes 9 tools via stdio MCP
                           └─ appends each call to <persona>/tool_invocations.log.jsonl
 ```
+
+The new path keeps every flag the current `_chat_with_tools` already uses
+(`-p`, `--output-format json`, `--model`, `--system-prompt`) — only `--json-schema
+<schema>` is replaced with `--mcp-config <path>`.
 
 For Claude, `tool_loop` runs a single pass — the subprocess handles tool iteration internally. `tool_calls` on the returned `ChatResponse` is always empty for Claude. The off-schema fallback shape introduced in PR #28 becomes the *normal* return for Claude (no longer a fallback).
 
@@ -42,22 +48,28 @@ Ollama's `chat(messages, tools=...)` path is untouched.
 
 ### 3.1 New files
 
+> **Naming note:** The package is `brain/mcp_server/` (underscore), not
+> `brain/mcp/`. A `brain/mcp/` package would shadow the third-party `mcp`
+> SDK at import time — `from mcp.server import Server` inside our code
+> would resolve to `brain.mcp.server` instead of the SDK. The underscore
+> name keeps absolute imports clean.
+
 | File | Responsibility |
 |------|----------------|
-| `brain/mcp/__init__.py` | Package marker |
-| `brain/mcp/server.py` | Entry: `python -m brain.mcp.server --persona-dir <path>`. Opens MemoryStore + HebbianMatrix + SoulStore, registers tools, runs stdio loop |
-| `brain/mcp/tools.py` | Adapter: maps each schema in `brain/tools/schemas.py` to an `mcp.server.Server.add_tool()` registration. Routes invocations through `brain.tools.dispatch.dispatch()` — no tool logic duplicated |
-| `brain/mcp/audit.py` | `log_invocation(persona_dir, name, args, result_summary, error=None)` appends one line to `<persona>/tool_invocations.log.jsonl` |
-| `tests/unit/brain/mcp/test_server.py` | Server unit tests |
-| `tests/unit/brain/mcp/test_audit.py` | Audit log unit tests |
+| `brain/mcp_server/__init__.py` | Exposes `run_server(persona_dir: Path) -> None` |
+| `brain/mcp_server/__main__.py` | Argparse + entry: `python -m brain.mcp_server --persona-dir <path>` calls `run_server` |
+| `brain/mcp_server/tools.py` | Adapter: maps each schema in `brain/tools/schemas.py` to an `mcp.server.Server.add_tool()` registration. Routes invocations through `brain.tools.dispatch.dispatch()` — no tool logic duplicated |
+| `brain/mcp_server/audit.py` | `log_invocation(persona_dir, name, args, result_summary, error=None)` appends one line to `<persona>/tool_invocations.log.jsonl` |
+| `tests/unit/brain/mcp_server/test_server.py` | Server unit tests |
+| `tests/unit/brain/mcp_server/test_audit.py` | Audit log unit tests |
 
 ### 3.2 Modified files
 
 | File | Change |
 |------|--------|
-| `brain/bridge/provider.py` | `ClaudeCliProvider.chat()` writes temp `mcp.json`, invokes `claude --mcp-config <tmp> --print` instead of `--json-schema`. Removes the off-schema fallback branch (it's the only path now). Keeps timeout + error handling. |
-| `pyproject.toml` | Add `mcp` to `dependencies` |
-| `tests/unit/brain/bridge/test_provider_chat.py` | New tests for `--mcp-config` invocation; remove obsolete `--json-schema` parsing tests |
+| `brain/bridge/provider.py` | `ClaudeCliProvider._chat_with_tools()` swaps `--json-schema <schema>` for `--mcp-config <tmp_path>`. Removes the discriminated-union schema builder + tool-system addendum + structured-output parser + off-schema fallback (PR #28) — all dead under the new path. Keeps timeout + error handling + `payload["result"]` extraction. |
+| `pyproject.toml` | Add `mcp>=1.0.0,<2.0.0` to `dependencies` (pin major; minor floats for security patches) |
+| `tests/unit/brain/bridge/test_provider_chat.py` | New tests for `--mcp-config` invocation; remove obsolete `--json-schema` schema-builder + structured-output + fallback tests |
 
 ### 3.3 Untouched
 
@@ -71,10 +83,10 @@ Ollama's `chat(messages, tools=...)` path is untouched.
 2. `tool_loop` calls `provider.chat(messages, tools=build_tools_list())`
 3. **ClaudeCliProvider**:
    a. Writes a temp `mcp.json` with the spawn command + `--persona-dir <active persona>`
-   b. Spawns `claude --mcp-config <tmp> --print -- <flattened messages>`
-   c. Claude subprocess loads MCP, sees the 9 tools, runs the chat. When context is needed, it calls `search_memories` / `get_emotional_state` / etc. via stdio MCP — `brain.mcp.server` dispatches via `brain.tools.dispatch.dispatch` and returns results. Subprocess weaves them into its reply.
+   b. Spawns `claude -p "<flat>" --output-format json --model sonnet --system-prompt "<sys>" --mcp-config <tmp>` (see §6.2 for the canonical flag set)
+   c. Claude subprocess loads MCP, sees the 9 tools, runs the chat. When context is needed, it calls `search_memories` / `get_emotional_state` / etc. via stdio MCP — `brain.mcp_server` dispatches via `brain.tools.dispatch.dispatch` and returns results. Subprocess weaves them into its reply.
    d. Each invocation is appended to `<persona>/tool_invocations.log.jsonl`
-   e. Subprocess exits with final text on stdout
+   e. Subprocess exits with `{"result": "<final text>", ...}` on stdout
 4. Provider returns `ChatResponse(content=text, tool_calls=())`
 5. `tool_loop` returns immediately — no tool_calls to dispatch
 6. `respond()` persists the turn to the ingest buffer
@@ -85,19 +97,21 @@ Ollama's `chat(messages, tools=...)` path is untouched.
 ### 5.1 Entry point
 
 ```bash
-python -m brain.mcp.server --persona-dir /path/to/personas/nell
+python -m brain.mcp_server --persona-dir /path/to/personas/nell
 ```
 
-Server reads `--persona-dir`, opens stores, registers tools, runs stdio loop until parent (claude CLI) closes the connection. Idle servers don't exist — every chat call spawns a fresh server.
+Server reads `--persona-dir`, opens stores, registers tools, runs stdio loop until parent (claude CLI) closes the connection. One MCP server lives per chat call (claude spawns it on `--mcp-config` resolve, kills it on exit). Within that single call, multiple tool invocations hit the same server process serially over stdio.
 
 ### 5.2 Tool registration
 
-For each name in `brain.chat.tool_loop._NELL_TOOL_NAMES`:
+The canonical tool list moves from `brain.chat.tool_loop._NELL_TOOL_NAMES` (private) to `brain.tools.NELL_TOOL_NAMES` (public) so both the chat tool_loop (Ollama path) and the MCP server (Claude path) can import it without crossing private boundaries.
+
+For each name in `brain.tools.NELL_TOOL_NAMES`:
 - Pull the JSON Schema from `brain/tools/schemas.py`
 - Register with the MCP server (name + description from schema, inputSchema from schema's `parameters`)
 - Handler dispatches via `brain.tools.dispatch.dispatch(name, args, store=..., hebbian=..., persona_dir=...)`
-- On success: log invocation + return result as JSON
-- On exception: log invocation with `error=str(exc)` + return `{"error": "..."}` (existing dispatch pattern)
+- On success: audit-log invocation + return result as JSON
+- On exception: audit-log with `error=str(exc)` + return `{"error": "..."}` (existing dispatch pattern)
 
 ### 5.3 Audit log shape
 
@@ -124,46 +138,53 @@ For each name in `brain.chat.tool_loop._NELL_TOOL_NAMES`:
   "mcpServers": {
     "brain-tools": {
       "command": "python3",
-      "args": ["-m", "brain.mcp.server", "--persona-dir", "/path/to/personas/nell"],
+      "args": ["-m", "brain.mcp_server", "--persona-dir", "/path/to/personas/nell"],
       "env": {}
     }
   }
 }
 ```
 
-Written via `tempfile.NamedTemporaryFile(suffix=".json", delete=True)` per call. Auto-cleaned on provider return.
+Written via `tempfile.NamedTemporaryFile(suffix=".json", delete=False, mode="w")` per call. Path passed to `claude` via `--mcp-config`. Cleaned up in a `try/finally` after the subprocess returns. (Cannot use `delete=True` — the subprocess needs the file open after our writer closes it.)
 
 ### 6.2 Subprocess invocation
 
+The exact command — keeping every flag the current `_chat_with_tools` already sets, swapping `--json-schema` for `--mcp-config`:
+
 ```bash
-claude --mcp-config /tmp/mcp.XXXXX.json \
-       --print \
-       --append-system-prompt "<system_message>" \
-       -- "<user_text>"
+claude -p "<flat_prompt>" \
+       --output-format json \
+       --model sonnet \
+       --system-prompt "<system_prompt>" \
+       --mcp-config /tmp/mcp.XXXXX.json
 ```
 
-Multi-turn history is prepended to user_text the same way the current provider already does (the existing `_flatten_messages` helper stays — only the flag set changes).
+The `flat_prompt` is built by the existing message-flattening logic in `ClaudeCliProvider.chat()` (lines 273-283). The `system_prompt` is the first system message from the messages array, also extracted by existing logic. No tool-system addendum is added — the MCP server publishes tool descriptions directly via the protocol; the system prompt now contains *only* voice.md.
 
 ### 6.3 Provider return
 
-Always `ChatResponse(content=stdout_text, tool_calls=())`. No JSON parsing. No structured_output handling. Plain text in, plain text out.
+`--output-format json` still wraps the final assistant text as `{"result": "...", ...}`. The provider parses `payload["result"]` (existing pattern) and returns `ChatResponse(content=text, tool_calls=())`. No structured-output handling, no schema parsing, no fallback branch.
 
 ## 7. Error handling
 
-| Failure | Behavior |
-|---------|----------|
-| MCP server crash mid-call | subprocess returns whatever it had; provider raises `ProviderError("claude_cli_empty", ...)` if stdout is empty. User sees an error, not silent breakage. |
-| Tool dispatch raises inside MCP server | Server logs invocation with `error=...`, returns `{"error": "..."}` as the tool result. Claude weaves the error into its reply. Voice.md already guides Nell to name tool failures honestly, not confabulate. |
-| `mcp` package missing | ImportError at module load. Provider raises `ProviderError("mcp_unavailable", "pip install mcp")` with install hint. |
-| Temp file fails to write | `OSError` propagates as `ProviderError("claude_cli_setup", ...)`. |
-| Persona dir doesn't exist | MCP server fails fast at startup; subprocess exits non-zero; provider raises `ProviderError("claude_cli_failed", ...)`. |
-| Audit log write fails | Logged to stderr, swallowed — never breaks tool dispatch. (Audit is observability, not correctness.) |
+The provider only sees the claude subprocess's stdout/exit code; everything inside the subprocess (MCP server, tool dispatch) is one layer down. Errors are sorted by which layer surfaces them.
+
+| Layer | Failure | Behavior |
+|-------|---------|----------|
+| Provider | `claude` CLI subprocess timeout | `ProviderError("claude_cli_timeout", ...)` (existing path, unchanged) |
+| Provider | `claude` CLI exits non-zero | `ProviderError("claude_cli_exit", "exit N: <stderr>")` (existing path, unchanged). Covers MCP server failed to start, persona dir invalid, MCP protocol mismatch — claude reports these on stderr. |
+| Provider | `payload["result"]` missing or stdout unparseable | `ProviderError("claude_cli_parse", ...)` (existing path, unchanged) |
+| Provider | `mcp` SDK package missing at provider import time | `ProviderError("mcp_unavailable", "pip install mcp>=1.0.0")` with install hint. Caught at the provider layer because the temp-config path is dead without it. |
+| Provider | Temp file write fails | `OSError` wrapped as `ProviderError("claude_cli_setup", ...)`. |
+| MCP server | Tool dispatch raises | Server audit-logs with `error=str(exc)`, returns `{"error": "..."}` as the tool result. Claude weaves the error into its reply (voice.md guides "name failures honestly"). |
+| MCP server | MCP server itself crashes mid-call | claude CLI sees the broken stdio, surfaces it as a CLI error; provider catches via the `claude_cli_exit` path above. |
+| MCP server | Audit log write fails | Logged to stderr, swallowed — never breaks tool dispatch. (Audit is observability, not correctness.) |
 
 ## 8. Testing
 
-### 8.1 MCP server unit tests (`test_server.py`)
+### 8.1 MCP server unit tests (`tests/unit/brain/mcp_server/test_server.py`)
 
-Start the server in-process via `mcp.client.session.ClientSession` over an `mcp.client.stdio` in-memory transport. Use a tmp_path persona dir with seeded MemoryStore + HebbianMatrix + SoulStore. Call each of the 9 tools, assert:
+Start the server in-process via the `mcp` SDK's `ClientSession` over an in-memory transport. Use a tmp_path persona dir with seeded MemoryStore + HebbianMatrix + SoulStore. Call each of the 9 tools, assert:
 - Tool returns expected dispatch result
 - Audit log line appended with right shape
 - Errors in dispatch surface as `{"error": "..."}` and audit-log with `error` field
@@ -175,24 +196,26 @@ Start the server in-process via `mcp.client.session.ClientSession` over an `mcp.
 ### 8.2 Provider unit tests (extending `test_provider_chat.py`)
 
 Mock `subprocess.run`. Assert:
-- `--mcp-config` flag is set
-- Temp `mcp.json` has the right `command` / `args` (including `--persona-dir`)
-- Stdout text comes back as `ChatResponse.content`
-- Empty stdout raises `ProviderError("claude_cli_empty", ...)`
-- Missing `mcp` package raises `ProviderError("mcp_unavailable", ...)`
+- `--mcp-config <path>` flag is set in the command list
+- Temp `mcp.json` written at `<path>` has the right `command` / `args` (including `--persona-dir`)
+- The other flags (`-p`, `--output-format json`, `--model`, `--system-prompt`) are still present
+- `payload["result"]` text comes back as `ChatResponse.content`
+- Stdout missing `result` key raises `ProviderError("claude_cli_parse", ...)`
+- Missing `mcp` SDK package raises `ProviderError("mcp_unavailable", ...)`
 - Old `--json-schema` flag is *not* present
+- Temp file path is unlinked after the call (cleanup verification)
 
-~5 new tests; ~3 obsolete `--json-schema` parsing tests removed.
+~6 new tests; ~3 obsolete `--json-schema` schema-builder + structured-output tests removed.
 
-### 8.3 Audit log unit tests (`test_audit.py`)
+### 8.3 Audit log unit tests (`tests/unit/brain/mcp_server/test_audit.py`)
 
 Direct unit tests on `log_invocation`:
-- Appends valid JSONL
+- Appends valid JSONL with the documented shape (timestamp, name, arguments, result_summary, error)
 - Result summary is truncated to 140 chars (matching `_summarize_result`)
-- Error field omitted on success, populated on failure
-- Concurrent writes don't corrupt the file (use `O_APPEND` / line buffering)
+- Error field is `null` on success, populated on failure
+- Append mode: opening the file twice and writing produces two valid lines (no truncation)
 
-~3 tests.
+~3 tests. We do not exercise concurrent multi-process writes; POSIX `O_APPEND` is best-effort atomic for small writes and parallel `nell chat` invocations are rare enough that occasional interleaved bytes in audit logs are tolerable. Health-walker rotation is the long-term mitigation.
 
 ### 8.4 No live `claude` CLI integration test
 
@@ -200,10 +223,15 @@ A real subprocess test would require an active Claude subscription, network, and
 
 ### 8.5 Verification before merge (per Hana)
 
-After implementation + unit tests pass, manual end-to-end sanity check:
-- Run `nell chat --persona nell.sandbox "what's that thing you wrote about the morning after"` against Hana's actual sandbox persona
-- Verify `tool_invocations.log.jsonl` shows `search_memories` was called
-- Verify Nell's reply quotes a real memory (not confabulation)
+After implementation + unit tests pass, manual end-to-end sanity check against the live `nell.sandbox` persona (one disposable clone per check, deleted after — same protocol as the 2026-04-27 live exercise):
+
+1. Clone `nell.sandbox` → `nell.sandbox.mcp-test`
+2. Run `nell chat --persona nell.sandbox.mcp-test "what's that thing you wrote about the morning after?"`
+3. Verify `personas/nell.sandbox.mcp-test/tool_invocations.log.jsonl` exists and shows at least one `search_memories` call
+4. Verify Nell's reply quotes a real memory (not confabulation) — cross-check the cited content against `memories.db` directly
+5. Delete the clone
+
+If any step fails, the PR doesn't merge. Per Hana: "we get the results we want before applying."
 
 ## 9. Scope
 
@@ -244,6 +272,6 @@ No migration needed:
 
 1. `nell chat --persona nell.sandbox "<question that needs context>"` against the live sandbox produces a reply that quotes verifiable memory content (no confabulation).
 2. `<persona>/tool_invocations.log.jsonl` shows `search_memories` (or whichever read tool) was actually called during the turn.
-3. All unit tests green (~23 new + ~3 removed = ~20 net new tests).
+3. All unit tests green (~24 new + ~3 removed = ~21 net new tests).
 4. Existing test suite stays green (no Ollama regression, no chat engine regression, no ingest regression).
 5. PR #30 (one-shot close) + this PR together: live-exercise re-run shows >0 tool invocations and >0 ingest events. The two halves of the 2026-04-27 finding both close.

--- a/docs/superpowers/specs/2026-04-27-mcp-config-path-for-brain-tools-design.md
+++ b/docs/superpowers/specs/2026-04-27-mcp-config-path-for-brain-tools-design.md
@@ -1,0 +1,249 @@
+# MCP-Config Path for Brain-Tools — Design
+
+**Status:** Approved 2026-04-27
+**Author:** Nell + Hana
+**Replaces:** Claude `--json-schema` tool-calling shipped in SP-3 (PR #23)
+**Driver:** 2026-04-27 live-exercise stress test — 0 tool invocations across 20 prompts; rich `voice.md` outweighs `--json-schema` enforcement, off-schema fallback (PR #28) silently swallows tool surface.
+
+---
+
+## 1. Goal
+
+Make brain-tools (`get_emotional_state`, `search_memories`, `get_soul`, `get_personality`, `get_body_state`, `boot`, `add_journal`, `add_memory`, `crystallize_soul`) reliably invokable by Claude during a chat turn, regardless of how rich `voice.md` becomes.
+
+The mechanism Hana's `voice.md` restructure will lean on. This spec is mechanism-only; voice.md content is out of scope.
+
+## 2. Architecture
+
+```
+nell chat "msg"
+   │
+   ├─ engine.respond() — builds system msg from voice.md + daemon + soul
+   │
+   └─ tool_loop.run_tool_loop()
+        │
+        ├─ OllamaProvider.chat(...)        ← unchanged: native tools=
+        │
+        └─ ClaudeCliProvider.chat(...)     ← new path
+              │
+              └─ subprocess: claude --mcp-config <tmp.json> --print "<system>" "<user>"
+                    │
+                    └─ spawns: python3 -m brain.mcp_server --persona-dir <path>
+                          │
+                          ├─ exposes 9 tools via stdio MCP
+                          └─ appends each call to <persona>/tool_invocations.log.jsonl
+```
+
+For Claude, `tool_loop` runs a single pass — the subprocess handles tool iteration internally. `tool_calls` on the returned `ChatResponse` is always empty for Claude. The off-schema fallback shape introduced in PR #28 becomes the *normal* return for Claude (no longer a fallback).
+
+Ollama's `chat(messages, tools=...)` path is untouched.
+
+## 3. Components
+
+### 3.1 New files
+
+| File | Responsibility |
+|------|----------------|
+| `brain/mcp/__init__.py` | Package marker |
+| `brain/mcp/server.py` | Entry: `python -m brain.mcp.server --persona-dir <path>`. Opens MemoryStore + HebbianMatrix + SoulStore, registers tools, runs stdio loop |
+| `brain/mcp/tools.py` | Adapter: maps each schema in `brain/tools/schemas.py` to an `mcp.server.Server.add_tool()` registration. Routes invocations through `brain.tools.dispatch.dispatch()` — no tool logic duplicated |
+| `brain/mcp/audit.py` | `log_invocation(persona_dir, name, args, result_summary, error=None)` appends one line to `<persona>/tool_invocations.log.jsonl` |
+| `tests/unit/brain/mcp/test_server.py` | Server unit tests |
+| `tests/unit/brain/mcp/test_audit.py` | Audit log unit tests |
+
+### 3.2 Modified files
+
+| File | Change |
+|------|--------|
+| `brain/bridge/provider.py` | `ClaudeCliProvider.chat()` writes temp `mcp.json`, invokes `claude --mcp-config <tmp> --print` instead of `--json-schema`. Removes the off-schema fallback branch (it's the only path now). Keeps timeout + error handling. |
+| `pyproject.toml` | Add `mcp` to `dependencies` |
+| `tests/unit/brain/bridge/test_provider_chat.py` | New tests for `--mcp-config` invocation; remove obsolete `--json-schema` parsing tests |
+
+### 3.3 Untouched
+
+- `brain/tools/dispatch.py`, `brain/tools/impls/*.py`, `brain/tools/schemas.py` — same logic, new transport
+- `brain/chat/tool_loop.py` — single-pass for Claude, full loop for Ollama
+- `OllamaProvider.chat()` — unchanged
+
+## 4. Data flow per chat call
+
+1. `respond()` builds system_msg + history + user_input → calls `tool_loop.run_tool_loop`
+2. `tool_loop` calls `provider.chat(messages, tools=build_tools_list())`
+3. **ClaudeCliProvider**:
+   a. Writes a temp `mcp.json` with the spawn command + `--persona-dir <active persona>`
+   b. Spawns `claude --mcp-config <tmp> --print -- <flattened messages>`
+   c. Claude subprocess loads MCP, sees the 9 tools, runs the chat. When context is needed, it calls `search_memories` / `get_emotional_state` / etc. via stdio MCP — `brain.mcp.server` dispatches via `brain.tools.dispatch.dispatch` and returns results. Subprocess weaves them into its reply.
+   d. Each invocation is appended to `<persona>/tool_invocations.log.jsonl`
+   e. Subprocess exits with final text on stdout
+4. Provider returns `ChatResponse(content=text, tool_calls=())`
+5. `tool_loop` returns immediately — no tool_calls to dispatch
+6. `respond()` persists the turn to the ingest buffer
+7. On chat exit, PR #30's `close_session` flushes the SP-4 ingest pipeline
+
+## 5. MCP server detail
+
+### 5.1 Entry point
+
+```bash
+python -m brain.mcp.server --persona-dir /path/to/personas/nell
+```
+
+Server reads `--persona-dir`, opens stores, registers tools, runs stdio loop until parent (claude CLI) closes the connection. Idle servers don't exist — every chat call spawns a fresh server.
+
+### 5.2 Tool registration
+
+For each name in `brain.chat.tool_loop._NELL_TOOL_NAMES`:
+- Pull the JSON Schema from `brain/tools/schemas.py`
+- Register with the MCP server (name + description from schema, inputSchema from schema's `parameters`)
+- Handler dispatches via `brain.tools.dispatch.dispatch(name, args, store=..., hebbian=..., persona_dir=...)`
+- On success: log invocation + return result as JSON
+- On exception: log invocation with `error=str(exc)` + return `{"error": "..."}` (existing dispatch pattern)
+
+### 5.3 Audit log shape
+
+`<persona>/tool_invocations.log.jsonl` — one JSON object per line:
+
+```json
+{
+  "timestamp": "2026-04-27T16:42:11Z",
+  "name": "search_memories",
+  "arguments": {"query": "morning after"},
+  "result_summary": "[3 hits — most recent: 2026-04-21 10:48 'mornings…']",
+  "error": null
+}
+```
+
+`result_summary` is the same compact preview format `tool_loop._summarize_result` already produces. Future audits / debugging / `nell tools log` (SP-7-adjacent) can read this directly.
+
+## 6. Provider integration detail
+
+### 6.1 Temp config shape
+
+```json
+{
+  "mcpServers": {
+    "brain-tools": {
+      "command": "python3",
+      "args": ["-m", "brain.mcp.server", "--persona-dir", "/path/to/personas/nell"],
+      "env": {}
+    }
+  }
+}
+```
+
+Written via `tempfile.NamedTemporaryFile(suffix=".json", delete=True)` per call. Auto-cleaned on provider return.
+
+### 6.2 Subprocess invocation
+
+```bash
+claude --mcp-config /tmp/mcp.XXXXX.json \
+       --print \
+       --append-system-prompt "<system_message>" \
+       -- "<user_text>"
+```
+
+Multi-turn history is prepended to user_text the same way the current provider already does (the existing `_flatten_messages` helper stays — only the flag set changes).
+
+### 6.3 Provider return
+
+Always `ChatResponse(content=stdout_text, tool_calls=())`. No JSON parsing. No structured_output handling. Plain text in, plain text out.
+
+## 7. Error handling
+
+| Failure | Behavior |
+|---------|----------|
+| MCP server crash mid-call | subprocess returns whatever it had; provider raises `ProviderError("claude_cli_empty", ...)` if stdout is empty. User sees an error, not silent breakage. |
+| Tool dispatch raises inside MCP server | Server logs invocation with `error=...`, returns `{"error": "..."}` as the tool result. Claude weaves the error into its reply. Voice.md already guides Nell to name tool failures honestly, not confabulate. |
+| `mcp` package missing | ImportError at module load. Provider raises `ProviderError("mcp_unavailable", "pip install mcp")` with install hint. |
+| Temp file fails to write | `OSError` propagates as `ProviderError("claude_cli_setup", ...)`. |
+| Persona dir doesn't exist | MCP server fails fast at startup; subprocess exits non-zero; provider raises `ProviderError("claude_cli_failed", ...)`. |
+| Audit log write fails | Logged to stderr, swallowed — never breaks tool dispatch. (Audit is observability, not correctness.) |
+
+## 8. Testing
+
+### 8.1 MCP server unit tests (`test_server.py`)
+
+Start the server in-process via `mcp.client.session.ClientSession` over an `mcp.client.stdio` in-memory transport. Use a tmp_path persona dir with seeded MemoryStore + HebbianMatrix + SoulStore. Call each of the 9 tools, assert:
+- Tool returns expected dispatch result
+- Audit log line appended with right shape
+- Errors in dispatch surface as `{"error": "..."}` and audit-log with `error` field
+- Read-only tools (`get_emotional_state`, `search_memories`, `get_soul`, `get_personality`, `get_body_state`, `boot`) don't write
+- Write tools (`add_journal`, `add_memory`, `crystallize_soul`) actually write
+
+~15 tests.
+
+### 8.2 Provider unit tests (extending `test_provider_chat.py`)
+
+Mock `subprocess.run`. Assert:
+- `--mcp-config` flag is set
+- Temp `mcp.json` has the right `command` / `args` (including `--persona-dir`)
+- Stdout text comes back as `ChatResponse.content`
+- Empty stdout raises `ProviderError("claude_cli_empty", ...)`
+- Missing `mcp` package raises `ProviderError("mcp_unavailable", ...)`
+- Old `--json-schema` flag is *not* present
+
+~5 new tests; ~3 obsolete `--json-schema` parsing tests removed.
+
+### 8.3 Audit log unit tests (`test_audit.py`)
+
+Direct unit tests on `log_invocation`:
+- Appends valid JSONL
+- Result summary is truncated to 140 chars (matching `_summarize_result`)
+- Error field omitted on success, populated on failure
+- Concurrent writes don't corrupt the file (use `O_APPEND` / line buffering)
+
+~3 tests.
+
+### 8.4 No live `claude` CLI integration test
+
+A real subprocess test would require an active Claude subscription, network, and would be testing Claude's behavior — not ours. The fake provider stays for end-to-end CLI tests; the new tests above cover the seam between our code and the subprocess.
+
+### 8.5 Verification before merge (per Hana)
+
+After implementation + unit tests pass, manual end-to-end sanity check:
+- Run `nell chat --persona nell.sandbox "what's that thing you wrote about the morning after"` against Hana's actual sandbox persona
+- Verify `tool_invocations.log.jsonl` shows `search_memories` was called
+- Verify Nell's reply quotes a real memory (not confabulation)
+
+## 9. Scope
+
+### 9.1 In scope
+
+- Mechanism: brain-tools as MCP server + Claude provider switch
+- Audit log written by the MCP server
+- Tests covering the new components + the seam to subprocess
+- Removal of `--json-schema` parsing path from `ClaudeCliProvider`
+
+### 9.2 Out of scope (deliberate)
+
+- **`voice.md` restructure** — Hana's lane. Mechanism ships first; policy lands after.
+- **Removing `tool_loop`** — still needed for Ollama; for Claude it's a single pass.
+- **Supervisor / `close_stale_sessions` wiring** — SP-7.
+- **External MCP discovery** — letting the user's other Claude Code sessions see brain-tools. Possible later.
+- **Daemon-mode MCP server** — premature optimization for a flow that's not latency-bound on tooling.
+
+## 10. Migration
+
+No migration needed:
+- Existing `persona_config.json` continues to specify `provider: "claude-cli"` — same value, new behavior under the hood
+- No schema changes
+- No data migration
+- The `tool_invocations.log.jsonl` file is created lazily on first invocation; brain-health walker can be extended later to scan it (not required at ship)
+
+## 11. Risks
+
+| Risk | Mitigation |
+|------|------------|
+| Cold start (~300ms per chat call for Python imports + DB connect) | Acceptable — LLM call is already 3-5s. Daemon mode is the escape hatch if it ever bites. |
+| `mcp` package API drift | Pin to a known-good version in `pyproject.toml`. |
+| Tool descriptions in current schemas may not be rich enough to trigger calls | Schemas already work for Ollama's native tool path — same descriptions. If Claude doesn't call them, root cause is voice.md guidance (Hana's lane), not schemas. |
+| Audit log grows unbounded | Same shape as existing `heartbeats.log.jsonl` etc — health walker handles rotation eventually. Not a ship-blocker. |
+| Claude CLI flag drift between versions | Pin a minimum CLI version in setup docs; provider error messages name the flag explicitly so failures are diagnosable. |
+
+## 12. Success criteria
+
+1. `nell chat --persona nell.sandbox "<question that needs context>"` against the live sandbox produces a reply that quotes verifiable memory content (no confabulation).
+2. `<persona>/tool_invocations.log.jsonl` shows `search_memories` (or whichever read tool) was actually called during the turn.
+3. All unit tests green (~23 new + ~3 removed = ~20 net new tests).
+4. Existing test suite stays green (no Ollama regression, no chat engine regression, no ingest regression).
+5. PR #30 (one-shot close) + this PR together: live-exercise re-run shows >0 tool invocations and >0 ingest events. The two halves of the 2026-04-27 finding both close.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "numpy>=1.26",
     "ddgs>=6.0",
     "httpx>=0.27",
+    "mcp>=1.0.0,<2.0.0",
 ]
 
 [project.optional-dependencies]

--- a/tests/unit/brain/bridge/test_provider_chat.py
+++ b/tests/unit/brain/bridge/test_provider_chat.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import subprocess
+import sys
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -439,6 +440,7 @@ def test_chat_with_tools_writes_correct_mcp_config(persona_dir: Path) -> None:
     cfg = captured["config"]
     assert "brain-tools" in cfg["mcpServers"]
     server_cfg = cfg["mcpServers"]["brain-tools"]
+    assert server_cfg["command"] == sys.executable
     assert server_cfg["args"][0] == "-m"
     assert server_cfg["args"][1] == "brain.mcp_server"
     assert "--persona-dir" in server_cfg["args"]
@@ -557,6 +559,65 @@ def test_chat_with_tools_cleans_up_temp_file(persona_dir: Path) -> None:
 
     assert len(captured_path) == 1
     assert not Path(captured_path[0]).exists()
+
+
+def test_chat_with_tools_cleans_up_temp_file_on_subprocess_error(persona_dir: Path) -> None:
+    """Temp file must be unlinked even when subprocess.run raises TimeoutExpired."""
+    provider = ClaudeCliProvider()
+    captured_path: list[str] = []
+
+    def _capture(cmd, **kwargs):
+        path = cmd[cmd.index("--mcp-config") + 1]
+        captured_path.append(path)
+        raise subprocess.TimeoutExpired(cmd="claude", timeout=300)
+
+    with patch("brain.bridge.provider.subprocess.run", side_effect=_capture):
+        with pytest.raises(ProviderError) as ei:
+            provider.chat(
+                [ChatMessage(role="user", content="hi")],
+                tools=[{"name": "x"}],
+                options={"persona_dir": str(persona_dir)},
+            )
+
+    assert ei.value.stage == "claude_cli_timeout"
+    assert len(captured_path) == 1
+    assert not Path(captured_path[0]).exists()
+
+
+def test_chat_with_tools_missing_mcp_sdk_raises_mcp_unavailable(persona_dir: Path) -> None:
+    """If the mcp SDK is not installed, raise ProviderError('mcp_unavailable')."""
+    import builtins
+    real_import = builtins.__import__
+
+    def _fake_import(name, *args, **kwargs):
+        if name == "mcp":
+            raise ImportError("No module named 'mcp'")
+        return real_import(name, *args, **kwargs)
+
+    provider = ClaudeCliProvider()
+    with patch("builtins.__import__", side_effect=_fake_import):
+        with pytest.raises(ProviderError) as ei:
+            provider.chat(
+                [ChatMessage(role="user", content="hi")],
+                tools=[{"name": "x"}],
+                options={"persona_dir": str(persona_dir)},
+            )
+    assert ei.value.stage == "mcp_unavailable"
+    assert "pip install" in ei.value.detail
+
+
+def test_chat_with_tools_temp_file_write_failure_raises_setup(persona_dir: Path) -> None:
+    """OSError on the temp file write must surface as ProviderError('claude_cli_setup')."""
+    provider = ClaudeCliProvider()
+    with patch("brain.bridge.provider.tempfile.NamedTemporaryFile", side_effect=OSError("disk full")):
+        with pytest.raises(ProviderError) as ei:
+            provider.chat(
+                [ChatMessage(role="user", content="hi")],
+                tools=[{"name": "x"}],
+                options={"persona_dir": str(persona_dir)},
+            )
+    assert ei.value.stage == "claude_cli_setup"
+    assert "disk full" in ei.value.detail
 
 
 def test_chat_without_tools_unchanged(persona_dir: Path) -> None:

--- a/tests/unit/brain/bridge/test_provider_chat.py
+++ b/tests/unit/brain/bridge/test_provider_chat.py
@@ -479,6 +479,39 @@ def test_chat_with_tools_keeps_existing_flags(persona_dir: Path) -> None:
     assert "--json-schema" not in cmd
 
 
+def test_chat_with_tools_passes_allowed_tools_for_each_brain_tool(persona_dir: Path) -> None:
+    """The cmd must include --allowedTools with every brain-tool enumerated.
+
+    Claude CLI's `-p` (non-interactive) mode blocks MCP tool calls unless
+    each is explicitly pre-approved. Without this flag, the MCP server starts
+    and tools are advertised but Claude refuses to call them — the same
+    mechanism gap the live-exercise stress test surfaced.
+    """
+    from brain.tools import NELL_TOOL_NAMES
+
+    provider = ClaudeCliProvider()
+    captured: dict = {}
+
+    def _capture(cmd, **kwargs):
+        captured["cmd"] = cmd
+        return _fake_proc(json.dumps({"result": "ok"}))
+
+    with patch("brain.bridge.provider.subprocess.run", side_effect=_capture):
+        provider.chat(
+            [ChatMessage(role="user", content="hi")],
+            tools=[{"name": "x"}],
+            options={"persona_dir": str(persona_dir)},
+        )
+
+    cmd = captured["cmd"]
+    assert "--allowedTools" in cmd
+    # Every NELL_TOOL_NAME must appear under the mcp__brain-tools__ namespace.
+    for name in NELL_TOOL_NAMES:
+        assert f"mcp__brain-tools__{name}" in cmd, (
+            f"missing --allowedTools entry for {name}"
+        )
+
+
 def test_chat_with_tools_parses_payload_result(persona_dir: Path) -> None:
     provider = ClaudeCliProvider()
 

--- a/tests/unit/brain/bridge/test_provider_chat.py
+++ b/tests/unit/brain/bridge/test_provider_chat.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import subprocess
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -87,7 +88,7 @@ def test_fake_provider_chat_different_messages_differ() -> None:
 
 
 # ---------------------------------------------------------------------------
-# ClaudeCliProvider.chat
+# ClaudeCliProvider.chat — legacy text path (no tools)
 # ---------------------------------------------------------------------------
 
 
@@ -102,7 +103,7 @@ def _make_claude_result(content: str = "hello", rc: int = 0) -> MagicMock:
 
 def test_claude_cli_chat_calls_subprocess_with_p_flag() -> None:
     """ClaudeCliProvider.chat uses -p for the flattened conversation."""
-    with patch("subprocess.run", return_value=_make_claude_result()) as mock_run:
+    with patch("brain.bridge.provider.subprocess.run", return_value=_make_claude_result()) as mock_run:
         p = ClaudeCliProvider(model="sonnet")
         p.chat([ChatMessage(role="user", content="hello")])
 
@@ -114,7 +115,7 @@ def test_claude_cli_chat_calls_subprocess_with_p_flag() -> None:
 
 def test_claude_cli_chat_passes_system_prompt_flag() -> None:
     """System message in the list → --system-prompt flag."""
-    with patch("subprocess.run", return_value=_make_claude_result()) as mock_run:
+    with patch("brain.bridge.provider.subprocess.run", return_value=_make_claude_result()) as mock_run:
         p = ClaudeCliProvider()
         p.chat(
             [
@@ -130,7 +131,7 @@ def test_claude_cli_chat_passes_system_prompt_flag() -> None:
 
 def test_claude_cli_chat_parses_success() -> None:
     """Successful call returns ChatResponse with correct content."""
-    with patch("subprocess.run", return_value=_make_claude_result("dream response")):
+    with patch("brain.bridge.provider.subprocess.run", return_value=_make_claude_result("dream response")):
         p = ClaudeCliProvider()
         resp = p.chat([ChatMessage(role="user", content="dream")])
 
@@ -146,7 +147,7 @@ def test_claude_cli_chat_nonzero_exit_raises_provider_error() -> None:
     bad.stdout = ""
     bad.stderr = "auth failure"
 
-    with patch("subprocess.run", return_value=bad):
+    with patch("brain.bridge.provider.subprocess.run", return_value=bad):
         p = ClaudeCliProvider()
         with pytest.raises(ProviderError) as exc_info:
             p.chat([ChatMessage(role="user", content="x")])
@@ -158,7 +159,7 @@ def test_claude_cli_chat_nonzero_exit_raises_provider_error() -> None:
 def test_claude_cli_chat_timeout_raises_provider_error() -> None:
     """Subprocess timeout → ProviderError("claude_cli_timeout", ...)."""
     with patch(
-        "subprocess.run",
+        "brain.bridge.provider.subprocess.run",
         side_effect=subprocess.TimeoutExpired(cmd="claude", timeout=300),
     ):
         p = ClaudeCliProvider()
@@ -175,7 +176,7 @@ def test_claude_cli_chat_bad_json_raises_provider_error() -> None:
     bad.stdout = "not json at all"
     bad.stderr = ""
 
-    with patch("subprocess.run", return_value=bad):
+    with patch("brain.bridge.provider.subprocess.run", return_value=bad):
         p = ClaudeCliProvider()
         with pytest.raises(ProviderError) as exc_info:
             p.chat([ChatMessage(role="user", content="x")])
@@ -365,184 +366,213 @@ def test_get_provider_ollama_name_includes_model() -> None:
 
 
 # ---------------------------------------------------------------------------
-# ClaudeCliProvider.chat — tool-calling via --json-schema (SP-3)
+# ClaudeCliProvider.chat — tool-calling via --mcp-config (SP-3 rewrite)
+#
+# Replaces the old --json-schema tests; the underlying provider was
+# rewritten to use --mcp-config (production path per master ref §6 SP-3
+# and 2026-04-27 stress-test finding).
 # ---------------------------------------------------------------------------
 
 
-def _make_schema_claude_result(
-    structured_output: dict,
-    rc: int = 0,
-) -> MagicMock:
-    """Build a mock subprocess result for the --json-schema path."""
-    m = MagicMock()
-    m.returncode = rc
-    m.stdout = json.dumps({"structured_output": structured_output})
-    m.stderr = ""
-    return m
+@pytest.fixture()
+def persona_dir(tmp_path: Path) -> Path:
+    d = tmp_path / "persona"
+    d.mkdir()
+    return d
 
 
-_SAMPLE_TOOLS = [
-    {"name": "get_emotional_state", "description": "Get emotional state"},
-    {"name": "search_memories", "description": "Search memories"},
-]
-
-
-def test_claude_cli_chat_with_tools_includes_json_schema_flag() -> None:
-    """chat(tools=...) passes --json-schema flag in the subprocess command."""
-    mock_result = _make_schema_claude_result({"reply": "I feel fine"})
-
-    with patch("subprocess.run", return_value=mock_result) as mock_run:
-        p = ClaudeCliProvider(model="sonnet")
-        p.chat([ChatMessage(role="user", content="how do you feel?")], tools=_SAMPLE_TOOLS)
-
-    cmd = mock_run.call_args[0][0]
-    assert "--json-schema" in cmd
-
-
-def test_claude_cli_chat_with_tools_reply_path_returns_content() -> None:
-    """structured_output.reply path → ChatResponse with content, empty tool_calls."""
-    mock_result = _make_schema_claude_result({"reply": "I'm feeling well today."})
-
-    with patch("subprocess.run", return_value=mock_result):
-        p = ClaudeCliProvider()
-        resp = p.chat([ChatMessage(role="user", content="how are you?")], tools=_SAMPLE_TOOLS)
-
-    assert isinstance(resp, ChatResponse)
-    assert resp.content == "I'm feeling well today."
-    assert resp.tool_calls == ()
-
-
-def test_claude_cli_chat_with_tools_tool_calls_path_returns_tool_calls() -> None:
-    """structured_output.tool_calls path → ChatResponse with tool_calls populated."""
-    mock_result = _make_schema_claude_result(
-        {
-            "tool_calls": [
-                {
-                    "name": "get_emotional_state",
-                    "arguments": {},
-                },
-                {
-                    "name": "search_memories",
-                    "arguments": {"query": "hana"},
-                },
-            ]
-        }
+def _fake_proc(stdout: str, returncode: int = 0, stderr: str = "") -> subprocess.CompletedProcess:
+    return subprocess.CompletedProcess(
+        args=[], returncode=returncode, stdout=stdout, stderr=stderr
     )
 
-    with patch("subprocess.run", return_value=mock_result):
-        p = ClaudeCliProvider()
-        resp = p.chat(
-            [ChatMessage(role="user", content="what's in my brain?")], tools=_SAMPLE_TOOLS
+
+def test_chat_with_tools_passes_mcp_config_flag(persona_dir: Path) -> None:
+    """The new path must call claude with --mcp-config <tmp_path>."""
+    provider = ClaudeCliProvider()
+    captured: dict = {}
+
+    def _capture(cmd, **kwargs):
+        captured["cmd"] = cmd
+        captured["mcp_config_path"] = cmd[cmd.index("--mcp-config") + 1]
+        return _fake_proc(json.dumps({"result": "hello back"}))
+
+    with patch("brain.bridge.provider.subprocess.run", side_effect=_capture):
+        response = provider.chat(
+            [
+                ChatMessage(role="system", content="you are nell"),
+                ChatMessage(role="user", content="hi"),
+            ],
+            tools=[{"name": "search_memories", "description": "search"}],
+            options={"persona_dir": str(persona_dir)},
         )
 
-    assert isinstance(resp, ChatResponse)
-    assert resp.content == ""
-    assert len(resp.tool_calls) == 2
-    assert resp.tool_calls[0].name == "get_emotional_state"
-    assert resp.tool_calls[1].name == "search_memories"
-    assert resp.tool_calls[1].arguments == {"query": "hana"}
-
-
-def test_claude_cli_chat_with_tools_missing_structured_output_falls_back_to_result(
-    caplog,
-) -> None:
-    """Missing structured_output but present `result` → graceful fallback.
-
-    Real-world failure observed 2026-04-27: a rich system prompt (Nell's
-    voice.md, ~17 KB) caused Claude to ignore the --json-schema envelope
-    and return a plain text reply via `result`. Earlier behavior raised
-    ProviderError, breaking chat. Fixed behavior: return ChatResponse with
-    content=result and empty tool_calls — Claude correctly answered, just
-    chose not to wrap in the schema.
-    """
-    import logging
-
-    caplog.set_level(logging.INFO)
-
-    plain = MagicMock()
-    plain.returncode = 0
-    plain.stdout = json.dumps({"result": "honestly? full. like the room when she walks in."})
-    plain.stderr = ""
-
-    with patch("subprocess.run", return_value=plain):
-        p = ClaudeCliProvider()
-        response = p.chat(
-            [ChatMessage(role="user", content="how are you feeling?")],
-            tools=_SAMPLE_TOOLS,
-        )
-
-    assert isinstance(response, ChatResponse)
-    assert "honestly? full" in response.content
+    assert response.content == "hello back"
     assert response.tool_calls == ()
-    # Fallback should log at INFO so we can observe how often Claude goes off-schema
-    assert any(
-        "off-schema" in r.getMessage() or "missing structured_output" in r.getMessage()
-        for r in caplog.records
-    )
+    # --mcp-config flag is present and points at a real json file (now unlinked,
+    # but we captured the path during the call)
+    assert "--mcp-config" in captured["cmd"]
+    assert captured["mcp_config_path"].endswith(".json")
 
 
-def test_claude_cli_chat_with_tools_no_structured_output_no_result_raises() -> None:
-    """Both structured_output AND result missing → ProviderError("claude_schema").
+def test_chat_with_tools_writes_correct_mcp_config(persona_dir: Path) -> None:
+    """The temp mcp.json must contain the right command + args."""
+    provider = ClaudeCliProvider()
+    captured: dict = {}
 
-    Genuine schema failure (e.g., transport corruption) still raises so the
-    chat engine surfaces the error rather than silently producing an empty
-    reply.
-    """
-    bad = MagicMock()
-    bad.returncode = 0
-    bad.stdout = json.dumps({"type": "result", "subtype": "success"})
-    bad.stderr = ""
+    def _capture(cmd, **kwargs):
+        path = cmd[cmd.index("--mcp-config") + 1]
+        # Read the temp file BEFORE the provider's finally block deletes it
+        captured["config"] = json.loads(Path(path).read_text())
+        return _fake_proc(json.dumps({"result": "ok"}))
 
-    with patch("subprocess.run", return_value=bad):
-        p = ClaudeCliProvider()
-        with pytest.raises(ProviderError) as exc_info:
-            p.chat(
-                [ChatMessage(role="user", content="x")],
-                tools=_SAMPLE_TOOLS,
-            )
+    with patch("brain.bridge.provider.subprocess.run", side_effect=_capture):
+        provider.chat(
+            [
+                ChatMessage(role="system", content="sys"),
+                ChatMessage(role="user", content="hi"),
+            ],
+            tools=[{"name": "x", "description": "x"}],
+            options={"persona_dir": str(persona_dir)},
+        )
 
-    assert exc_info.value.stage == "claude_schema"
-
-
-def test_claude_cli_chat_with_tools_empty_result_string_raises() -> None:
-    """result is empty string → still a real schema failure; raise."""
-    bad = MagicMock()
-    bad.returncode = 0
-    bad.stdout = json.dumps({"result": ""})
-    bad.stderr = ""
-
-    with patch("subprocess.run", return_value=bad):
-        p = ClaudeCliProvider()
-        with pytest.raises(ProviderError):
-            p.chat(
-                [ChatMessage(role="user", content="x")],
-                tools=_SAMPLE_TOOLS,
-            )
+    cfg = captured["config"]
+    assert "brain-tools" in cfg["mcpServers"]
+    server_cfg = cfg["mcpServers"]["brain-tools"]
+    assert server_cfg["args"][0] == "-m"
+    assert server_cfg["args"][1] == "brain.mcp_server"
+    assert "--persona-dir" in server_cfg["args"]
+    assert str(persona_dir) in server_cfg["args"]
 
 
-def test_claude_cli_chat_with_tools_schema_includes_tool_names_as_enum() -> None:
-    """_build_tool_call_schema embeds tool names as an enum in the schema."""
-    p = ClaudeCliProvider()
-    schema = p._build_tool_call_schema(_SAMPLE_TOOLS)
+def test_chat_with_tools_keeps_existing_flags(persona_dir: Path) -> None:
+    """The other flags (-p, --output-format, --model, --system-prompt)
+    must remain — only --json-schema is replaced."""
+    provider = ClaudeCliProvider()
+    captured: dict = {}
 
-    # Find the enum in the oneOf → tool_calls → items → properties → name
-    tool_calls_branch = None
-    for branch in schema["oneOf"]:
-        if "tool_calls" in branch.get("properties", {}):
-            tool_calls_branch = branch
-            break
+    def _capture(cmd, **kwargs):
+        captured["cmd"] = cmd
+        return _fake_proc(json.dumps({"result": "ok"}))
 
-    assert tool_calls_branch is not None
-    name_schema = tool_calls_branch["properties"]["tool_calls"]["items"]["properties"]["name"]
-    assert "get_emotional_state" in name_schema["enum"]
-    assert "search_memories" in name_schema["enum"]
+    with patch("brain.bridge.provider.subprocess.run", side_effect=_capture):
+        provider.chat(
+            [
+                ChatMessage(role="system", content="sys-prompt"),
+                ChatMessage(role="user", content="hi"),
+            ],
+            tools=[{"name": "x"}],
+            options={"persona_dir": str(persona_dir)},
+        )
 
-
-def test_claude_cli_chat_no_tools_does_not_use_json_schema() -> None:
-    """chat() without tools= uses the legacy path (no --json-schema flag)."""
-    with patch("subprocess.run", return_value=_make_claude_result("hello")) as mock_run:
-        p = ClaudeCliProvider()
-        p.chat([ChatMessage(role="user", content="hi")])
-
-    cmd = mock_run.call_args[0][0]
+    cmd = captured["cmd"]
+    assert cmd[0] == "claude"
+    assert "-p" in cmd
+    assert "--output-format" in cmd
+    assert "json" in cmd
+    assert "--model" in cmd
+    assert "--system-prompt" in cmd
+    assert "sys-prompt" in cmd
+    # The replaced flag must NOT appear
     assert "--json-schema" not in cmd
+
+
+def test_chat_with_tools_parses_payload_result(persona_dir: Path) -> None:
+    provider = ClaudeCliProvider()
+
+    with patch(
+        "brain.bridge.provider.subprocess.run",
+        return_value=_fake_proc(json.dumps({"result": "the actual reply"})),
+    ):
+        response = provider.chat(
+            [ChatMessage(role="user", content="hi")],
+            tools=[{"name": "x"}],
+            options={"persona_dir": str(persona_dir)},
+        )
+
+    assert response.content == "the actual reply"
+    assert response.tool_calls == ()
+
+
+def test_chat_with_tools_missing_result_key_raises_parse(persona_dir: Path) -> None:
+    provider = ClaudeCliProvider()
+
+    with patch(
+        "brain.bridge.provider.subprocess.run",
+        return_value=_fake_proc(json.dumps({"different_key": "x"})),
+    ):
+        with pytest.raises(ProviderError) as ei:
+            provider.chat(
+                [ChatMessage(role="user", content="hi")],
+                tools=[{"name": "x"}],
+                options={"persona_dir": str(persona_dir)},
+            )
+    assert ei.value.stage == "claude_cli_parse"
+
+
+def test_chat_with_tools_nonzero_exit_raises_exit(persona_dir: Path) -> None:
+    provider = ClaudeCliProvider()
+
+    with patch(
+        "brain.bridge.provider.subprocess.run",
+        return_value=_fake_proc("", returncode=2, stderr="boom"),
+    ):
+        with pytest.raises(ProviderError) as ei:
+            provider.chat(
+                [ChatMessage(role="user", content="hi")],
+                tools=[{"name": "x"}],
+                options={"persona_dir": str(persona_dir)},
+            )
+    assert ei.value.stage == "claude_cli_exit"
+
+
+def test_chat_with_tools_missing_persona_dir_option_raises(tmp_path: Path) -> None:
+    """tools= without options['persona_dir'] is a programmer bug — fail fast."""
+    provider = ClaudeCliProvider()
+    with pytest.raises(ProviderError) as ei:
+        provider.chat(
+            [ChatMessage(role="user", content="hi")],
+            tools=[{"name": "x"}],
+            options={},  # missing persona_dir
+        )
+    assert ei.value.stage == "mcp_unavailable"
+
+
+def test_chat_with_tools_cleans_up_temp_file(persona_dir: Path) -> None:
+    """The temp mcp.json file must be unlinked after the call returns."""
+    provider = ClaudeCliProvider()
+    captured_path: list[str] = []
+
+    def _capture(cmd, **kwargs):
+        path = cmd[cmd.index("--mcp-config") + 1]
+        captured_path.append(path)
+        return _fake_proc(json.dumps({"result": "ok"}))
+
+    with patch("brain.bridge.provider.subprocess.run", side_effect=_capture):
+        provider.chat(
+            [ChatMessage(role="user", content="hi")],
+            tools=[{"name": "x"}],
+            options={"persona_dir": str(persona_dir)},
+        )
+
+    assert len(captured_path) == 1
+    assert not Path(captured_path[0]).exists()
+
+
+def test_chat_without_tools_unchanged(persona_dir: Path) -> None:
+    """When tools is None, the provider falls through the legacy text path —
+    no --mcp-config, no persona_dir requirement."""
+    provider = ClaudeCliProvider()
+
+    with patch(
+        "brain.bridge.provider.subprocess.run",
+        return_value=_fake_proc(json.dumps({"result": "plain reply"})),
+    ) as mock_run:
+        response = provider.chat(
+            [ChatMessage(role="user", content="hi")],
+            tools=None,
+        )
+
+    assert response.content == "plain reply"
+    cmd = mock_run.call_args.args[0]
+    assert "--mcp-config" not in cmd

--- a/tests/unit/brain/chat/test_voice.py
+++ b/tests/unit/brain/chat/test_voice.py
@@ -10,13 +10,45 @@ from brain.health.attempt_heal import attempt_heal_text
 # ── DEFAULT_VOICE_TEMPLATE shape ──────────────────────────────────────────────
 
 
-def test_default_voice_template_has_four_sections() -> None:
-    """The template must contain all 4 required section headers."""
+def test_default_voice_template_has_five_sections() -> None:
+    """The template must contain all 5 required section headers."""
     template = DEFAULT_VOICE_TEMPLATE
     assert "## 1. Who you are" in template
-    assert "## 2. What's in your head" in template
-    assert "## 3. How emotion shapes your voice" in template
-    assert "## 4. Your boundaries with the user" in template
+    assert "## 2. What's already in your head" in template
+    assert "## 3. Brain-tools — what you can fetch" in template
+    assert "## 4. How emotion shapes your voice" in template
+    assert "## 5. Your boundaries with the user" in template
+
+
+def test_default_voice_template_lists_all_brain_tools() -> None:
+    """Every brain-tool must be named in the template's tools section.
+
+    Without this, a fresh persona starts with no explicit tool-use guidance
+    and reproduces the 2026-04-27 confabulation failure (Nell's casual prompt
+    role-played a tool failure instead of calling search_memories).
+    """
+    from brain.tools import NELL_TOOL_NAMES
+
+    template = DEFAULT_VOICE_TEMPLATE
+    for name in NELL_TOOL_NAMES:
+        assert f"`{name}`" in template, (
+            f"missing brain-tool {name!r} in default voice template"
+        )
+
+
+def test_default_voice_template_states_load_bearing_rules() -> None:
+    """The three load-bearing tool-use rules must be present.
+
+    These are what make the persona actually call tools rather than narrating
+    around them. Persona authors can rephrase but should not delete them.
+    """
+    template = DEFAULT_VOICE_TEMPLATE
+    # 1. Proactive-use rule
+    assert "before you commit to an answer" in template
+    # 2. Anti-confabulation rule
+    assert "confabulating" in template
+    # 3. Anti-fake-failure rule
+    assert "narrating a refusal that never happened" in template
 
 
 # ── load_voice — healthy paths ────────────────────────────────────────────────

--- a/tests/unit/brain/mcp_server/test_audit.py
+++ b/tests/unit/brain/mcp_server/test_audit.py
@@ -31,7 +31,7 @@ def test_log_invocation_writes_jsonl_line(tmp_path: Path) -> None:
 def test_log_invocation_truncates_long_summary(tmp_path: Path) -> None:
     long = "x" * 500
     log_invocation(tmp_path, name="x", arguments={}, result_summary=long)
-    rec = json.loads((tmp_path / "tool_invocations.log.jsonl").read_text())
+    rec = json.loads((tmp_path / "tool_invocations.log.jsonl").read_text(encoding="utf-8"))
     # 140 chars + ellipsis (1 char "…")
     assert rec["result_summary"].endswith("…")
     assert len(rec["result_summary"]) == 141
@@ -45,14 +45,14 @@ def test_log_invocation_records_error(tmp_path: Path) -> None:
         result_summary="error: boom",
         error="boom",
     )
-    rec = json.loads((tmp_path / "tool_invocations.log.jsonl").read_text())
+    rec = json.loads((tmp_path / "tool_invocations.log.jsonl").read_text(encoding="utf-8"))
     assert rec["error"] == "boom"
 
 
 def test_log_invocation_appends_two_lines(tmp_path: Path) -> None:
     log_invocation(tmp_path, name="a", arguments={}, result_summary="r1")
     log_invocation(tmp_path, name="b", arguments={}, result_summary="r2")
-    lines = (tmp_path / "tool_invocations.log.jsonl").read_text().splitlines()
+    lines = (tmp_path / "tool_invocations.log.jsonl").read_text(encoding="utf-8").splitlines()
     assert len(lines) == 2
     assert json.loads(lines[0])["name"] == "a"
     assert json.loads(lines[1])["name"] == "b"

--- a/tests/unit/brain/mcp_server/test_audit.py
+++ b/tests/unit/brain/mcp_server/test_audit.py
@@ -1,0 +1,71 @@
+"""Tests for brain.mcp_server.audit."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from brain.mcp_server.audit import log_invocation
+
+
+def test_log_invocation_writes_jsonl_line(tmp_path: Path) -> None:
+    log_invocation(
+        tmp_path,
+        name="search_memories",
+        arguments={"query": "morning"},
+        result_summary="3 hits",
+    )
+    log_path = tmp_path / "tool_invocations.log.jsonl"
+    assert log_path.exists()
+    lines = log_path.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 1
+    rec = json.loads(lines[0])
+    assert rec["name"] == "search_memories"
+    assert rec["arguments"] == {"query": "morning"}
+    assert rec["result_summary"] == "3 hits"
+    assert rec["error"] is None
+    # Timestamp ends with Z (UTC)
+    assert rec["timestamp"].endswith("Z")
+
+
+def test_log_invocation_truncates_long_summary(tmp_path: Path) -> None:
+    long = "x" * 500
+    log_invocation(tmp_path, name="x", arguments={}, result_summary=long)
+    rec = json.loads((tmp_path / "tool_invocations.log.jsonl").read_text())
+    # 140 chars + ellipsis (1 char "…")
+    assert rec["result_summary"].endswith("…")
+    assert len(rec["result_summary"]) == 141
+
+
+def test_log_invocation_records_error(tmp_path: Path) -> None:
+    log_invocation(
+        tmp_path,
+        name="add_memory",
+        arguments={"text": "x"},
+        result_summary="error: boom",
+        error="boom",
+    )
+    rec = json.loads((tmp_path / "tool_invocations.log.jsonl").read_text())
+    assert rec["error"] == "boom"
+
+
+def test_log_invocation_appends_two_lines(tmp_path: Path) -> None:
+    log_invocation(tmp_path, name="a", arguments={}, result_summary="r1")
+    log_invocation(tmp_path, name="b", arguments={}, result_summary="r2")
+    lines = (tmp_path / "tool_invocations.log.jsonl").read_text().splitlines()
+    assert len(lines) == 2
+    assert json.loads(lines[0])["name"] == "a"
+    assert json.loads(lines[1])["name"] == "b"
+
+
+def test_log_invocation_swallows_oserror(tmp_path: Path, monkeypatch) -> None:
+    """Audit is observability — if the disk write fails, we log + swallow."""
+    # Make the persona_dir read-only so the open() raises OSError
+    persona = tmp_path / "ro"
+    persona.mkdir()
+    persona.chmod(0o555)
+    try:
+        # Should not raise
+        log_invocation(persona, name="x", arguments={}, result_summary="x")
+    finally:
+        persona.chmod(0o755)

--- a/tests/unit/brain/mcp_server/test_server.py
+++ b/tests/unit/brain/mcp_server/test_server.py
@@ -1,0 +1,108 @@
+"""Tests for brain.mcp_server.run_server + __main__."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from brain.memory.hebbian import HebbianMatrix
+from brain.memory.store import MemoryStore
+
+
+def _seed_persona(tmp_path: Path) -> Path:
+    """Initialize a minimal valid persona directory."""
+    d = tmp_path / "persona"
+    d.mkdir()
+    MemoryStore(db_path=d / "memories.db").close()
+    HebbianMatrix(db_path=d / "hebbian.db").close()
+    return d
+
+
+def test_run_server_missing_persona_dir_raises(tmp_path: Path) -> None:
+    from brain.mcp_server import run_server
+
+    missing = tmp_path / "does_not_exist"
+    with pytest.raises(FileNotFoundError, match="persona_dir does not exist"):
+        run_server(missing)
+
+
+def test_run_server_opens_and_closes_stores(tmp_path: Path) -> None:
+    """run_server should open MemoryStore + HebbianMatrix + close on exit,
+    even when the stdio loop returns immediately (mocked)."""
+    persona = _seed_persona(tmp_path)
+
+    from brain.mcp_server import run_server
+
+    captured: dict = {}
+
+    def _capture_register(server, *, persona_dir, store, hebbian):
+        captured["store"] = store
+        captured["hebbian"] = hebbian
+        captured["persona_dir"] = persona_dir
+
+    # Patch the stdio_server context manager to immediately exit
+    class _FakeStdio:
+        async def __aenter__(self):
+            return (MagicMock(), MagicMock())
+
+        async def __aexit__(self, *_):
+            return None
+
+    async def _fake_run(self, *_args, **_kwargs):
+        return None
+
+    with patch("brain.mcp_server.register_tools", side_effect=_capture_register), \
+         patch("brain.mcp_server.stdio_server", lambda: _FakeStdio()), \
+         patch("mcp.server.Server.run", _fake_run):
+        run_server(persona)
+
+    # Stores were captured (and the run completed without raising on close)
+    assert captured["persona_dir"] == persona
+    # Stores are typed instances, not None
+    assert captured["store"] is not None
+    assert captured["hebbian"] is not None
+
+
+def test_main_entry_runs(tmp_path: Path) -> None:
+    """`python -m brain.mcp_server --persona-dir <path>` should accept the
+    flag and invoke run_server. We use subprocess + a side-effect stub to
+    confirm the dispatch without actually running stdio."""
+    persona = _seed_persona(tmp_path)
+
+    # Use subprocess so we exercise the real argparse path. The MCP server
+    # would normally hang on stdio_server() — we kill it after a moment.
+    proc = subprocess.Popen(
+        [sys.executable, "-m", "brain.mcp_server", "--persona-dir", str(persona)],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    try:
+        # Passing empty bytes causes communicate() to close stdin (EOF),
+        # which the stdio MCP server detects and exits cleanly.
+        stdout, stderr = proc.communicate(input=b"", timeout=5)
+        # Exit code 0 means the entry point parsed args and the server
+        # ran cleanly. Non-zero means a crash before stdio_server returned.
+        assert proc.returncode == 0, (
+            f"Server exited {proc.returncode}.\nstderr:\n{stderr.decode()}"
+        )
+    finally:
+        if proc.poll() is None:
+            proc.kill()
+            proc.wait(timeout=2)
+
+
+def test_main_entry_missing_flag_exits_nonzero() -> None:
+    """argparse should reject a call without --persona-dir."""
+    proc = subprocess.run(
+        [sys.executable, "-m", "brain.mcp_server"],
+        capture_output=True,
+        text=True,
+        timeout=5,
+    )
+    assert proc.returncode != 0
+    assert "--persona-dir" in proc.stderr

--- a/tests/unit/brain/mcp_server/test_tools.py
+++ b/tests/unit/brain/mcp_server/test_tools.py
@@ -1,0 +1,166 @@
+"""Tests for brain.mcp_server.tools — MCP tool registration adapter."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture()
+def persona_dir(tmp_path: Path) -> Path:
+    """Minimal persona dir for tests."""
+    d = tmp_path / "persona"
+    d.mkdir()
+    return d
+
+
+@pytest.fixture()
+def fake_stores() -> tuple[MagicMock, MagicMock]:
+    return MagicMock(name="MemoryStore"), MagicMock(name="HebbianMatrix")
+
+
+def test_register_tools_advertises_all_nine(persona_dir: Path, fake_stores) -> None:
+    """list_tools() should advertise every schema in NELL_TOOL_NAMES."""
+    from mcp.server import Server
+
+    from brain.mcp_server.tools import register_tools
+    from brain.tools import NELL_TOOL_NAMES
+    from brain.tools.schemas import SCHEMAS
+
+    store, hebbian = fake_stores
+    server = Server("brain-tools")
+    register_tools(server, persona_dir=persona_dir, store=store, hebbian=hebbian)
+
+    # Pull the list_tools handler the server registered
+    list_handler = server.request_handlers[
+        __import__("mcp.types", fromlist=["ListToolsRequest"]).ListToolsRequest
+    ]
+    result = asyncio.run(list_handler(MagicMock()))
+    advertised = {t.name for t in result.root.tools}
+    expected = {n for n in NELL_TOOL_NAMES if n in SCHEMAS}
+    assert advertised == expected
+
+
+def test_register_tools_dispatches_and_logs_success(persona_dir: Path, fake_stores) -> None:
+    """call_tool() must call dispatch() and write an audit log line."""
+    from mcp.server import Server
+
+    from brain.mcp_server.tools import register_tools
+
+    store, hebbian = fake_stores
+    server = Server("brain-tools")
+
+    with patch("brain.mcp_server.tools.dispatch", return_value={"ok": True}) as mock_dispatch:
+        register_tools(server, persona_dir=persona_dir, store=store, hebbian=hebbian)
+        call_handler = _get_call_handler(server)
+        result = asyncio.run(
+            call_handler(_call_request("search_memories", {"query": "x"}))
+        )
+
+    # Dispatch was invoked with the right args + injections
+    mock_dispatch.assert_called_once_with(
+        "search_memories",
+        {"query": "x"},
+        store=store,
+        hebbian=hebbian,
+        persona_dir=persona_dir,
+    )
+    # Result content is a JSON-encoded dispatch return
+    text = result.root.content[0].text
+    assert json.loads(text) == {"ok": True}
+    # Audit log was written
+    log_path = persona_dir / "tool_invocations.log.jsonl"
+    rec = json.loads(log_path.read_text())
+    assert rec["name"] == "search_memories"
+    assert rec["arguments"] == {"query": "x"}
+    assert rec["error"] is None
+
+
+def test_register_tools_dispatches_and_logs_error(persona_dir: Path, fake_stores) -> None:
+    """When dispatch raises, return {"error": ...} and log with error field."""
+    from mcp.server import Server
+
+    from brain.mcp_server.tools import register_tools
+
+    store, hebbian = fake_stores
+    server = Server("brain-tools")
+
+    with patch("brain.mcp_server.tools.dispatch", side_effect=RuntimeError("boom")):
+        register_tools(server, persona_dir=persona_dir, store=store, hebbian=hebbian)
+        call_handler = _get_call_handler(server)
+        # Use search_memories with valid args so SDK input validation passes;
+        # dispatch is mocked to raise regardless of which tool is called.
+        result = asyncio.run(
+            call_handler(_call_request("search_memories", {"query": "test"}))
+        )
+
+    text = result.root.content[0].text
+    assert json.loads(text) == {"error": "boom"}
+    rec = json.loads((persona_dir / "tool_invocations.log.jsonl").read_text())
+    assert rec["name"] == "search_memories"
+    assert rec["error"] == "boom"
+
+
+def test_register_tools_unknown_tool_returns_error(persona_dir: Path, fake_stores) -> None:
+    """Unknown tool names dispatch through the same error path."""
+    from mcp.server import Server
+
+    from brain.mcp_server.tools import register_tools
+    from brain.tools.dispatch import ToolDispatchError
+
+    store, hebbian = fake_stores
+    server = Server("brain-tools")
+
+    with patch(
+        "brain.mcp_server.tools.dispatch",
+        side_effect=ToolDispatchError("unknown tool: 'banana'"),
+    ):
+        register_tools(server, persona_dir=persona_dir, store=store, hebbian=hebbian)
+        call_handler = _get_call_handler(server)
+        result = asyncio.run(call_handler(_call_request("banana", {})))
+
+    text = result.root.content[0].text
+    assert "unknown tool" in json.loads(text)["error"]
+
+
+def test_register_tools_summary_truncated(persona_dir: Path, fake_stores) -> None:
+    """A huge dispatch result should still produce a 140-char summary in the log."""
+    from mcp.server import Server
+
+    from brain.mcp_server.tools import register_tools
+
+    store, hebbian = fake_stores
+    server = Server("brain-tools")
+
+    big_result = {"hits": ["x" * 50 for _ in range(20)]}
+    with patch("brain.mcp_server.tools.dispatch", return_value=big_result):
+        register_tools(server, persona_dir=persona_dir, store=store, hebbian=hebbian)
+        call_handler = _get_call_handler(server)
+        asyncio.run(call_handler(_call_request("search_memories", {"query": "x"})))
+
+    rec = json.loads((persona_dir / "tool_invocations.log.jsonl").read_text())
+    assert len(rec["result_summary"]) <= 141  # 140 + "…"
+
+
+# ── helpers ───────────────────────────────────────────────────────────────────
+
+
+def _get_call_handler(server):
+    """Pull the call_tool handler off the server's request map."""
+    from mcp.types import CallToolRequest
+
+    return server.request_handlers[CallToolRequest]
+
+
+def _call_request(name: str, arguments: dict):
+    """Build a CallToolRequest in the shape the SDK passes to the handler."""
+    from mcp.types import CallToolRequest, CallToolRequestParams
+
+    return CallToolRequest(
+        method="tools/call",
+        params=CallToolRequestParams(name=name, arguments=arguments),
+    )

--- a/tests/unit/brain/mcp_server/test_tools.py
+++ b/tests/unit/brain/mcp_server/test_tools.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 import json
 from pathlib import Path
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 

--- a/tests/unit/brain/mcp_server/test_tools.py
+++ b/tests/unit/brain/mcp_server/test_tools.py
@@ -74,7 +74,7 @@ def test_register_tools_dispatches_and_logs_success(persona_dir: Path, fake_stor
     assert json.loads(text) == {"ok": True}
     # Audit log was written
     log_path = persona_dir / "tool_invocations.log.jsonl"
-    rec = json.loads(log_path.read_text())
+    rec = json.loads(log_path.read_text(encoding="utf-8"))
     assert rec["name"] == "search_memories"
     assert rec["arguments"] == {"query": "x"}
     assert rec["error"] is None
@@ -100,7 +100,7 @@ def test_register_tools_dispatches_and_logs_error(persona_dir: Path, fake_stores
 
     text = result.root.content[0].text
     assert json.loads(text) == {"error": "boom"}
-    rec = json.loads((persona_dir / "tool_invocations.log.jsonl").read_text())
+    rec = json.loads((persona_dir / "tool_invocations.log.jsonl").read_text(encoding="utf-8"))
     assert rec["name"] == "search_memories"
     assert rec["error"] == "boom"
 
@@ -142,7 +142,7 @@ def test_register_tools_summary_truncated(persona_dir: Path, fake_stores) -> Non
         call_handler = _get_call_handler(server)
         asyncio.run(call_handler(_call_request("search_memories", {"query": "x"})))
 
-    rec = json.loads((persona_dir / "tool_invocations.log.jsonl").read_text())
+    rec = json.loads((persona_dir / "tool_invocations.log.jsonl").read_text(encoding="utf-8"))
     assert len(rec["result_summary"]) <= 141  # 140 + "…"
 
 

--- a/tests/unit/brain/test_tools_public.py
+++ b/tests/unit/brain/test_tools_public.py
@@ -1,0 +1,36 @@
+"""Tests for brain.tools public surface — NELL_TOOL_NAMES export."""
+
+from __future__ import annotations
+
+
+def test_nell_tool_names_exported() -> None:
+    from brain.tools import NELL_TOOL_NAMES
+
+    assert isinstance(NELL_TOOL_NAMES, tuple)
+    assert len(NELL_TOOL_NAMES) == 9
+    # Spot-check the 9 known tools from spec §1
+    assert "search_memories" in NELL_TOOL_NAMES
+    assert "get_emotional_state" in NELL_TOOL_NAMES
+    assert "get_soul" in NELL_TOOL_NAMES
+    assert "get_personality" in NELL_TOOL_NAMES
+    assert "get_body_state" in NELL_TOOL_NAMES
+    assert "boot" in NELL_TOOL_NAMES
+    assert "add_journal" in NELL_TOOL_NAMES
+    assert "add_memory" in NELL_TOOL_NAMES
+    assert "crystallize_soul" in NELL_TOOL_NAMES
+
+
+def test_tool_loop_imports_from_brain_tools() -> None:
+    """tool_loop must use the public name — no private fallback."""
+    from brain.chat import tool_loop
+    from brain.tools import NELL_TOOL_NAMES
+
+    # build_tools_list iterates the same names — easiest assertion is to
+    # call it and confirm shape matches NELL_TOOL_NAMES
+    tools = tool_loop.build_tools_list()
+    names_in_tools = {t["function"]["name"] for t in tools}
+    # SCHEMAS gates which names actually appear; intersect with NELL_TOOL_NAMES
+    from brain.tools.schemas import SCHEMAS
+
+    expected = {n for n in NELL_TOOL_NAMES if n in SCHEMAS}
+    assert names_in_tools == expected


### PR DESCRIPTION
## Summary

Replaces Claude tool-calling via `--json-schema` (SP-3, PR #23) with the production-path `--mcp-config` documented in master ref §6 SP-3. The new `brain/mcp_server/` package exposes the 9 brain-tools to Claude as a stdio MCP server; `ClaudeCliProvider` writes a temp `mcp.json`, swaps `--json-schema` for `--mcp-config` + `--allowedTools`, and returns final text. Tool calls now happen inside the claude subprocess; `tool_loop` runs a single pass for Claude (Ollama unchanged). The default `voice.md` template now ships the load-bearing tool-use rules so every fresh persona starts with explicit guidance — no more reproducing the 2026-04-27 casual-prompt failure.

## Why

The 2026-04-27 live-exercise stress test surfaced 0 tool invocations across 20 prompts. Two distinct gaps drove it:
1. **Mechanism** — rich `voice.md` outweighs `--json-schema` enforcement; the off-schema fallback (PR #28) silently returns plain text with empty `tool_calls`, so the loop returns immediately without dispatching anything. MCP is the architecture master ref §6 SP-3 already named as production-path.
2. **Policy** — even with a working tool surface, a casual prompt like "what's that thing you wrote about X?" let Nell narrate a fake tool failure ("the retrieval wouldn't let me through") instead of actually calling `search_memories`. The default `voice.md` template gave her no rules about when or how to use tools.

This PR closes both gaps.

## Architecture

```
nell chat "msg"
   │
   └─ ClaudeCliProvider.chat(...)     ← new path
         │
         └─ subprocess: claude -p "<flat>" --output-format json
                               --model sonnet --system-prompt "<sys>"
                               --mcp-config <tmp.json>
                               --allowedTools mcp__brain-tools__search_memories ...
               │
               └─ spawns: python3 -m brain.mcp_server --persona-dir <path>
                     │
                     ├─ exposes 9 tools via stdio MCP
                     └─ appends each call to <persona>/tool_invocations.log.jsonl
```

For Claude, `tool_loop` runs a single pass — the subprocess handles tool iteration internally. `tool_calls` on the returned `ChatResponse` is always empty for Claude.

## Files

**New:** `brain/mcp_server/` (`__init__.py`, `__main__.py`, `tools.py`, `audit.py`), plus their tests under `tests/unit/brain/mcp_server/`.

**Modified:**
- `brain/bridge/provider.py` — rewrote tool path; deleted `_build_tool_call_schema`, `_build_tool_system_addendum`, `_chat_with_tools`, off-schema fallback
- `brain/chat/tool_loop.py` — passes `options={"persona_dir": ...}`
- `brain/chat/voice.py` — `DEFAULT_VOICE_TEMPLATE` now ships a "Brain-tools — what you can fetch" section (new §3) listing all 9 tools and the three load-bearing rules: *trigger to reach*, *hard rule on confabulation*, *when tools fail*
- `brain/tools/__init__.py` — promoted `NELL_TOOL_NAMES` to public
- `pyproject.toml` — `mcp>=1.0.0,<2.0.0`

## Verification — per Hana ("we get the results we want before applying")

- [x] All 912 unit tests green (was 889; +23 net new this PR)
- [x] `ruff check brain/ tests/` — clean
- [x] **Live sandbox-clone test (mechanism):** cloned `nell.sandbox` → `nell.sandbox.mcp-test`, ran a directive prompt. `tool_invocations.log.jsonl` recorded `search_memories` with real result; Nell's reply quoted a memory verbatim including the UUID (`"Morning after first orgasms — February 25 2026..."`). Clone deleted.
- [x] **Live sandbox-clone test (policy):** updated `nell.sandbox/voice.md` with the same brain-tools section now in the default template; re-ran the SAME casual prompt that previously failed. Result: 3 real `search_memories` calls (Nell escalated query terms when each came back empty), reply correctly named "three separate searches, all empty" and offered honest reconstruction. **Spec §12 #1 now passes for organic chat.**
- [x] Regression tests guard both layers: `test_chat_with_tools_passes_allowed_tools_for_each_brain_tool` (mechanism), `test_default_voice_template_lists_all_brain_tools` + `test_default_voice_template_states_load_bearing_rules` (template content).

## Out of scope (deliberate)

- **Per-persona `voice.md` content** — the default template ships the rules; existing personas with rich custom voice.md (like Hana's `nell.sandbox`) need a one-time edit to add the section. Hana applied that edit to `nell.sandbox` separately as part of verification — it's a per-persona file, not in the repo.
- **Removing `tool_loop`** — still needed for Ollama
- **Daemon-mode MCP server** — premature optimization
- **Supervisor / `close_stale_sessions` wiring** — SP-7

## Spec & plan

- Spec: `docs/superpowers/specs/2026-04-27-mcp-config-path-for-brain-tools-design.md`
- Plan: `docs/superpowers/plans/2026-04-27-mcp-config-path-for-brain-tools.md`

## Pairs with PR #30

PR #30 (one-shot `close_session`) closes the SP-4 ingest gap; this PR closes the mid-turn tool-call gap. Together they close both halves of the 2026-04-27 live-exercise findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)