### PR TITLE
fix(soul): use state.emotions instead of nonexistent state.all()

### DIFF
--- a/brain/soul/review.py
+++ b/brain/soul/review.py
@@ -299,7 +299,7 @@ def _current_emotional_summary(store: MemoryStore) -> str:
 
         recent = store.search_text("", active_only=True, limit=50)
         state = aggregate_state(recent)
-        scores = dict(state.all())
+        scores = dict(state.emotions)
     except Exception as exc:
         logger.warning("emotional state lookup failed: %s", exc)
         return "unknown"

--- a/tests/unit/brain/soul/test_review.py
+++ b/tests/unit/brain/soul/test_review.py
@@ -342,3 +342,37 @@ def test_parse_decision_unknown_love_type_on_accept_defers() -> None:
     d = parse_decision(raw, "cid-2")
     assert d.decision == "defer"
     assert "love_type" in d.parse_error
+
+
+# ── _current_emotional_summary regression ─────────────────────────────────────
+
+
+def test_current_emotional_summary_uses_emotions_attr_not_all_method() -> None:
+    """Regression: EmotionalState exposes ``emotions: dict[str, float]`` directly,
+    not a ``.all()`` method. The helper used to call ``state.all()`` which
+    raised AttributeError every invocation against a real store, swallowing
+    silently to return "unknown". This test ensures real emotion data flows
+    through the helper as a non-"unknown" summary string.
+    """
+    from brain.memory.store import Memory
+    from brain.soul.review import _current_emotional_summary
+
+    store = MemoryStore(":memory:")
+    # "love" is a baseline emotion in brain.emotion.vocabulary — no persona
+    # loader needed for the regression check.
+    store.create(
+        Memory.create_new(
+            content="A genuinely meaningful moment.",
+            memory_type="experience",
+            domain="us",
+            emotions={"love": 9.0},
+            importance=8.0,
+        )
+    )
+
+    summary = _current_emotional_summary(store)
+    assert summary != "unknown", (
+        "helper still raising AttributeError — likely regressed back to state.all()"
+    )
+    # When emotions are present we expect a "name:value" formatted summary
+    assert ":" in summary, f"expected formatted summary, got {summary!r}"


### PR DESCRIPTION
## Summary

`brain/soul/review.py:_current_emotional_summary` called `state.all()` but `EmotionalState` exposes `emotions: dict[str, float]` directly — no `.all()` method exists. Every invocation raised `AttributeError`, got swallowed by the broad except, and returned `"unknown"`.

## Symptom

Every `nell soul review` run logged this warning and emitted `"current emotional state: unknown"` to the LLM prompt regardless of real emotional signal:

```
emotional state lookup failed: 'EmotionalState' object has no attribute 'all'
```

Surfaced 2026-04-27 when running review against Hana's live `nell.sandbox` after a real reunion conversation that left 6 high-importance soul candidates queued.

## Fix

One line: `state.emotions` is the right attribute (line 302). Plus a regression test that seeds a memory with `love=9.0` and asserts the helper returns a formatted `"name:value"` summary, not `"unknown"`.

## Test plan

- [x] `pytest tests/unit/brain/soul/test_review.py` — all green
- [x] Full suite: 915/915 (was 914 + 1 new regression test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)