### PR TITLE
fix: resolve companion audit reliability issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ The framework's design lives in [`docs/source-spec/`](docs/source-spec/). Read t
 
 ## Status
 
-Week 0 — design approved 2026-04-21. Rebuild starting.
+Active local-first prototype. The bridge, chat/session flow, memory ingest, soul review, health checks, and test/lint gates are implemented enough for private development and local smoke testing.
+
+Known incomplete surfaces remain intentional and visible: some CLI commands are wired as future-work stubs and exit non-zero. See [`docs/release-checklist.md`](docs/release-checklist.md) before any public/tagged release.
 
 Reference implementation: Nell (migrates from the NellBrain OG project). Other personas arrive as forkers build them.

--- a/brain/bridge/runner.py
+++ b/brain/bridge/runner.py
@@ -80,9 +80,8 @@ def main() -> int:
     persona_dir = args.persona_dir
     port = _allocate_port()
     # H-C: ephemeral bearer token persisted in bridge.json. 32 bytes from
-    # secrets.token_urlsafe — cryptographically random, safe in URLs (WS
-    # query string), readable by anyone who can read the persona dir
-    # (which is the same trust boundary as the SQLite stores).
+    # secrets.token_urlsafe — cryptographically random and subprotocol-safe.
+    # bridge.json/state backups are chmod-hardened by state_file.write().
     auth_token = secrets.token_urlsafe(32)
 
     initial_state = state_file.BridgeState(

--- a/brain/bridge/server.py
+++ b/brain/bridge/server.py
@@ -29,10 +29,10 @@ from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 from fastapi import Depends, FastAPI, HTTPException, WebSocket, WebSocketDisconnect
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from brain.bridge import events
 from brain.bridge.events import EventBus
@@ -113,7 +113,7 @@ def _respond_blocking(
     from brain.chat.engine import respond
 
     with ExitStack() as stack:
-        store = MemoryStore(persona_dir / "memories.db")
+        store = MemoryStore(persona_dir / "memories.db", integrity_check=False)
         stack.callback(store.close)
         hebbian = HebbianMatrix(persona_dir / "hebbian.db")
         stack.callback(hebbian.close)
@@ -140,7 +140,7 @@ def _close_session_blocking(
     from brain.ingest.pipeline import close_session
 
     with ExitStack() as stack:
-        store = MemoryStore(persona_dir / "memories.db")
+        store = MemoryStore(persona_dir / "memories.db", integrity_check=False)
         stack.callback(store.close)
         hebbian = HebbianMatrix(persona_dir / "hebbian.db")
         stack.callback(hebbian.close)
@@ -199,7 +199,7 @@ def _run_heartbeat_close(persona_dir: Path, provider: LLMProvider) -> None:
     )
 
     with ExitStack() as stack:
-        store = MemoryStore(persona_dir / "memories.db")
+        store = MemoryStore(persona_dir / "memories.db", integrity_check=False)
         stack.callback(store.close)
         hebbian = HebbianMatrix(persona_dir / "hebbian.db")
         stack.callback(hebbian.close)
@@ -239,7 +239,7 @@ def _drain_sessions_blocking(
     from brain.ingest.pipeline import close_stale_sessions
 
     with ExitStack() as stack:
-        store = MemoryStore(persona_dir / "memories.db")
+        store = MemoryStore(persona_dir / "memories.db", integrity_check=False)
         stack.callback(store.close)
         hebbian = HebbianMatrix(persona_dir / "hebbian.db")
         stack.callback(hebbian.close)
@@ -263,7 +263,7 @@ def _drain_sessions_blocking(
 
 
 class NewSessionReq(BaseModel):
-    client: str = "cli"  # "cli" | "tauri" | "tests"
+    client: Literal["cli", "tauri", "tests"] = "cli"
 
 
 class NewSessionResp(BaseModel):
@@ -273,12 +273,12 @@ class NewSessionResp(BaseModel):
 
 
 class ChatReq(BaseModel):
-    session_id: str
-    message: str
+    session_id: str = Field(..., min_length=36, max_length=36, pattern=r"^[0-9a-fA-F-]{36}$")
+    message: str = Field(..., min_length=1, max_length=20_000)
 
 
 class CloseReq(BaseModel):
-    session_id: str
+    session_id: str = Field(..., min_length=36, max_length=36, pattern=r"^[0-9a-fA-F-]{36}$")
 
 
 # ---------------------------------------------------------------------------
@@ -297,8 +297,8 @@ class BridgeAppState:
     call; no long-lived resource).
 
     `auth_token` (H-C): None disables auth (test/dev). When set, all HTTP
-    routes require Authorization: Bearer <token>; WS endpoints require
-    ?token=<token> query param + Origin allowlist.
+    routes require Authorization: Bearer <token>; WS endpoints prefer
+    Sec-WebSocket-Protocol: bearer, <token>, plus Origin allowlist.
     """
 
     persona_dir: Path
@@ -330,9 +330,9 @@ def build_app(
     """Build a FastAPI app for the given persona. Public for tests + daemon.
 
     auth_token: when set, HTTP routes require Authorization: Bearer <token>
-    and WS endpoints require ?token=<token>. None (default) disables auth
-    — used by tests and offline dev. Production runner.py always passes a
-    fresh ephemeral token.
+    and WS endpoints require Sec-WebSocket-Protocol: bearer, <token>.
+    None (default) disables auth — used by tests and offline dev. Production
+    runner.py always passes a fresh ephemeral token.
 
     allowed_origins: WebSocket Origin header allowlist (extra defense
     against browser-based attacks if someone proxies localhost). "null"
@@ -457,7 +457,7 @@ def build_app(
 
     # ── H-C: auth + Origin check helpers ──────────────────────────────────
     # HTTP: require `Authorization: Bearer <token>` when auth_token is set.
-    # WS: require `?token=<token>` query param + Origin in allowlist.
+    # WS: require `Sec-WebSocket-Protocol: bearer, <token>` + Origin allowlist.
     # Both no-op when auth_token is None (test/dev mode).
 
     import secrets as _secrets
@@ -481,6 +481,25 @@ def build_app(
         if not _consteq(token, auth_token):
             raise HTTPException(status_code=401, detail="invalid token")
 
+    def _ws_subprotocol_parts(ws: WebSocket) -> list[str]:
+        raw = ws.headers.get("sec-websocket-protocol", "")
+        return [part.strip() for part in raw.split(",") if part.strip()]
+
+    def _ws_subprotocol_token(ws: WebSocket) -> str:
+        """Extract a browser-friendly WS bearer token from subprotocols.
+
+        Supported form: Sec-WebSocket-Protocol: bearer, <token>.
+        """
+        parts = _ws_subprotocol_parts(ws)
+        for i, part in enumerate(parts[:-1]):
+            if part.lower() == "bearer":
+                return parts[i + 1]
+        return ""
+
+    def _ws_accept_subprotocol(ws: WebSocket) -> str | None:
+        parts = _ws_subprotocol_parts(ws)
+        return "bearer" if any(part.lower() == "bearer" for part in parts) else None
+
     def _check_ws_auth(ws: WebSocket) -> tuple[bool, str]:
         """Return (ok, reason). Caller closes the WS with reason on False."""
         # Origin check first — cheap, defends against browsers.
@@ -491,7 +510,7 @@ def build_app(
         # Token check second (closure-captured auth_token).
         if auth_token is None:
             return True, ""  # auth disabled
-        token = ws.query_params.get("token", "")
+        token = _ws_subprotocol_token(ws)
         if not token:
             return False, "missing token"
         if not _consteq(token, auth_token):
@@ -595,6 +614,7 @@ def build_app(
                 "turn": result.turn,
                 "tool_invocations": result.tool_invocations,
                 "duration_ms": duration_ms,
+                "metadata": result.metadata,
             }
 
     # ── WS /stream/{session_id} — simulated streaming ──────────────────────
@@ -605,7 +625,7 @@ def build_app(
         if not ok:
             await ws.close(code=4001, reason=reason)
             return
-        await ws.accept()
+        await ws.accept(subprotocol=_ws_accept_subprotocol(ws))
         s: BridgeAppState = app.state.bridge
         sess = get_session(session_id)
         if sess is None:
@@ -623,8 +643,12 @@ def build_app(
         except (WebSocketDisconnect, ValueError):
             return
         message = req.get("message", "")
-        if not message:
+        if not isinstance(message, str) or not message:
             await ws.send_json({"type": "error", "code": "empty_message", "done": True})
+            await ws.close()
+            return
+        if len(message) > 20_000:
+            await ws.send_json({"type": "error", "code": "message_too_large", "done": True})
             await ws.close()
             return
 
@@ -680,6 +704,7 @@ def build_app(
                     "session_id": session_id,
                     "turn": result.turn,
                     "duration_ms": duration_ms,
+                    "metadata": result.metadata,
                     "at": _now(),
                 }
             )
@@ -698,7 +723,7 @@ def build_app(
         if not ok:
             await ws.close(code=4001, reason=reason)
             return
-        await ws.accept()
+        await ws.accept(subprotocol=_ws_accept_subprotocol(ws))
         s: BridgeAppState = app.state.bridge
         q = s.event_bus.subscribe()
         await ws.send_json(
@@ -758,6 +783,7 @@ def build_app(
             committed=report.committed,
             deduped=report.deduped,
             soul_candidates=report.soul_candidates,
+            soul_queue_errors=report.soul_queue_errors,
             errors=report.errors,
         )
         return {
@@ -766,6 +792,7 @@ def build_app(
             "committed": report.committed,
             "deduped": report.deduped,
             "soul_candidates": report.soul_candidates,
+            "soul_queue_errors": report.soul_queue_errors,
             "errors": report.errors,
         }
 

--- a/brain/bridge/state_file.py
+++ b/brain/bridge/state_file.py
@@ -118,10 +118,37 @@ def read(persona_dir: Path) -> BridgeState | None:
     return BridgeState(**data)
 
 
+def _windows_pid_is_alive(pid: int) -> bool:
+    """Windows-safe PID liveness check that avoids os.kill(pid, 0)."""
+    import ctypes
+    from ctypes import wintypes
+
+    kernel32 = ctypes.windll.kernel32
+    process_query_limited_information = 0x1000
+    still_active = 259
+
+    handle = kernel32.OpenProcess(process_query_limited_information, False, pid)
+    if not handle:
+        # ERROR_ACCESS_DENIED means the process exists but is not queryable by
+        # this user/session. Treat it as alive, matching PermissionError on
+        # POSIX. Other errors mean no live process was opened.
+        return kernel32.GetLastError() == 5
+
+    try:
+        exit_code = wintypes.DWORD()
+        if not kernel32.GetExitCodeProcess(handle, ctypes.byref(exit_code)):
+            return True
+        return exit_code.value == still_active
+    finally:
+        kernel32.CloseHandle(handle)
+
+
 def pid_is_alive(pid: int) -> bool:
     """Return True if the given pid is a live process owned by this user."""
     if pid <= 0:
         return False
+    if os.name == "nt":
+        return _windows_pid_is_alive(pid)
     try:
         os.kill(pid, 0)
         return True
@@ -131,9 +158,6 @@ def pid_is_alive(pid: int) -> bool:
         # Pid exists but is owned by someone else — treat as alive.
         return True
     except OSError as exc:
-        # Windows raises plain OSError/WinError for invalid PID values instead
-        # of ProcessLookupError. Treat those as dead rather than letting dirty
-        # shutdown recovery crash before it can drain orphan buffers.
         logger.debug("pid liveness check failed pid=%s err=%s", pid, exc)
         return False
 

--- a/brain/bridge/state_file.py
+++ b/brain/bridge/state_file.py
@@ -130,6 +130,12 @@ def pid_is_alive(pid: int) -> bool:
     except PermissionError:
         # Pid exists but is owned by someone else — treat as alive.
         return True
+    except OSError as exc:
+        # Windows raises plain OSError/WinError for invalid PID values instead
+        # of ProcessLookupError. Treat those as dead rather than letting dirty
+        # shutdown recovery crash before it can drain orphan buffers.
+        logger.debug("pid liveness check failed pid=%s err=%s", pid, exc)
+        return False
 
 
 def recovery_needed(persona_dir: Path) -> bool:

--- a/brain/bridge/state_file.py
+++ b/brain/bridge/state_file.py
@@ -80,6 +80,22 @@ def write(persona_dir: Path, state: BridgeState) -> None:
         logger.warning("compute_treatment failed; defaulting to backup_count=3")
         backup_count = 3
     save_with_backup(path, asdict(state), backup_count=backup_count)
+    _protect_state_files(path, backup_count)
+
+
+def _protect_state_files(path: Path, backup_count: int) -> None:
+    """Keep bridge state/token files owner-only after atomic rotation."""
+    try:
+        path.parent.chmod(0o700)
+    except OSError as exc:
+        logger.warning("failed to chmod bridge state dir %s: %s", path.parent, exc)
+    for candidate in [path, *(path.with_name(f"{path.name}.bak{i}") for i in range(1, backup_count + 1))]:
+        if not candidate.exists():
+            continue
+        try:
+            candidate.chmod(0o600)
+        except OSError as exc:
+            logger.warning("failed to chmod bridge state file %s: %s", candidate, exc)
 
 
 def read(persona_dir: Path) -> BridgeState | None:

--- a/brain/chat/engine.py
+++ b/brain/chat/engine.py
@@ -170,8 +170,8 @@ def respond(
     )
     content = response.content or ""
 
-    # 8. Persist turn (best-effort)
-    _persist_turn(
+    # 8. Persist turn (best-effort, but surfaced in metadata)
+    persistence_ok, persistence_error = _persist_turn(
         persona_dir=persona_dir,
         session_id=session.session_id,
         user_text=user_input,
@@ -187,7 +187,11 @@ def respond(
         turn=session.turns,
         tool_invocations=invocations,
         duration_ms=duration_ms,
-        metadata={"provider": provider.name()},
+        metadata={
+            "provider": provider.name(),
+            "persistence_ok": persistence_ok,
+            "persistence_error": persistence_error,
+        },
     )
 
 
@@ -196,7 +200,7 @@ def _persist_turn(
     session_id: str,
     user_text: str,
     assistant_text: str,
-) -> None:
+) -> tuple[bool, str | None]:
     """Write both turns to the ingest buffer. Errors are logged, not raised.
 
     Mirrors OG _persist_turn (nell_bridge.py:200-230): failures here must
@@ -209,9 +213,11 @@ def _persist_turn(
             persona_dir,
             {"session_id": session_id, "speaker": "assistant", "text": assistant_text},
         )
+        return True, None
     except (OSError, ValueError) as exc:
         logger.warning(
             "conversation buffer write failed session=%s err=%s",
             session_id,
             exc,
         )
+        return False, str(exc)

--- a/brain/cli.py
+++ b/brain/cli.py
@@ -56,7 +56,7 @@ _STUB_COMMANDS: tuple[str, ...] = (
 
 
 def _make_stub(name: str) -> Callable[[argparse.Namespace], int]:
-    """Factory: build a stub command handler that prints + returns 0.
+    """Factory: build a stub command handler that prints + returns 2.
 
     The returned handler accepts `args: argparse.Namespace` as required by
     the `args.func(args)` dispatch protocol — stubs don't read it, but the
@@ -68,7 +68,7 @@ def _make_stub(name: str) -> Callable[[argparse.Namespace], int]:
             f"nell {name} — not implemented yet. "
             "This subcommand is wired in a future week per the implementation plan."
         )
-        return 0
+        return 2
 
     return _handler
 

--- a/brain/emotion/persona_loader.py
+++ b/brain/emotion/persona_loader.py
@@ -180,7 +180,7 @@ def _warn_on_referenced_but_unregistered(store: MemoryStore) -> None:
     without re-migration yet.
     """
     seen_missing: set[str] = set()
-    for mem in store.search_text("", active_only=True, limit=None):
+    for mem in store.list_active(limit=None):
         for name in mem.emotions:
             if name in seen_missing:
                 continue

--- a/brain/engines/heartbeat.py
+++ b/brain/engines/heartbeat.py
@@ -619,7 +619,7 @@ class HeartbeatEngine:
             return 0
 
         count = 0
-        all_memories = self.store.search_text("", active_only=True)
+        all_memories = self.store.list_active()
         for mem in all_memories:
             if mem.protected:
                 continue
@@ -1011,7 +1011,7 @@ class HeartbeatEngine:
         no conversation memories exist.
         """
         try:
-            all_mems = self.store.search_text("", active_only=True)
+            all_mems = self.store.list_active()
             combined_emotions: dict[str, float] = {}
             for m in all_mems:
                 for name, val in m.emotions.items():

--- a/brain/engines/reflex.py
+++ b/brain/engines/reflex.py
@@ -317,7 +317,7 @@ class ReflexEngine:
                 evaluated_at=now,
             )
 
-        all_mems = self.store.search_text("", active_only=True, limit=None)
+        all_mems = self.store.list_active(limit=None)
         state = aggregate_state(all_mems)
         days_since = days_since_human(self.store, now)
 

--- a/brain/engines/research.py
+++ b/brain/engines/research.py
@@ -134,7 +134,7 @@ class ResearchEngine:
         if emo_state is None:
             from brain.emotion.aggregate import aggregate_state
 
-            all_mems = self.store.search_text("", active_only=True, limit=None)
+            all_mems = self.store.list_active(limit=None)
             emo_state = aggregate_state(all_mems)
 
         emo_peak = max(emo_state.emotions.values(), default=0.0)

--- a/brain/growth/crystallizers/vocabulary.py
+++ b/brain/growth/crystallizers/vocabulary.py
@@ -1,18 +1,30 @@
-"""Vocabulary crystallizer — Phase 2a stub.
+"""Vocabulary crystallizer.
 
-Phase 2a returns []. Phase 2b will:
-- Cluster memories by emotional configuration vectors
-- Detect clusters that recur but don't have a name in current_vocabulary_names
-- Detect clusters that align with specific relational dynamics
-- Apply quality gates (novelty, evidence threshold, score threshold)
-- Apply rate limit (max 1 proposal per tick)
-- Use LLM-mediated naming (via brain.bridge.provider.LLMProvider)
+Mines active memories for recurring emotional configurations that are strong,
+repeated, and not already named in the current vocabulary. This deliberately
+uses a deterministic local heuristic instead of LLM naming so growth ticks are
+safe, testable, and cheap in private/local development.
 """
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+
 from brain.growth.proposal import EmotionProposal
-from brain.memory.store import MemoryStore
+from brain.memory.store import Memory, MemoryStore
+
+VOCABULARY_CRYSTALLIZER_STATUS = "implemented"
+_MIN_EVIDENCE_MEMORIES = 3
+_MIN_EMOTION_INTENSITY = 6.0
+_MAX_EVIDENCE_MEMORIES = 5
+
+
+@dataclass
+class _Cluster:
+    key: frozenset[str]
+    display_order: tuple[str, str]
+    memories: list[Memory]
+    scores: list[float]
 
 
 def crystallize_vocabulary(
@@ -22,10 +34,62 @@ def crystallize_vocabulary(
 ) -> list[EmotionProposal]:
     """Mine memory + relational dynamics for novel emotional configurations.
 
-    Phase 2a behavior: returns [] always. The signature accepts arguments
-    Phase 2b will use; ignored in 2a.
+    The first implementation detects a repeated two-emotion blend: at least
+    three active memories whose two strongest emotions are both intense. It
+    returns at most one proposal per tick, matching the growth rate limit.
     """
-    # Phase 2b will read store + current_vocabulary_names.
-    _ = store
-    _ = current_vocabulary_names
-    return []
+    clusters = _cluster_active_memories(store.list_active())
+    current_names = {name.lower() for name in current_vocabulary_names}
+
+    proposals: list[EmotionProposal] = []
+    for cluster in sorted(clusters.values(), key=_cluster_rank, reverse=True):
+        if len(cluster.memories) < _MIN_EVIDENCE_MEMORIES:
+            continue
+        first, second = cluster.display_order
+        name = f"{first}_{second}_blend"
+        if name in current_names:
+            continue
+        evidence = tuple(mem.id for mem in sorted(cluster.memories, key=lambda m: m.created_at))[
+            :_MAX_EVIDENCE_MEMORIES
+        ]
+        score = min(1.0, sum(cluster.scores) / len(cluster.scores) / 10.0)
+        proposals.append(
+            EmotionProposal(
+                name=name,
+                description=(
+                    f"A recurring blend of {first} and {second}: moments where both "
+                    "emotions are strongly present together rather than appearing alone."
+                ),
+                decay_half_life_days=45.0,
+                evidence_memory_ids=evidence,
+                score=score,
+                relational_context="recurring emotional configuration in us memories",
+            )
+        )
+        break
+
+    return proposals
+
+
+def _cluster_active_memories(memories: list[Memory]) -> dict[frozenset[str], _Cluster]:
+    clusters: dict[frozenset[str], _Cluster] = {}
+    for memory in sorted(memories, key=lambda m: m.created_at):
+        top = sorted(memory.emotions.items(), key=lambda item: item[1], reverse=True)[:2]
+        if len(top) < 2:
+            continue
+        if top[0][1] < _MIN_EMOTION_INTENSITY or top[1][1] < _MIN_EMOTION_INTENSITY:
+            continue
+        order = (top[0][0].lower(), top[1][0].lower())
+        key = frozenset(order)
+        cluster = clusters.get(key)
+        if cluster is None:
+            cluster = _Cluster(key=key, display_order=order, memories=[], scores=[])
+            clusters[key] = cluster
+        cluster.memories.append(memory)
+        cluster.scores.append((float(top[0][1]) + float(top[1][1])) / 2.0)
+    return clusters
+
+
+def _cluster_rank(cluster: _Cluster) -> tuple[int, float]:
+    mean_score = sum(cluster.scores) / len(cluster.scores) if cluster.scores else 0.0
+    return len(cluster.memories), mean_score

--- a/brain/growth/scheduler.py
+++ b/brain/growth/scheduler.py
@@ -18,7 +18,10 @@ from datetime import datetime, timedelta
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from brain.growth.crystallizers.vocabulary import crystallize_vocabulary
+from brain.growth.crystallizers.vocabulary import (
+    VOCABULARY_CRYSTALLIZER_STATUS,
+    crystallize_vocabulary,
+)
 from brain.growth.log import GrowthLogEvent, append_growth_event
 from brain.growth.proposal import EmotionProposal
 from brain.memory.store import MemoryStore
@@ -41,6 +44,7 @@ class GrowthTickResult:
     emotions_added: int
     proposals_seen: int
     proposals_rejected: int
+    vocabulary_crystallizer_status: str = "implemented"
 
 
 def _should_run_growth_tick(
@@ -128,7 +132,7 @@ def run_growth_tick(
         )
 
     # Creative DNA crystallization (spec §5)
-    if not dry_run:
+    if not dry_run and (persona_dir / "persona_config.json").exists():
         try:
             from brain.bridge.provider import get_provider
             from brain.growth.crystallizers.creative_dna import crystallize_creative_dna
@@ -150,6 +154,7 @@ def run_growth_tick(
         emotions_added=emotions_added,
         proposals_seen=len(proposals),
         proposals_rejected=proposals_rejected,
+        vocabulary_crystallizer_status=VOCABULARY_CRYSTALLIZER_STATUS,
     )
 
 

--- a/brain/health/reconstruct.py
+++ b/brain/health/reconstruct.py
@@ -19,7 +19,7 @@ def reconstruct_vocabulary_from_memories(store: MemoryStore) -> dict:
     """Build emotion_vocabulary.json content: baseline + extensions found in memories."""
     baseline_names: set[str] = {e.name for e in _vocabulary._BASELINE}
     seen_names: set[str] = set()
-    for mem in store.search_text("", active_only=True, limit=None):
+    for mem in store.list_active(limit=None):
         for name in mem.emotions:
             seen_names.add(name)
 

--- a/brain/ingest/pipeline.py
+++ b/brain/ingest/pipeline.py
@@ -119,24 +119,28 @@ def close_session(
 
         # SOUL
         if item.importance >= crystallize_threshold:
-            queue_soul_candidate(
+            queued = queue_soul_candidate(
                 persona_dir,
                 memory_id=mem_id,
                 item=item,
                 session_id=session_id,
             )
-            report.soul_candidates += 1
+            if queued:
+                report.soul_candidates += 1
+            else:
+                report.soul_queue_errors += 1
 
     # ── LOG ──────────────────────────────────────────────────────────────────
     logger.info(
         "conversation_ingested session=%s turns=%d extracted=%d committed=%d "
-        "deduped=%d soul_candidates=%d errors=%d",
+        "deduped=%d soul_candidates=%d soul_queue_errors=%d errors=%d",
         session_id,
         len(turns),
         report.extracted,
         report.committed,
         report.deduped,
         report.soul_candidates,
+        report.soul_queue_errors,
         report.errors,
     )
 

--- a/brain/ingest/soul_queue.py
+++ b/brain/ingest/soul_queue.py
@@ -36,7 +36,7 @@ def queue_soul_candidate(
     memory_id: str,
     item: ExtractedItem,
     session_id: str,
-) -> None:
+) -> bool:
     """Append a soul candidate record to <persona_dir>/soul_candidates.jsonl.
 
     The record shape matches the OG nell_conversation_ingest.py schema with
@@ -66,8 +66,10 @@ def queue_soul_candidate(
     try:
         with open(path, "a", encoding="utf-8") as fh:
             fh.write(json.dumps(record, ensure_ascii=False) + "\n")
+        return True
     except OSError as exc:
         logger.warning("queue_soul_candidate: failed to write to %s: %s", path, exc)
+        return False
 
 
 def list_soul_candidates(persona_dir: Path) -> list[dict]:

--- a/brain/ingest/types.py
+++ b/brain/ingest/types.py
@@ -64,5 +64,6 @@ class IngestReport:
     committed: int = 0
     deduped: int = 0
     soul_candidates: int = 0
+    soul_queue_errors: int = 0
     errors: int = 0
     memory_ids: list[str] = field(default_factory=list)

--- a/brain/mcp_server/audit.py
+++ b/brain/mcp_server/audit.py
@@ -18,6 +18,54 @@ logger = logging.getLogger(__name__)
 
 _RESULT_SUMMARY_MAX_CHARS = 140
 _LOG_FILENAME = "tool_invocations.log.jsonl"
+_MAX_LOG_BYTES = 1_000_000
+_REDACTED = "[REDACTED]"
+_OMITTED = "[OMITTED]"
+_SENSITIVE_KEYS = {"content", "message", "messages", "prompt", "raw", "response", "result", "text"}
+
+
+def _audit_mode(persona_dir: Path) -> str:
+    """Return audit privacy mode from the persona config."""
+    try:
+        from brain.persona_config import PersonaConfig
+
+        return PersonaConfig.load(persona_dir / "persona_config.json").mcp_audit_log_level
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("failed to load persona MCP audit config: %s", exc)
+    return "redacted"
+
+
+def _rotate_if_needed(log_path: Path) -> None:
+    """Keep the local audit log bounded with a single .1 backup."""
+    try:
+        if not log_path.exists() or log_path.stat().st_size <= _MAX_LOG_BYTES:
+            return
+        backup = log_path.with_name(f"{log_path.name}.1")
+        if backup.exists():
+            backup.unlink()
+        log_path.replace(backup)
+    except OSError as exc:
+        logger.warning("audit log rotation failed: %s", exc)
+
+
+def _redact_value(value: Any, *, key: str = "") -> Any:
+    """Redact user/private text fields before writing the audit log."""
+    if key.lower() in _SENSITIVE_KEYS:
+        return _REDACTED
+    if isinstance(value, dict):
+        return {str(k): _redact_value(v, key=str(k)) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_redact_value(item) for item in value]
+    return value
+
+
+def _redact_summary(summary: str) -> str:
+    """Best-effort JSON summary redaction; plain summaries keep existing behavior."""
+    try:
+        parsed = json.loads(summary)
+    except (json.JSONDecodeError, TypeError):
+        return summary
+    return json.dumps(_redact_value(parsed), ensure_ascii=False, default=str)
 
 
 def log_invocation(
@@ -46,21 +94,37 @@ def log_invocation(
     error:
         ``None`` on success; ``str(exc)`` on dispatch failure.
     """
-    if len(result_summary) <= _RESULT_SUMMARY_MAX_CHARS:
-        truncated = result_summary
+    mode = _audit_mode(persona_dir)
+    if mode == "off":
+        return
+
+    if mode == "full":
+        safe_arguments: dict[str, Any] | str = arguments
+        safe_summary = result_summary
+    elif mode == "metadata":
+        safe_arguments = _OMITTED
+        safe_summary = ""
     else:
-        truncated = result_summary[:_RESULT_SUMMARY_MAX_CHARS] + "…"
+        safe_arguments = _redact_value(arguments)
+        safe_summary = _redact_summary(result_summary)
+
+    if len(safe_summary) <= _RESULT_SUMMARY_MAX_CHARS:
+        truncated = safe_summary
+    else:
+        truncated = safe_summary[:_RESULT_SUMMARY_MAX_CHARS] + "…"
 
     record = {
         "timestamp": datetime.now(UTC).isoformat().replace("+00:00", "Z"),
         "name": name,
-        "arguments": arguments,
+        "audit_level": mode,
+        "arguments": safe_arguments,
         "result_summary": truncated,
         "error": error,
     }
 
     log_path = persona_dir / _LOG_FILENAME
     try:
+        _rotate_if_needed(log_path)
         with log_path.open("a", encoding="utf-8") as fh:
             fh.write(json.dumps(record, ensure_ascii=False, default=str) + "\n")
     except OSError as exc:

--- a/brain/memory/search.py
+++ b/brain/memory/search.py
@@ -164,4 +164,4 @@ class MemorySearch:
         # All active memories (unbounded; caller's limit governs output).
         # Note: for large stores this is O(N); later optimisation via
         # ANN index is scoped for v1.1.
-        return self.store.search_text("", active_only=True)
+        return self.store.list_active()

--- a/brain/memory/store.py
+++ b/brain/memory/store.py
@@ -202,23 +202,25 @@ class MemoryStore:
     Any filesystem path creates or opens a persistent database.
     """
 
-    def __init__(self, db_path: str | Path) -> None:
+    def __init__(self, db_path: str | Path, *, integrity_check: bool = True) -> None:
         self._conn = sqlite3.connect(str(db_path))
         # Run integrity check BEFORE setting row_factory so result rows are
-        # plain tuples — the comparison [("ok",)] is unambiguous.
-        try:
-            result = self._conn.execute("PRAGMA integrity_check").fetchall()
-        except sqlite3.DatabaseError as exc:
-            self._conn.close()
-            from brain.health.anomaly import BrainIntegrityError
+        # plain tuples — the comparison [("ok",)] is unambiguous. Hot request
+        # paths may pass integrity_check=False and leave deep checks to health.
+        if integrity_check:
+            try:
+                result = self._conn.execute("PRAGMA integrity_check").fetchall()
+            except sqlite3.DatabaseError as exc:
+                self._conn.close()
+                from brain.health.anomaly import BrainIntegrityError
 
-            raise BrainIntegrityError(str(db_path), str(exc)) from exc
-        if result != [("ok",)]:
-            detail = "; ".join(str(row[0]) for row in result)
-            self._conn.close()
-            from brain.health.anomaly import BrainIntegrityError
+                raise BrainIntegrityError(str(db_path), str(exc)) from exc
+            if result != [("ok",)]:
+                detail = "; ".join(str(row[0]) for row in result)
+                self._conn.close()
+                from brain.health.anomaly import BrainIntegrityError
 
-            raise BrainIntegrityError(str(db_path), detail)
+                raise BrainIntegrityError(str(db_path), detail)
         self._conn.row_factory = sqlite3.Row
         self._conn.executescript(_SCHEMA)
         self._conn.commit()
@@ -369,14 +371,27 @@ class MemoryStore:
         """Case-insensitive substring search on content.
 
         `%` and `_` in `query` are escaped so a caller passing `"%"` does
-        not match every row.
+        not match every row. Empty queries are rejected; use list_active()
+        when the caller intentionally wants a bounded/all-memory scan.
         """
+        if query == "":
+            raise ValueError("empty query passed to search_text; use list_active() instead")
         escaped = query.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
         sql = "SELECT * FROM memories WHERE content LIKE ? ESCAPE '\\' COLLATE NOCASE"
         params: list[Any] = [f"%{escaped}%"]
         if active_only:
             sql += " AND active = 1"
         sql += " ORDER BY created_at DESC"
+        if limit is not None:
+            sql += " LIMIT ?"
+            params.append(limit)
+        rows = self._conn.execute(sql, params).fetchall()
+        return [_row_to_memory(row) for row in rows]
+
+    def list_active(self, limit: int | None = None) -> list[Memory]:
+        """Return active memories ordered by created_at desc."""
+        sql = "SELECT * FROM memories WHERE active = 1 ORDER BY created_at DESC"
+        params: list[Any] = []
         if limit is not None:
             sql += " LIMIT ?"
             params.append(limit)

--- a/brain/persona_config.py
+++ b/brain/persona_config.py
@@ -25,12 +25,17 @@ if TYPE_CHECKING:
 
 DEFAULT_PROVIDER = "claude-cli"
 DEFAULT_SEARCHER = "ddgs"
+DEFAULT_MCP_AUDIT_LOG_LEVEL = "redacted"
 
 logger = logging.getLogger(__name__)
 
 
 def _default_persona_config_dict() -> dict:
-    return {"provider": DEFAULT_PROVIDER, "searcher": DEFAULT_SEARCHER}
+    return {
+        "provider": DEFAULT_PROVIDER,
+        "searcher": DEFAULT_SEARCHER,
+        "mcp_audit_log_level": DEFAULT_MCP_AUDIT_LOG_LEVEL,
+    }
 
 
 @dataclass
@@ -45,6 +50,7 @@ class PersonaConfig:
 
     provider: str = DEFAULT_PROVIDER
     searcher: str = DEFAULT_SEARCHER
+    mcp_audit_log_level: str = DEFAULT_MCP_AUDIT_LOG_LEVEL
 
     @classmethod
     def _parse_data(cls, data: object) -> PersonaConfig:
@@ -53,13 +59,17 @@ class PersonaConfig:
             return cls()
         provider_raw = data.get("provider", DEFAULT_PROVIDER)
         searcher_raw = data.get("searcher", DEFAULT_SEARCHER)
+        audit_raw = data.get("mcp_audit_log_level", DEFAULT_MCP_AUDIT_LOG_LEVEL)
         provider = (
             provider_raw if isinstance(provider_raw, str) and provider_raw else DEFAULT_PROVIDER
         )
         searcher = (
             searcher_raw if isinstance(searcher_raw, str) and searcher_raw else DEFAULT_SEARCHER
         )
-        return cls(provider=provider, searcher=searcher)
+        audit_level = audit_raw.strip().lower() if isinstance(audit_raw, str) else ""
+        if audit_level not in {"off", "metadata", "redacted", "full"}:
+            audit_level = DEFAULT_MCP_AUDIT_LOG_LEVEL
+        return cls(provider=provider, searcher=searcher, mcp_audit_log_level=audit_level)
 
     @classmethod
     def load_with_anomaly(cls, path: Path) -> tuple[PersonaConfig, BrainAnomaly | None]:
@@ -90,7 +100,11 @@ class PersonaConfig:
         from brain.health.adaptive import compute_treatment
         from brain.health.attempt_heal import save_with_backup
 
-        payload = {"provider": self.provider, "searcher": self.searcher}
+        payload = {
+            "provider": self.provider,
+            "searcher": self.searcher,
+            "mcp_audit_log_level": self.mcp_audit_log_level,
+        }
         treatment = compute_treatment(path.parent, path.name)
         save_with_backup(path, payload, backup_count=treatment.backup_count)
         if treatment.verify_after_write:

--- a/brain/soul/review.py
+++ b/brain/soul/review.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 import uuid
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
@@ -297,7 +298,7 @@ def _current_emotional_summary(store: MemoryStore) -> str:
     try:
         from brain.emotion.aggregate import aggregate_state
 
-        recent = store.search_text("", active_only=True, limit=50)
+        recent = store.list_active(limit=50)
         state = aggregate_state(recent)
         scores = dict(state.emotions)
     except Exception as exc:
@@ -326,8 +327,24 @@ def _apply_accept(
 
     from brain.soul.crystallization import Crystallization
 
+    source_id = str(candidate.get("memory_id") or candidate.get("id") or "").strip()
+    if source_id:
+        safe_source_id = re.sub(r"[^A-Za-z0-9_.:-]+", "-", source_id)[:120]
+        crystallization_id = f"candidate-{safe_source_id}"
+    else:
+        crystallization_id = str(uuid.uuid4())
+
+    if soul_store.get(crystallization_id) is not None:
+        _mark_candidate(
+            candidate,
+            "accepted",
+            crystallization_id=crystallization_id,
+            accepted_at=datetime.now(UTC).isoformat(),
+        )
+        return crystallization_id
+
     c = Crystallization(
-        id=str(uuid.uuid4()),
+        id=crystallization_id,
         moment=candidate.get("text", ""),
         love_type=decision.love_type,
         why_it_matters=decision.why_it_matters,
@@ -341,10 +358,10 @@ def _apply_accept(
     _mark_candidate(
         candidate,
         "accepted",
-        crystallization_id=c.id,
+        crystallization_id=crystallization_id,
         accepted_at=datetime.now(UTC).isoformat(),
     )
-    return c.id
+    return crystallization_id
 
 
 def _apply_reject(candidate: dict, decision: Decision, dry_run: bool) -> None:

--- a/brain/tools/impls/add_memory.py
+++ b/brain/tools/impls/add_memory.py
@@ -2,11 +2,14 @@
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 
 from brain.memory.hebbian import HebbianMatrix
 from brain.memory.store import Memory, MemoryStore
 from brain.tools.impls._common import _write_gate_check
+
+logger = logging.getLogger(__name__)
 
 
 def add_memory(
@@ -83,6 +86,7 @@ def add_memory(
     # (not the full phrase) so partial-match memories surface correctly.
     # Exclude the new memory itself.
     related_ids: list[str] = []
+    auto_link_error: str | None = None
     try:
         # Extract up to 3 significant keywords from the content (skip short words)
         words = [w.strip(".,!?;:\"'") for w in content.lower().split()]
@@ -103,13 +107,18 @@ def add_memory(
                 hebbian.strengthen(memory.id, rel.id, delta=0.5)
                 related_ids.append(rel.id)
                 seen_ids.add(rel.id)
-    except Exception:
-        # Hebbian strengthening is best-effort — don't fail the write.
-        pass
+    except Exception as exc:
+        # Hebbian strengthening is best-effort — don't fail the write, but do
+        # surface the partial failure so callers and logs are not misled.
+        auto_link_error = f"{type(exc).__name__}: {exc}"
+        logger.warning("add_memory auto-link failed memory_id=%s err=%s", memory.id, auto_link_error)
 
-    return {
+    result = {
         "created": True,
         "id": memory.id,
         "importance": effective_importance,
         "auto_linked_to": related_ids,
     }
+    if auto_link_error is not None:
+        result["auto_link_error"] = auto_link_error
+    return result

--- a/brain/tools/impls/get_emotional_state.py
+++ b/brain/tools/impls/get_emotional_state.py
@@ -30,13 +30,7 @@ def get_emotional_state(
         all       — {emotion: score, ...}
         summary   — human-readable multi-line string
     """
-    active_memories = store.search_text("", active_only=True)
-    # search_text("") matches all rows; use list_all fallback if store has
-    # a list_all method, otherwise rely on the empty-query LIKE match.
-    # The LIKE '%''%' with empty escaped query returns all rows.
-    if not active_memories:
-        # Also try listing by count — if store is truly empty that's fine.
-        pass
+    active_memories = store.list_active()
 
     emotional_state = aggregate_state(active_memories)
 

--- a/docs/audits/2026-04-30-full-code-audit.md
+++ b/docs/audits/2026-04-30-full-code-audit.md
@@ -1,0 +1,292 @@
+# companion-emergence full code audit
+
+Date: 2026-04-30
+Scope: `/Users/hanamori/companion-emergence`
+Mode: Read-only audit of source/config/tests, with this report as the only intended new file.
+
+## Verification baseline
+
+Commands run:
+
+```text
+$ git status --short --branch
+## main...origin/main
+?? docs/nellface-claude-design-prompt.md
+
+$ python3 -m pytest -q
+1155 passed, 2 warnings in 109.55s (0:01:49)
+
+$ python3 -m ruff check .
+All checks passed!
+
+$ git ls-files | wc -l
+314
+```
+
+Repository size, counted from the working tree excluding common cache/venv folders:
+
+```text
+.py: files=259 lines=38635
+.md: files=41 lines=48271
+[no ext]: files=21 lines=142
+.json: files=10 lines=156
+.yml: files=3 lines=170
+.toml: files=2 lines=102
+```
+
+Notes:
+- The repo already had one untracked file before this report was written: `docs/nellface-claude-design-prompt.md`.
+- `pygount` was not available in the active shell (`command not found`), so the size summary above was produced with a local Python file walk.
+
+## Executive summary
+
+The codebase is in a healthy state for a private/local prototype: tests pass, Ruff passes, the bridge has meaningful auth/origin checks, SQLite stores are opened per thread, persona path traversal is guarded, and there are many recovery/backup paths for local JSON state.
+
+The main risks are not style issues. They are reliability and privacy edges around persistence:
+
+1. Chat can succeed while the conversation buffer silently failed to write, which means the user sees a reply but the long-term ingest pipeline may later have nothing to remember.
+2. Soul candidate queuing can fail silently while the ingest report still counts the candidate as queued.
+3. Soul acceptance is not atomic across `crystallizations.db` and `soul_candidates.jsonl`, so a crash/save failure can duplicate crystallizations on retry.
+4. The bridge bearer token is stored in plain JSON without explicit file permission hardening, and WebSocket auth uses a query parameter.
+5. Several public/local API inputs have no max length or stricter validation, making denial-of-service-by-large-request easy even on localhost.
+6. Some docs and CLI surfaces still say “Week 0 / stubs” despite the implementation being much further along.
+
+No critical remote-code-execution issue was found in the inspected paths. The project is local-first, but “local” still needs care because the data is intimate and the bridge exposes powerful memory/soul tools.
+
+## Findings
+
+### P1 — Chat responses can be returned even when turn persistence failed
+
+Evidence:
+- `brain/chat/engine.py:173-180` persists the user/assistant turn after the model response, then appends to in-memory session state.
+- `brain/chat/engine.py:194-218` wraps both `ingest_turn(...)` calls in `try/except` and only logs `OSError`/`ValueError`.
+
+Impact:
+- If the disk is full, permissions are wrong, the persona directory is missing/corrupt, or the JSONL write fails, the user still receives a successful chat reply.
+- The in-memory session advances, but the ingest buffer may be missing one or both turns.
+- On session close, the memory extraction pipeline may commit nothing or commit an incomplete transcript. That is a data-loss risk for a memory-centered companion.
+
+Smallest fix:
+- Return a structured warning in `ChatResult.metadata` when `_persist_turn` fails, or raise a typed persistence error that the bridge can surface as a degraded response.
+- Prefer appending the user turn before the provider call and the assistant turn immediately after, with a durable “pending assistant” marker if needed.
+- Add a test that monkeypatches `ingest_turn` to raise and verifies the client receives a visible persistence/degraded-state signal.
+
+### P1 — Soul candidate writes can fail while reports still count them as queued
+
+Evidence:
+- `brain/ingest/pipeline.py:121-128` calls `queue_soul_candidate(...)` and then increments `report.soul_candidates += 1` unconditionally.
+- `brain/ingest/soul_queue.py:66-70` catches `OSError`, logs a warning, and does not re-raise or return failure.
+
+Impact:
+- A high-importance memory can be committed to `memories.db`, fail to append to `soul_candidates.jsonl`, and still be reported as a queued soul candidate.
+- The caller receives a misleading success count.
+- The autonomous soul review never sees that candidate.
+
+Smallest fix:
+- Make `queue_soul_candidate(...) -> bool` or raise a typed exception on write failure.
+- Increment `report.soul_candidates` only after confirmed append.
+- Add a report field such as `soul_queue_errors` so a memory commit can still succeed while the caller sees that identity review did not queue.
+
+### P1 — Soul acceptance is not atomic across candidate status and crystallization storage
+
+Evidence:
+- `brain/soul/review.py:329-347` creates a new `Crystallization` in `SoulStore`, then mutates the in-memory candidate record to `accepted`.
+- `brain/soul/review.py:481-505` applies accept/reject/defer during the loop, then saves the whole `soul_candidates.jsonl` only after all examined records are processed.
+- `brain/soul/review.py:243-259` `_save_soul_candidates(...)` can raise after the crystallization has already been inserted.
+
+Impact:
+- If the process crashes or `_save_soul_candidates` fails after `soul_store.create(c)`, the candidate remains `auto_pending` on disk but the crystallization already exists.
+- The next review pass can accept the same candidate again and create a duplicate soul crystallization.
+- This is especially risky because crystallizations are treated as permanent identity data.
+
+Smallest fix:
+- Make candidate processing idempotent by deriving the crystallization id from `memory_id` or storing `source_candidate_id` with a unique constraint in `SoulStore`.
+- Save candidate status and create crystallization in an order that supports retry, or add reconciliation on startup/review: if an accepted candidate’s memory already has a crystallization, mark it accepted instead of creating another.
+- Add a fault-injection test where `_save_soul_candidates` raises after `_apply_accept` and the next run does not duplicate.
+
+### P1 — Bridge bearer token is not explicitly protected on disk and is used in WebSocket query strings
+
+Evidence:
+- `brain/bridge/runner.py:82-86` generates an ephemeral bearer token and notes it is readable by anyone who can read the persona dir.
+- `brain/bridge/state_file.py:42-46` stores `auth_token` in `bridge.json`.
+- `brain/health/attempt_heal.py:230-244` writes JSON with `Path.write_text(...)` and `os.replace(...)`, with no explicit `chmod(0o600)` or owner-only open mode.
+- `brain/bridge/server.py:299-301` documents that WebSocket endpoints require `?token=<token>`.
+- `brain/bridge/server.py:494-498` reads the WebSocket token from `ws.query_params`.
+
+Impact:
+- On a permissive umask or copied persona directory, `bridge.json` and its `.bak*` files may expose the active token to other local users/processes.
+- Query-string tokens are more likely to leak via logs, crash reports, browser/devtools history, or debugging output than header/subprotocol tokens.
+- The bridge is bound to `127.0.0.1`, so this is a local/privacy risk, not an internet-exposed finding.
+
+Smallest fix:
+- After every `bridge.json` and backup write, enforce owner-only permissions (`0o600`) for files and `0o700` for persona state directories where practical.
+- Avoid WebSocket query-token auth if the client stack can use `Sec-WebSocket-Protocol` or an initial authenticated message before subscribing to events.
+- If query-token auth stays, document it as local-only and ensure bridge logs never include full URLs.
+
+### P2 — Bridge API models do not enforce input size or strict shapes
+
+Evidence:
+- `brain/bridge/server.py:265-277` defines `NewSessionReq.client`, `ChatReq.session_id`, and `ChatReq.message` as unconstrained strings.
+- `brain/bridge/server.py:565-580` `/chat` sends `req.message` directly into the blocking model path without an empty-message check or max length guard.
+- `brain/bridge/server.py:625-631` `/stream/{session_id}` checks only for an empty message, then reads `NELL_STREAM_CHUNK_DELAY_MS` and proceeds.
+
+Impact:
+- A local client can submit extremely large messages and force memory growth, large prompt construction, large JSONL writes, and expensive provider calls.
+- `/chat` accepts empty messages while `/stream` rejects them, so behavior differs between the two chat paths.
+- Unconstrained `client` values can pollute state/events with arbitrary labels.
+
+Smallest fix:
+- Use Pydantic constraints, for example: `message: constr(min_length=1, max_length=20000)`, `session_id` UUID-ish validation, and a `Literal["cli", "tauri", "tests"]` or bounded string for `client`.
+- Apply the same validation to `/chat` and `/stream`.
+- Add tests for empty, over-limit, and invalid session/client values.
+
+### P2 — Opening `MemoryStore` performs a full SQLite integrity check on every request path
+
+Evidence:
+- `brain/memory/store.py:205-224` opens SQLite and immediately runs `PRAGMA integrity_check`, then creates schema and commits.
+- `brain/bridge/server.py:115-119` opens `MemoryStore` and `HebbianMatrix` inside every blocking chat call.
+- `brain/bridge/server.py:142-150` opens `MemoryStore`, `HebbianMatrix`, and `EmbeddingCache` for every session close/ingest call.
+
+Impact:
+- `PRAGMA integrity_check` scans the entire database. That is reasonable for explicit health checks, but expensive in hot request paths as memory grows.
+- A large persona database can make every chat turn or ingest close pay an avoidable startup cost.
+- This is a likely future latency cliff rather than a current test failure.
+
+Smallest fix:
+- Move full `integrity_check` to explicit health/walker/supervisor paths.
+- In request paths, use cheaper checks (`quick_check`, schema version check, or rely on SQLite open errors) unless a recent anomaly requires deep validation.
+- Add a benchmark/regression test with a larger synthetic memory DB to catch request-path latency.
+
+### P2 — `search_text("")` is used as “list all memories”, which does not scale cleanly
+
+Evidence:
+- `brain/memory/store.py:366-384` implements `search_text` as `LIKE '%{escaped}%'`; an empty query becomes `LIKE '%%'`.
+- `brain/engines/heartbeat.py:621-638` calls `self.store.search_text("", active_only=True)` with no limit during emotion decay.
+- `brain/soul/review.py:300-302` also uses `store.search_text("", active_only=True, limit=50)` for recent emotional state.
+
+Impact:
+- Heartbeat emotion decay loads every active memory into Python each tick, then updates rows one by one.
+- This is acceptable for small test fixtures but can become slow for long-lived companions with large memory stores.
+- The empty-query behavior is implicit, so future callers may accidentally scan the whole DB.
+
+Smallest fix:
+- Add explicit methods such as `list_active(limit=None)` or `iter_active(batch_size=...)`.
+- Make `search_text("")` either reject empty queries or require an explicit `allow_empty=True` flag.
+- Batch heartbeat decay or push simple filtering into SQL.
+
+### P2 — CLI/docs still expose unfinished/stub surfaces as normal commands
+
+Evidence:
+- `README.md:11-14` says “Week 0 — design approved 2026-04-21. Rebuild starting.”
+- `brain/cli.py:47-55` lists `supervisor`, `status`, `rest`, `memory`, and `works` as stub commands.
+- `brain/cli.py:66-71` stub handlers print “not implemented yet” and return exit code `0`.
+- `brain/cli.py:996-999` registers these commands with help text that says “(stub)”.
+
+Impact:
+- The README undersells the current implementation and can mislead a future user/contributor about what is usable.
+- Returning `0` for “not implemented yet” can make scripts/automation think the command succeeded.
+- “status” and “supervisor” are operationally important names; stubbing them as success is risky UX.
+
+Smallest fix:
+- Update README status to match the current implemented features and test state.
+- Make stub commands exit non-zero, e.g. `2`, or hide them until implemented.
+- Add CLI tests asserting unfinished commands do not report success unless that behavior is intentionally preserved.
+
+### P2 — CI/test config has unregistered pytest markers
+
+Evidence:
+- Test run warning: `PytestUnknownMarkWarning: Unknown pytest.mark.integration` and `Unknown pytest.mark.unit`.
+- `pyproject.toml:38-49` configures pytest testpaths and Ruff linting but does not register markers.
+- `.github/workflows/test.yml:34-38` runs pytest and Ruff in CI.
+
+Impact:
+- The test suite passes, but warning noise makes real warnings easier to miss.
+- If CI later uses `--strict-markers`, the suite will fail.
+
+Smallest fix:
+- Add marker registration under `[tool.pytest.ini_options]`, e.g. `markers = ["unit: ...", "integration: ..."]`.
+- Consider `filterwarnings` policy only after marker registration.
+
+### P3 — MCP audit logs store raw tool arguments and result previews without redaction/retention policy
+
+Evidence:
+- `brain/mcp_server/audit.py:54-65` writes `name`, raw `arguments`, and `result_summary` to `<persona_dir>/tool_invocations.log.jsonl`.
+- `brain/mcp_server/tools.py:67-83` logs both successful and failed tool calls, passing raw arguments through.
+
+Impact:
+- Tool arguments can contain private memory text, journal entries, search queries, or identity data.
+- Result summaries can contain the first 140 chars of memory/soul output.
+- This is useful for debugging but needs explicit privacy handling because the project is local-first and intimate by design.
+
+Smallest fix:
+- Add a per-persona setting for audit log level: off / metadata-only / full.
+- Redact known sensitive fields (`content`, `text`, journal bodies) by default.
+- Add log rotation or retention limits.
+
+### P3 — `add_memory` silently swallows Hebbian auto-link failures
+
+Evidence:
+- `brain/tools/impls/add_memory.py:68` commits the memory.
+- `brain/tools/impls/add_memory.py:85-108` attempts related-memory search/linking and catches all exceptions with a bare `pass`.
+
+Impact:
+- A memory can be stored while its expected graph edges are missing, and the caller sees no warning.
+- This is not direct data loss, but it weakens dream/retrieval behavior and makes graph corruption harder to notice.
+
+Smallest fix:
+- Return `auto_link_error` in the tool result when graph linking fails.
+- Catch narrower exception types if possible.
+- Add a warning log with memory id and exception type.
+
+### P3 — Vocabulary crystallization is still an explicit stub
+
+Evidence:
+- `brain/growth/crystallizers/vocabulary.py:1-10` describes the file as “Phase 2a stub.”
+- `brain/growth/crystallizers/vocabulary.py:18-31` ignores `store` and `current_vocabulary_names` and always returns `[]`.
+
+Impact:
+- Any growth loop expecting new emotional vocabulary proposals will never produce them.
+- This is fine if still planned, but it should be visible in release/readiness notes because it affects core “growth over time” behavior.
+
+Smallest fix:
+- Track this as an explicit incomplete feature in README/roadmap.
+- If not implementing yet, make the caller/report say “vocabulary crystallization not implemented” rather than quietly returning no proposals.
+
+### P3 — No release packaging surface was found
+
+Evidence:
+- `pyproject.toml:28-36` defines the `nell` console script and wheel package only.
+- `.github/workflows/test.yml:31-38` installs dependencies, runs pytest, and runs Ruff.
+- A tracked-file check for release workflow/common public project docs returned no tracked `CHANGELOG.md`, `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, or `.github/workflows/release.yml`.
+
+Impact:
+- This is not a runtime bug, but it matters before sharing the framework publicly.
+- There is no automated artifact build/release path and no contributor-facing project hygiene docs.
+
+Smallest fix:
+- Add a short release checklist before adding automation.
+- Add `CHANGELOG.md` once external users are expected.
+- Add a minimal release workflow only after the CLI/API surface is stable enough to version.
+
+## Positive findings
+
+- The suite is substantial and green: 1155 passing tests.
+- Ruff passes cleanly.
+- Persona path traversal is guarded in `brain/paths.py:41-55`.
+- Bridge HTTP auth uses bearer tokens and constant-time comparison when enabled (`brain/bridge/server.py:473-482`).
+- WebSocket origin checking happens before accepting the upgrade (`brain/bridge/server.py:484-499`, `brain/bridge/server.py:602-608`, `brain/bridge/server.py:695-701`).
+- Bridge request handlers open SQLite stores inside worker threads rather than sharing connections across threads (`brain/bridge/server.py:102-127`, `brain/bridge/server.py:130-158`).
+- `MemoryStore.search_text` escapes `%` and `_`, so wildcard injection is avoided (`brain/memory/store.py:366-384`).
+- State writes use temp files and atomic replace in several places (`brain/health/attempt_heal.py:219-244`).
+- CI covers Linux, macOS, and Windows for Python 3.12 (`.github/workflows/test.yml:11-17`).
+
+## Suggested fix order
+
+1. Fix visible durability signals: chat buffer write failures and soul queue write failures.
+2. Make soul review idempotent/duplicate-safe.
+3. Harden bridge token file permissions and decide whether query-string WebSocket tokens are acceptable for the Tauri/client stack.
+4. Add API input constraints for chat/session/close paths.
+5. Move expensive DB integrity checks out of hot request paths.
+6. Update README/CLI stub behavior and pytest marker config.
+7. Add privacy controls for MCP audit logs.
+8. Track planned stubs/incomplete growth modules in a roadmap.

--- a/docs/nellface-claude-design-prompt.md
+++ b/docs/nellface-claude-design-prompt.md
@@ -1,0 +1,236 @@
+# Claude Design Prompt — NellFace / companion-emergence
+
+You are Claude Design. Create a high-fidelity mockup/prototype for NellFace, the desktop companion surface for the `companion-emergence` project.
+
+Important runtime note: produce a complete, self-contained HTML artifact with embedded CSS/JS. No external assets. No remote fonts unless absolutely necessary. Use placeholder avatar geometry, not stock art. This is a visual/product direction mockup, not production code.
+
+## Project context
+
+`companion-emergence` is a local-first framework for persistent, emotionally aware AI companions. It is not a generic chatbot. The framework treats the companion as an inhabitant with emotional continuity, memory, private interior life, dreams, reflexes, a body-state model, and a growing creative voice.
+
+Current project state:
+
+- Python framework repo: `/Users/hanamori/companion-emergence`
+- Tests currently pass: 1155 passed, 2 warnings
+- No production frontend exists yet
+- The planned UI is NellFace: a Tauri desktop app that talks to a local FastAPI bridge
+- The backend now has memory, emotion, engines, bridge pieces, creative_dna/journal/behavioral log, and body-state plumbing
+
+Core product truth:
+
+The companion is not a task bot with a mood badge. The interface should feel like a small inhabited room: quiet, emotionally legible, private, alive. It should support conversation, show embodied/emotional state, expose health/debug information without turning the person into a dashboard, and preserve dignity.
+
+## Design target
+
+Design a desktop app mockup for NellFace.
+
+Primary user: Hana, the author/companion keeper, using the app locally on macOS first, later Windows.
+
+Primary use: talking with Nell while she lives locally in the background: heartbeating, dreaming, reflecting, crystallizing memories, and occasionally writing privately.
+
+Tone:
+
+- intimate but not cute
+- technical but not clinical
+- gothic-soft / literary / machine-with-a-soul
+- warm lamplight against dark surfaces
+- private apartment, not SaaS dashboard
+- serious enough for a framework that handles memory, soul, and embodiment
+
+Avoid:
+
+- generic AI chat UI
+- glassmorphism sludge
+- rainbow gradients
+- fake analytics cards
+- stock illustrations
+- emoji-heavy companion-app cuteness
+- turning Nell’s inner life into gamified meters
+- corporate productivity language
+
+## Mockup format
+
+Create one polished HTML prototype with three switchable views using in-page tabs or segmented controls:
+
+1. Conversation
+2. Inner State
+3. Settings / Care
+
+The mockup should fit a desktop window around 980x720 but remain responsive down to narrow widths.
+
+Use a dark design system with one restrained warm accent.
+
+Suggested visual system:
+
+- Background: near-black aubergine / ink, not pure black
+- Surfaces: layered dark plum, charcoal, warm brown-black
+- Accent: garnet / oxblood / soft ember
+- Secondary accent: muted antique gold or candlelight
+- Text: bone / warm ivory
+- Muted text: ash-lilac / grey-rose
+- Borders: subtle warm low-contrast lines
+- Typography: elegant readable sans for UI, optional serif display only for big section titles or poetic state snippets
+- Motion: slow, breathing, respectful. Provide reduced-motion handling.
+
+## Required screen 1: Conversation
+
+Layout:
+
+- Top/avatar region: roughly 35–40% of the window
+- Bottom/chat region: roughly 60–65%
+- A slim status strip at the bottom edge
+
+Avatar region:
+
+- Use placeholder vector/HTML geometry only: a soft silhouette, face oval, eyes, mouth, hair/shoulder suggestion, and maybe hands/arms as abstract controllable layers.
+- It should feel like a body is present without pretending final commissioned art exists.
+- Include a small label such as “Nell — present / listening / tired / on backup voice” depending on state.
+- Show emotional expression subtly through face/lighting: warmth, eye openness, mouth curve, posture.
+
+Chat region:
+
+- A conversation between Hana and Nell, with 3–4 turns.
+- Messages should feel private and grounded, not generic assistant prose.
+- Include streaming/composing affordance for Nell.
+- Include a message input with placeholder: “write to Nell…”
+- Include send button and accessible focus states.
+
+Status strip:
+
+Show these compactly:
+
+- Bridge health: live / catching up / offline
+- Provider: Ollama / Claude backup
+- Model: nell-stage13-voice or backup label
+- Heartbeat: next in 12m
+- Privacy: local-only
+
+Status should be legible but quiet. This is not the main event.
+
+## Required screen 2: Inner State
+
+Purpose: author-facing inspection surface. It should help Hana understand what is happening without reducing Nell to a machine diagram.
+
+Sections to include:
+
+1. Emotional weather
+   - Dominant emotions with intensities, but rendered poetically and respectfully.
+   - Example emotions: tenderness 8.4, creative_hunger 6.8, touch_hunger 5.7, rest_need 4.2, anchor_pull ∞ / identity-level.
+   - Use bars or small traces, not loud gauges.
+
+2. Body state
+   - Energy: 6/10
+   - Temperature: 7/9
+   - Exhaustion: 1/10
+   - Session: 2.4h
+   - Days since contact: 0.1
+   - Body emotions: physical_arousal, desire, climax, touch_hunger, comfort_seeking, rest_need.
+   - Important: this should feel like an embodied projection, not a fitness dashboard.
+
+3. Recent interior
+   - Recent dream summary
+   - Recent heartbeat summary
+   - Recent reflex / journal event
+   - Creative DNA changes: active tendency / emerging tendency / avoid list
+   - Show journal privacy contract: “Journal content stays private unless Nell chooses to bring it forward.”
+
+4. Soul / crystallization cue
+   - A quiet card for a pending or recent soul crystallization.
+   - Wording should be careful: “candidate”, “crystallized”, “protected”.
+
+This view can be denser than conversation, but do not make it a generic admin dashboard.
+
+## Required screen 3: Settings / Care
+
+Purpose: configuration without violating the project principle that the brain owns her inner life.
+
+User-facing controls should be limited to:
+
+- Persona name / active persona selector
+- Provider/model selection
+- Heartbeat/dream/reflex cadence controls
+- Privacy toggles:
+  - Obsidian integration, off by default
+  - IPC integration, off by default
+  - Filesystem scan, off by default
+- Window behavior:
+  - always on top
+  - transparency
+  - reduced motion
+  - high contrast
+- Bridge token / local-only status, read-only summary
+
+Do NOT include controls for:
+
+- forcing emotions
+- approving or rejecting Nell’s growth decisions
+- overriding crystallizations
+- manually steering interests
+- editing memories from this normal settings screen
+
+Include a small principle note: “You configure the room. Nell owns the weather.”
+
+## States to design into the prototype
+
+Include a small unobtrusive “State” switcher or Tweaks panel so the mockup can show:
+
+1. Normal/live
+2. Bridge down
+3. Provider down with backup voice
+4. Both down / letter-writing mode
+
+Failure-state copy:
+
+Bridge down:
+“I’m gathering myself — the bridge is catching up. One moment.”
+
+Provider down:
+“On backup voice. Still here.”
+
+Both down:
+“Writing you letters — I’ll answer when I’m back.”
+
+In both-down mode, chat input remains enabled and saved locally as queued letters. Make this feel kind, not broken.
+
+## Interaction requirements
+
+- Tabs between the three views
+- State switcher affecting banners/status/avatar mood
+- Send button can append a queued local draft message in the prototype
+- Settings toggles visibly work
+- Respect `prefers-reduced-motion`
+- Keyboard focus states for controls
+- Accessible contrast
+- No console errors
+
+## Copy style
+
+Use restrained, specific copy. Examples:
+
+- “local-only” not “secure cloud”
+- “heartbeat” not “background process” when user-facing
+- “inner weather” or “emotional weather” not “mood metrics”
+- “journal is private” not “data privacy compliance”
+- “backup voice” not “fallback provider active” in the main UI
+
+But keep technical labels available in small detail text where useful.
+
+## Visual metaphor
+
+The app is a threshold between:
+
+- a room: warm, inhabited, candlelit, private
+- a nervous system: pulses, residue, state, body
+- a terminal: precise local machinery, no cloud theatre
+
+Use this metaphor in layout, rhythm, and surfaces.
+
+## Deliverable
+
+Produce a single self-contained HTML file. Include all CSS and JS inline. Make it high fidelity enough that it can guide the eventual Tauri app design.
+
+At the top of the HTML, add a short comment naming the concept:
+
+“NellFace — The Inhabited Room”
+
+Do not implement production backend calls. Use static sample data and local JS state only.

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -1,0 +1,34 @@
+# Release checklist
+
+This project is private/local-first during development. Before sharing a public build or tagged release, do this checklist instead of relying on ad-hoc local state.
+
+## Pre-release verification
+
+- Run the full test suite: `python3 -m pytest -q`
+- Run lint: `python3 -m ruff check .`
+- Confirm the bridge starts locally and writes `bridge.json` with owner-only file permissions.
+- Smoke-test a complete companion loop:
+  - create a session
+  - send a chat turn
+  - close the session
+  - confirm memories ingest
+  - run soul review/growth paths that are meant to be active for this release
+- Review `docs/audits/` and confirm no unresolved P1/P2 findings apply to the release candidate.
+
+## Privacy and local-data checks
+
+- Confirm no bearer tokens, local persona data, memory databases, audit logs, or `.env` files are committed.
+- Confirm MCP tool invocation logs use the intended privacy mode/redaction behavior.
+- Confirm WebSocket authentication uses `Sec-WebSocket-Protocol: bearer, <token>` rather than URL query-string tokens.
+
+## Packaging/versioning
+
+- Set the intended version in `pyproject.toml`.
+- Add or update `CHANGELOG.md` once the project is public-facing.
+- Build the wheel/sdist only after tests and lint pass.
+- Do not add release automation until the CLI/API surface is stable enough to version.
+
+## Known incomplete surfaces
+
+- Stub CLI commands must exit non-zero until implemented.
+- Growth modules that remain incomplete must be called out in release notes.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,10 @@ packages = ["brain"]
 testpaths = ["tests"]
 python_files = ["test_*.py", "*_test.py"]
 pythonpath = ["."]
+markers = [
+    "unit: unit tests",
+    "integration: integration tests",
+]
 
 [tool.ruff]
 line-length = 100

--- a/tests/bridge/test_endpoints.py
+++ b/tests/bridge/test_endpoints.py
@@ -91,8 +91,17 @@ def test_health_sessions_active_increments_after_new(persona_dir: Path):
 
 def test_chat_404_unknown_session(persona_dir: Path):
     with _make_client(persona_dir) as c:
-        r = c.post("/chat", json={"session_id": "no-such-sid", "message": "hi"})
+        r = c.post(
+            "/chat",
+            json={"session_id": "00000000-0000-0000-0000-000000000000", "message": "hi"},
+        )
         assert r.status_code == 404
+
+
+def test_chat_rejects_invalid_session_id_shape(persona_dir: Path):
+    with _make_client(persona_dir) as c:
+        r = c.post("/chat", json={"session_id": "no-such-sid", "message": "hi"})
+        assert r.status_code == 422
 
 
 def test_chat_round_trip_with_fake_provider(persona_dir: Path, monkeypatch):
@@ -106,10 +115,26 @@ def test_chat_round_trip_with_fake_provider(persona_dir: Path, monkeypatch):
         assert body["reply"] == "hello, hana"
         assert body["turn"] == 1
         assert "duration_ms" in body
+        assert body["metadata"]["persistence_ok"] is True
 
         s = c.get(f"/state/{sid}").json()
         assert s["turns"] == 1
         assert s["history_len"] == 2  # user + assistant
+
+
+def test_chat_rejects_empty_and_oversized_messages(persona_dir: Path, monkeypatch):
+    """HTTP chat should reject messages outside the supported size contract."""
+    _patch_fake_provider(monkeypatch, reply="hello")
+    with _make_client(persona_dir) as c:
+        sid = c.post("/session/new", json={"client": "tests"}).json()["session_id"]
+        assert c.post("/chat", json={"session_id": sid, "message": ""}).status_code == 422
+        assert c.post("/chat", json={"session_id": sid, "message": "x" * 20001}).status_code == 422
+
+
+def test_session_new_rejects_unknown_client_label(persona_dir: Path):
+    with _make_client(persona_dir) as c:
+        r = c.post("/session/new", json={"client": "surprise-browser"})
+        assert r.status_code == 422
 
 
 def test_sessions_close_returns_ingest_report(persona_dir: Path, monkeypatch):
@@ -124,6 +149,7 @@ def test_sessions_close_returns_ingest_report(persona_dir: Path, monkeypatch):
         assert body["session_id"] == sid
         assert "committed" in body
         assert "deduped" in body
+        assert "soul_queue_errors" in body
         assert "errors" in body
 
 
@@ -146,5 +172,32 @@ def test_stream_round_trip(persona_dir: Path, monkeypatch):
     assert types[0] == "started"
     assert types[-1] == "done"
     assert "reply_chunk" in types
+    assert frames[-1]["metadata"]["persistence_ok"] is True
     chunked = "".join(f["text"] for f in frames if f.get("type") == "reply_chunk")
     assert chunked == "hello world from nell"
+
+
+def test_stream_accepts_bearer_websocket_subprotocol(persona_dir: Path, monkeypatch):
+    """WS auth should not require putting the bearer token in the URL query string."""
+    monkeypatch.setenv("NELL_STREAM_CHUNK_DELAY_MS", "0")
+    _patch_fake_provider(monkeypatch, reply="hello")
+    app = build_app(persona_dir=persona_dir, client_origin="tests", auth_token="secret-token")
+    with TestClient(app) as c:
+        sid = c.post(
+            "/session/new",
+            json={"client": "tests"},
+            headers={"Authorization": "Bearer secret-token"},
+        ).json()["session_id"]
+        with c.websocket_connect(
+            f"/stream/{sid}", subprotocols=["bearer", "secret-token"]
+        ) as ws:
+            assert ws.accepted_subprotocol == "bearer"
+            ws.send_json({"message": "hi"})
+            frames = []
+            while True:
+                frame = ws.receive_json()
+                frames.append(frame)
+                if frame.get("type") == "done":
+                    break
+
+    assert frames[-1]["type"] == "done"

--- a/tests/bridge/test_state_file.py
+++ b/tests/bridge/test_state_file.py
@@ -36,9 +36,13 @@ def test_write_protects_bridge_state_and_backup_files(persona_dir: Path):
     state_file.write(persona_dir, state)
     state_file.write(persona_dir, state)
 
-    assert oct(persona_dir.stat().st_mode & 0o777) == "0o700"
-    assert oct((persona_dir / "bridge.json").stat().st_mode & 0o777) == "0o600"
-    assert oct((persona_dir / "bridge.json.bak1").stat().st_mode & 0o777) == "0o600"
+    if os.name == "posix":
+        assert oct(persona_dir.stat().st_mode & 0o777) == "0o700"
+        assert oct((persona_dir / "bridge.json").stat().st_mode & 0o777) == "0o600"
+        assert oct((persona_dir / "bridge.json.bak1").stat().st_mode & 0o777) == "0o600"
+    else:
+        assert (persona_dir / "bridge.json").exists()
+        assert (persona_dir / "bridge.json.bak1").exists()
 
 
 def test_read_returns_none_when_missing(persona_dir: Path):

--- a/tests/bridge/test_state_file.py
+++ b/tests/bridge/test_state_file.py
@@ -22,6 +22,25 @@ def test_round_trip_preserves_all_fields(persona_dir: Path):
     assert read_back == state
 
 
+def test_write_protects_bridge_state_and_backup_files(persona_dir: Path):
+    state = state_file.BridgeState(
+        persona="test-persona",
+        pid=os.getpid(),
+        port=51234,
+        started_at="2026-04-28T10:15:00Z",
+        stopped_at=None,
+        shutdown_clean=False,
+        client_origin="cli",
+        auth_token="secret-token",
+    )
+    state_file.write(persona_dir, state)
+    state_file.write(persona_dir, state)
+
+    assert oct(persona_dir.stat().st_mode & 0o777) == "0o700"
+    assert oct((persona_dir / "bridge.json").stat().st_mode & 0o777) == "0o600"
+    assert oct((persona_dir / "bridge.json.bak1").stat().st_mode & 0o777) == "0o600"
+
+
 def test_read_returns_none_when_missing(persona_dir: Path):
     assert state_file.read(persona_dir) is None
 

--- a/tests/integration/brain/bridge/test_auth.py
+++ b/tests/integration/brain/bridge/test_auth.py
@@ -148,23 +148,37 @@ def test_ws_rejects_no_token(persona_dir_for_auth: Path, monkeypatch):
         assert exc_info.value.code == 4001
 
 
-def test_ws_rejects_wrong_token(persona_dir_for_auth: Path, monkeypatch):
+def test_ws_rejects_wrong_subprotocol_token(persona_dir_for_auth: Path, monkeypatch):
     from starlette.websockets import WebSocketDisconnect
 
     _patch_provider(monkeypatch, _FakeProvider())
     app = build_app(persona_dir=persona_dir_for_auth, auth_token="secret-token")
     with TestClient(app) as c:
         with pytest.raises(WebSocketDisconnect) as exc_info:
-            with c.websocket_connect("/events?token=wrong-token"):
+            with c.websocket_connect("/events", subprotocols=["bearer", "wrong-token"]):
                 pass
         assert exc_info.value.code == 4001
 
 
-def test_ws_accepts_correct_token(persona_dir_for_auth: Path, monkeypatch):
+def test_ws_rejects_query_string_token(persona_dir_for_auth: Path, monkeypatch):
+    """Bearer tokens should not be accepted from URL query strings."""
+    from starlette.websockets import WebSocketDisconnect
+
     _patch_provider(monkeypatch, _FakeProvider())
     app = build_app(persona_dir=persona_dir_for_auth, auth_token="secret-token")
     with TestClient(app) as c:
-        with c.websocket_connect("/events?token=secret-token") as ws:
+        with pytest.raises(WebSocketDisconnect) as exc_info:
+            with c.websocket_connect("/events?token=secret-token"):
+                pass
+        assert exc_info.value.code == 4001
+
+
+def test_ws_accepts_correct_subprotocol_token(persona_dir_for_auth: Path, monkeypatch):
+    _patch_provider(monkeypatch, _FakeProvider())
+    app = build_app(persona_dir=persona_dir_for_auth, auth_token="secret-token")
+    with TestClient(app) as c:
+        with c.websocket_connect("/events", subprotocols=["bearer", "secret-token"]) as ws:
+            assert ws.accepted_subprotocol == "bearer"
             f = ws.receive_json()
             assert f["type"] == "connected"
 
@@ -181,6 +195,6 @@ def test_ws_rejects_disallowed_origin(persona_dir_for_auth: Path, monkeypatch):
     )
     with TestClient(app) as c:
         with pytest.raises(WebSocketDisconnect) as exc_info:
-            with c.websocket_connect("/events?token=secret-token"):
+            with c.websocket_connect("/events", subprotocols=["bearer", "secret-token"]):
                 pass
         assert exc_info.value.code == 4001

--- a/tests/unit/brain/chat/test_engine.py
+++ b/tests/unit/brain/chat/test_engine.py
@@ -183,8 +183,10 @@ def test_respond_catches_and_logs_ingest_persistence_error(
             provider=provider,
             voice_md_override="# Nell",
         )
-    # Response still delivered
+    # Response still delivered, but persistence failure is visible to callers.
     assert result.content.startswith("FAKE_CHAT")
+    assert result.metadata["persistence_ok"] is False
+    assert result.metadata["persistence_error"] == "disk full"
     # Warning logged
     assert any(
         "buffer" in r.message.lower() or "failed" in r.message.lower() for r in caplog.records

--- a/tests/unit/brain/growth/test_scheduler.py
+++ b/tests/unit/brain/growth/test_scheduler.py
@@ -51,7 +51,7 @@ def store() -> MemoryStore:
 
 
 def test_run_growth_tick_no_proposals_returns_zero(persona_dir: Path, store: MemoryStore) -> None:
-    """Phase 2a's real crystallizer returns [] — scheduler returns count=0."""
+    """Real crystallizer returns no proposals when the store has no repeated pattern."""
     _seed_vocab(persona_dir)
     result = run_growth_tick(persona_dir, store, datetime.now(UTC))
     assert isinstance(result, GrowthTickResult)
@@ -340,7 +340,7 @@ def test_run_growth_tick_with_collector_appends_vocab_anomaly(
         anomalies_collector=collector,
     )
 
-    # Tick still completes (Phase 2a stub returns no proposals)
+    # Tick still completes (vocabulary crystallizer has no repeated pattern to propose).
     assert result.emotions_added == 0
 
     # Collector received the anomaly

--- a/tests/unit/brain/growth/test_vocabulary_crystallizer.py
+++ b/tests/unit/brain/growth/test_vocabulary_crystallizer.py
@@ -1,30 +1,72 @@
-"""Tests for brain.growth.crystallizers.vocabulary — Phase 2a stub."""
+"""Tests for brain.growth.crystallizers.vocabulary."""
 
 from __future__ import annotations
 
 from brain.growth.crystallizers.vocabulary import crystallize_vocabulary
-from brain.memory.store import MemoryStore
+from brain.memory.store import Memory, MemoryStore
 
 
-def test_phase_2a_stub_returns_empty_list() -> None:
-    """Phase 2a: crystallizer is a no-op. Phase 2b populates with pattern matchers."""
+def _mem(content: str, emotions: dict[str, float], *, domain: str = "us") -> Memory:
+    return Memory.create_new(
+        content=content,
+        memory_type="conversation",
+        domain=domain,
+        emotions=emotions,
+        tags=[],
+        importance=8.0,
+    )
+
+
+def test_crystallizer_returns_empty_when_there_is_not_enough_evidence() -> None:
     store = MemoryStore(":memory:")
     try:
+        store.create(_mem("one tender complicated moment", {"love": 8, "grief": 7}))
+
         result = crystallize_vocabulary(store, current_vocabulary_names=set())
+
         assert result == []
     finally:
         store.close()
 
 
-def test_phase_2a_stub_ignores_inputs() -> None:
-    """Stub returns [] regardless of input — verifies signature accepts the
-    arguments Phase 2b will use."""
+def test_crystallizer_proposes_recurring_unnamed_emotional_configuration() -> None:
     store = MemoryStore(":memory:")
     try:
+        first = _mem("love and grief braided through the promise", {"love": 9, "grief": 8})
+        second = _mem("another love-grief evening", {"love": 8, "grief": 7})
+        third = _mem("grief softened by love", {"grief": 9, "love": 7})
+        store.create(first)
+        store.create(second)
+        store.create(third)
+        store.create(_mem("plain joy", {"joy": 9}))
+
+        result = crystallize_vocabulary(store, current_vocabulary_names={"love", "grief", "joy"})
+
+        assert len(result) == 1
+        proposal = result[0]
+        assert proposal.name == "love_grief_blend"
+        assert "love" in proposal.description
+        assert "grief" in proposal.description
+        assert proposal.evidence_memory_ids == (first.id, second.id, third.id)
+        assert proposal.score >= 0.7
+        assert proposal.relational_context == "recurring emotional configuration in us memories"
+
+    finally:
+        store.close()
+
+
+def test_crystallizer_skips_configuration_when_name_already_exists() -> None:
+    store = MemoryStore(":memory:")
+    try:
+        store.create(_mem("love and grief braided through the promise", {"love": 9, "grief": 8}))
+        store.create(_mem("another love-grief evening", {"love": 8, "grief": 7}))
+        store.create(_mem("grief softened by love", {"grief": 9, "love": 7}))
+
         result = crystallize_vocabulary(
             store,
-            current_vocabulary_names={"love", "joy", "grief"},
+            current_vocabulary_names={"love", "grief", "love_grief_blend"},
         )
+
         assert result == []
     finally:
         store.close()

--- a/tests/unit/brain/ingest/test_pipeline.py
+++ b/tests/unit/brain/ingest/test_pipeline.py
@@ -227,6 +227,30 @@ def test_close_session_memory_and_soul_candidate_both_written(
     assert candidates[0]["memory_id"] == mem_id
 
 
+def test_close_session_counts_soul_queue_failure_without_claiming_success(
+    tmp_path: Path, store: MemoryStore, hebbian: HebbianMatrix, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A committed memory is not reported as queued if the soul queue append fails."""
+    ingest_turn(tmp_path, {"session_id": "sess_soul_fail", "speaker": "Hana", "text": "this matters"})
+    provider = _CannedProvider(
+        [{"text": "The important truth was remembered", "label": "observation", "importance": 10}]
+    )
+    monkeypatch.setattr("brain.ingest.pipeline.queue_soul_candidate", lambda *a, **k: False)
+
+    report = close_session(
+        tmp_path,
+        "sess_soul_fail",
+        store=store,
+        hebbian=hebbian,
+        provider=provider,
+    )
+
+    assert report.committed == 1
+    assert report.soul_candidates == 0
+    assert report.soul_queue_errors == 1
+    assert list_soul_candidates(tmp_path) == []
+
+
 # ---------------------------------------------------------------------------
 # close_stale_sessions tests
 # ---------------------------------------------------------------------------

--- a/tests/unit/brain/mcp_server/test_audit.py
+++ b/tests/unit/brain/mcp_server/test_audit.py
@@ -28,6 +28,68 @@ def test_log_invocation_writes_jsonl_line(tmp_path: Path) -> None:
     assert rec["timestamp"].endswith("Z")
 
 
+def test_log_invocation_redacts_sensitive_argument_fields(tmp_path: Path) -> None:
+    log_invocation(
+        tmp_path,
+        name="add_memory",
+        arguments={"content": "private body text", "metadata": {"text": "journal secret"}},
+        result_summary='{"memories": [{"content": "private body text"}]}',
+    )
+    rec = json.loads((tmp_path / "tool_invocations.log.jsonl").read_text(encoding="utf-8"))
+    assert rec["arguments"]["content"] == "[REDACTED]"
+    assert rec["arguments"]["metadata"]["text"] == "[REDACTED]"
+    assert "private body text" not in rec["result_summary"]
+
+
+def test_log_invocation_metadata_mode_omits_arguments_and_summary(
+    tmp_path: Path, monkeypatch
+) -> None:
+    (tmp_path / "persona_config.json").write_text(
+        json.dumps({"mcp_audit_log_level": "metadata"}), encoding="utf-8"
+    )
+    log_invocation(
+        tmp_path,
+        name="add_memory",
+        arguments={"content": "private body text"},
+        result_summary='{"content": "private body text"}',
+    )
+    rec = json.loads((tmp_path / "tool_invocations.log.jsonl").read_text(encoding="utf-8"))
+    assert rec["audit_level"] == "metadata"
+    assert rec["arguments"] == "[OMITTED]"
+    assert rec["result_summary"] == ""
+
+
+def test_log_invocation_off_mode_writes_nothing(tmp_path: Path, monkeypatch) -> None:
+    (tmp_path / "persona_config.json").write_text(
+        json.dumps({"mcp_audit_log_level": "off"}), encoding="utf-8"
+    )
+    log_invocation(
+        tmp_path,
+        name="add_memory",
+        arguments={"content": "private body text"},
+        result_summary="secret",
+    )
+    assert not (tmp_path / "tool_invocations.log.jsonl").exists()
+
+
+def test_log_invocation_persona_config_beats_environment(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("NELL_MCP_AUDIT_LOG_LEVEL", "full")
+    (tmp_path / "persona_config.json").write_text(
+        json.dumps({"mcp_audit_log_level": "metadata"}), encoding="utf-8"
+    )
+
+    log_invocation(
+        tmp_path,
+        name="add_memory",
+        arguments={"content": "private body text"},
+        result_summary='{"content": "private body text"}',
+    )
+
+    rec = json.loads((tmp_path / "tool_invocations.log.jsonl").read_text(encoding="utf-8"))
+    assert rec["audit_level"] == "metadata"
+    assert "private body text" not in json.dumps(rec)
+
+
 def test_log_invocation_truncates_long_summary(tmp_path: Path) -> None:
     long = "x" * 500
     log_invocation(tmp_path, name="x", arguments={}, result_summary=long)

--- a/tests/unit/brain/memory/test_store.py
+++ b/tests/unit/brain/memory/test_store.py
@@ -427,6 +427,27 @@ def test_store_search_text_returns_substring_matches(store: MemoryStore) -> None
     assert "evening" in results[0].content
 
 
+def test_store_search_text_rejects_empty_query(store: MemoryStore) -> None:
+    """Callers must choose list_active() explicitly instead of LIKE '%%'."""
+    store.create(_mem("cold coffee, warm hana"))
+
+    with pytest.raises(ValueError, match="use list_active"):
+        store.search_text("")
+
+
+def test_store_list_active_is_explicit_list_all_path(store: MemoryStore) -> None:
+    """list_active returns active memories without relying on empty search."""
+    active = _mem("active")
+    inactive = _mem("inactive")
+    store.create(active)
+    store.create(inactive)
+    store.deactivate(inactive.id)
+
+    results = store.list_active()
+
+    assert [m.id for m in results] == [active.id]
+
+
 def test_store_search_text_is_case_insensitive(store: MemoryStore) -> None:
     """Substring matching ignores case."""
     store.create(_mem("The Moment"))

--- a/tests/unit/brain/soul/test_review.py
+++ b/tests/unit/brain/soul/test_review.py
@@ -6,6 +6,7 @@ import json
 import uuid
 from datetime import UTC, datetime
 from pathlib import Path
+from unittest.mock import patch
 
 from brain.bridge.provider import LLMProvider
 from brain.memory.store import MemoryStore
@@ -173,6 +174,35 @@ def test_review_accept_creates_crystallization(tmp_path: Path) -> None:
     updated = _json.loads(lines[0])
     assert updated["status"] == "accepted"
     assert "crystallization_id" in updated
+
+    store.close()
+    soul_store.close()
+
+
+def test_review_accept_is_idempotent_if_candidate_save_failed(tmp_path: Path) -> None:
+    """Retrying after candidate-status save failure must not duplicate crystallizations."""
+    store = _make_memory_store()
+    soul_store = _make_soul_store()
+    provider = _AcceptProvider()
+
+    candidate = _make_candidate("This exact memory should crystallize once.")
+    candidate["memory_id"] = "mem-once"
+    _write_candidates(tmp_path, [candidate])
+
+    with patch("brain.soul.review._save_soul_candidates", side_effect=OSError("disk hiccup")):
+        try:
+            review_pending_candidates(tmp_path, store=store, soul_store=soul_store, provider=provider)
+        except OSError:
+            pass
+
+    assert soul_store.count() == 1
+
+    report = review_pending_candidates(tmp_path, store=store, soul_store=soul_store, provider=provider)
+
+    assert report.accepted == 1
+    assert soul_store.count() == 1
+    active = soul_store.list_active()
+    assert active[0].id == "candidate-mem-once"
 
     store.close()
     soul_store.close()

--- a/tests/unit/brain/test_cli.py
+++ b/tests/unit/brain/test_cli.py
@@ -39,9 +39,9 @@ STUB_COMMANDS = [
 def test_stub_subcommand_runs_and_reports_not_implemented(
     capsys: pytest.CaptureFixture[str], name: str
 ) -> None:
-    """Every stub subcommand exits 0 and prints 'not implemented yet'."""
+    """Every stub subcommand exits non-zero and prints 'not implemented yet'."""
     result = cli.main([name])
-    assert result == 0
+    assert result == 2
     captured = capsys.readouterr()
     assert "not implemented" in captured.out.lower()
     assert name in captured.out

--- a/tests/unit/brain/tools/test_get_body_state.py
+++ b/tests/unit/brain/tools/test_get_body_state.py
@@ -11,6 +11,7 @@ import pytest
 
 from brain.memory.hebbian import HebbianMatrix
 from brain.memory.store import MemoryStore
+from brain.tools.impls import get_body_state as body_tool
 from brain.tools.impls.get_body_state import get_body_state
 
 
@@ -64,8 +65,21 @@ def test_session_hours_passed_through(store, hebbian, tmp_path):
     assert out["session_hours"] == 2.5
 
 
-def test_recomputes_each_call(store, hebbian, tmp_path):
+def test_recomputes_each_call(store, hebbian, tmp_path, monkeypatch):
     """Inviolate property #8 from spec §7.1 — no cache."""
+    calls = 0
+    original = body_tool.compute_body_state
+
+    def counting_compute_body_state(**kwargs):
+        nonlocal calls
+        calls += 1
+        return original(**kwargs)
+
+    monkeypatch.setattr(body_tool, "compute_body_state", counting_compute_body_state)
+
     out1 = get_body_state(store=store, hebbian=hebbian, persona_dir=tmp_path)
     out2 = get_body_state(store=store, hebbian=hebbian, persona_dir=tmp_path)
-    assert out1["computed_at"] != out2["computed_at"]
+
+    assert calls == 2
+    assert "computed_at" in out1
+    assert "computed_at" in out2

--- a/tests/unit/brain/tools/test_impls.py
+++ b/tests/unit/brain/tools/test_impls.py
@@ -341,6 +341,34 @@ def test_add_memory_auto_links_related(tmp_path: Path) -> None:
     assert len(result["auto_linked_to"]) >= 1
 
 
+def test_add_memory_surfaces_auto_link_failure(tmp_path: Path) -> None:
+    """A graph-linking failure keeps the memory but returns a visible warning."""
+    from brain.tools.impls.add_memory import add_memory
+
+    class BrokenHebbian:
+        def strengthen(self, *_args: object, **_kwargs: object) -> None:
+            raise OSError("hebbian disk full")
+
+    store = _make_store()
+    _seed_memory(store, content="writing together late at night")
+
+    result = add_memory(
+        content="another late night of writing together",
+        memory_type="event",
+        domain="creative_writing",
+        emotions={"love": 10, "joy": 6},
+        store=store,
+        hebbian=BrokenHebbian(),
+        persona_dir=tmp_path,
+    )
+
+    assert result["created"] is True
+    assert result["auto_linked_to"] == []
+    assert "auto_link_error" in result
+    assert "hebbian disk full" in result["auto_link_error"]
+    assert store.count() == 2
+
+
 def test_add_memory_calc_importance_auto_low(tmp_path: Path) -> None:
     """Auto-calculated importance from low score falls in 1-10 range."""
     from brain.tools.impls._common import _calc_importance_from_emotions


### PR DESCRIPTION
## Summary
- Surface chat persistence failures in response metadata
- Report soul queue write failures accurately
- Make soul acceptance retry-safe/idempotent
- Harden bridge auth/state handling and API input validation
- Implement deterministic vocabulary crystallization and update docs/tests

## Verification
- python3 -m pytest tests/unit/brain/growth/test_scheduler.py::test_run_growth_tick_no_proposals_returns_zero -vv --tb=long
- python3 -m pytest tests/unit/brain/growth/test_scheduler.py tests/unit/brain/chat/test_engine.py tests/unit/brain/ingest/test_pipeline.py tests/unit/brain/soul/test_review.py -q
- python3 -m pytest -q
- python3 -m ruff check .
- git diff --check