### PR TITLE
feat: add release readiness status surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,48 @@
+# Changelog
+
+All notable changes to companion-emergence will be tracked here.
+
+The project is still private/local-first during development. Entries below describe private release readiness, not a public stable API promise.
+
+## 0.0.1 - Unreleased
+
+### Added
+
+- Local-first persona data layout under the platform-aware `NELLBRAIN_HOME` root.
+- `nell` CLI entry point with migration, chat, bridge, health, soul, growth, dream, heartbeat, reflex, research, interest, and status surfaces.
+- `nell status` for checking a persona directory, provider/searcher config, memory database count, and bridge process state without contacting live providers.
+- Bridge HTTP/WebSocket server with local bearer-token authentication, session lifecycle endpoints, health checks, audit-safe event streaming, and dirty-shutdown recovery hooks.
+- Chat/session flow with memory retrieval, body/emotion state context, persistence metadata, and local ingestion on session close.
+- SQLite memory store, Hebbian associations, embedding cache, and health/self-healing support for local data files.
+- Soul candidate queue, review workflow, audit logging, duplicate-safe acceptance, and revocation support.
+- Growth scheduler and crystallizers for identity, preferences, relationships, style, and vocabulary.
+- MCP server tools with configurable audit logging modes: `off`, `metadata`, `redacted`, and `full`.
+- Release checklist for private smoke testing and future public/tagged releases.
+
+### Changed
+
+- Stub CLI commands intentionally exit non-zero until implemented, so incomplete surfaces are visible instead of silently pretending to work.
+- Provider-backed growth paths are guarded so local tests and dry runs do not accidentally hang on live provider calls.
+- Memory hot paths can avoid expensive integrity checks while health checks retain deeper verification.
+- Empty memory text searches are rejected; callers that want broad listing must use explicit listing APIs.
+
+### Security and privacy
+
+- WebSocket authentication uses bearer subprotocol headers instead of URL query-string tokens.
+- Bridge state files are protected with owner-only permissions where the platform supports POSIX permission bits.
+- MCP tool audit logging redacts sensitive arguments by default.
+- Status output does not print bridge bearer tokens.
+
+### Fixed
+
+- Chat persistence failures are surfaced in response metadata instead of disappearing silently.
+- Soul queue write failures increment explicit ingest error counts.
+- Soul review acceptance is retry/duplicate safe.
+- Windows CI no longer uses POSIX-only PID liveness probes.
+- Tests no longer assume POSIX chmod behavior on Windows or distinct timestamps from immediate back-to-back calls.
+
+### Known incomplete surfaces
+
+- `nell supervisor`, `nell rest`, `nell memory`, and `nell works` remain intentional future-work stubs.
+- Public release automation is deferred until the CLI/API surface is stable enough to version.
+- Public contributor documentation is not yet written because the project remains private during development.

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ The framework's design lives in [`docs/source-spec/`](docs/source-spec/). Read t
 
 Active local-first prototype. The bridge, chat/session flow, memory ingest, soul review, health checks, and test/lint gates are implemented enough for private development and local smoke testing.
 
-Known incomplete surfaces remain intentional and visible: some CLI commands are wired as future-work stubs and exit non-zero. See [`docs/release-checklist.md`](docs/release-checklist.md) before any public/tagged release.
+Known incomplete surfaces remain intentional and visible: some CLI commands are wired as future-work stubs and exit non-zero. See [`docs/roadmap.md`](docs/roadmap.md) and [`docs/release-checklist.md`](docs/release-checklist.md) before any public/tagged release.
+
+Operational quick check: `nell status --persona nell` reports local persona/config/memory/bridge state without contacting live providers.
 
 Reference implementation: Nell (migrates from the NellBrain OG project). Other personas arrive as forkers build them.

--- a/brain/cli.py
+++ b/brain/cli.py
@@ -13,6 +13,7 @@ from collections.abc import Callable
 from pathlib import Path
 
 from brain import __version__
+from brain.bridge import state_file
 from brain.bridge.provider import get_provider
 from brain.emotion.persona_loader import load_persona_vocabulary
 from brain.engines._interests import InterestSet
@@ -26,7 +27,7 @@ from brain.health.walker import walk_persona
 from brain.memory.hebbian import HebbianMatrix
 from brain.memory.store import MemoryStore
 from brain.migrator.cli import build_parser as _build_migrate_parser
-from brain.paths import get_persona_dir
+from brain.paths import get_home, get_persona_dir
 from brain.persona_config import PersonaConfig
 from brain.search.factory import get_searcher
 from brain.utils.time import iso_utc
@@ -48,7 +49,6 @@ def _resolve_routing(persona_dir: Path, args: argparse.Namespace) -> tuple[str, 
 # filled in across Weeks 2-8 as respective modules come online.
 _STUB_COMMANDS: tuple[str, ...] = (
     "supervisor",
-    "status",
     "rest",
     "memory",
     "works",
@@ -71,6 +71,65 @@ def _make_stub(name: str) -> Callable[[argparse.Namespace], int]:
         return 2
 
     return _handler
+
+
+def _status_handler(args: argparse.Namespace) -> int:
+    """Print local persona/bridge status without making provider calls or writes."""
+    persona_dir = get_persona_dir(args.persona)
+    persona_exists = persona_dir.exists()
+
+    print(f"companion-emergence {__version__}")
+    print(f"home: {get_home()}")
+    print(f"persona: {args.persona}")
+    print(f"persona_dir: {persona_dir}")
+    print(f"persona_exists: {'yes' if persona_exists else 'no'}")
+
+    state = state_file.read(persona_dir)
+    if not persona_exists:
+        _print_bridge_status(state)
+        return 1
+
+    config = PersonaConfig.load(persona_dir / "persona_config.json")
+    print(f"provider: {config.provider}")
+    print(f"searcher: {config.searcher}")
+    print(f"mcp_audit_log_level: {config.mcp_audit_log_level}")
+
+    memory_path = persona_dir / "memories.db"
+    if memory_path.exists():
+        store = MemoryStore(memory_path, integrity_check=False)
+        try:
+            print(f"memories_active: {store.count(active_only=True)}")
+        finally:
+            store.close()
+    else:
+        print("memories_active: missing")
+
+    _print_bridge_status(state)
+    return 0
+
+
+def _print_bridge_status(state: state_file.BridgeState | None) -> None:
+    """Print bridge status while never exposing bearer tokens."""
+    if state is None or state.pid is None:
+        print("bridge: not running")
+        return
+
+    if state_file.pid_is_alive(state.pid):
+        print("bridge: running")
+        print(f"pid: {state.pid}")
+        print(f"port: {state.port or 'unknown'}")
+        print(f"started_at: {state.started_at}")
+        print(f"client_origin: {state.client_origin}")
+        return
+
+    if not state.shutdown_clean:
+        print("bridge: crashed-dirty")
+        print(f"pid: {state.pid}")
+        print("recovery: needed on next bridge start")
+        return
+
+    print("bridge: stopped")
+    print(f"stopped_at: {state.stopped_at or 'unknown'}")
 
 
 def _dream_handler(args: argparse.Namespace) -> int:
@@ -997,6 +1056,17 @@ def _build_parser() -> argparse.ArgumentParser:
             help=f"(stub) {name} — wired in a later week",
         )
         sub.set_defaults(func=_make_stub(name))
+
+    status_sub = subparsers.add_parser(
+        "status",
+        help="Show local persona, memory, and bridge status without contacting providers.",
+    )
+    status_sub.add_argument(
+        "--persona",
+        default="nell",
+        help="Persona name to inspect. Defaults to nell.",
+    )
+    status_sub.set_defaults(func=_status_handler)
 
     _build_migrate_parser(subparsers)
 

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -24,7 +24,8 @@ This project is private/local-first during development. Before sharing a public 
 ## Packaging/versioning
 
 - Set the intended version in `pyproject.toml`.
-- Add or update `CHANGELOG.md` once the project is public-facing.
+- Add or update `CHANGELOG.md` before tagging or sharing a build.
+- Review `docs/roadmap.md` and confirm known stubs/incomplete surfaces are documented.
 - Build the wheel/sdist only after tests and lint pass.
 - Do not add release automation until the CLI/API surface is stable enough to version.
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,96 @@
+# Roadmap
+
+This roadmap keeps the project’s remaining work honest after the April 2026 audit remediation. It is not a public release promise; companion-emergence is still private/local-first during development.
+
+## Current posture
+
+The framework is a private prototype with enough implemented surface for local smoke testing:
+
+- CLI entry point: `nell`
+- local persona storage via `NELLBRAIN_HOME`
+- bridge daemon and HTTP/WebSocket API
+- chat/session lifecycle
+- memory ingest and retrieval
+- body/emotion context
+- soul candidate review
+- growth scheduler/crystallizers
+- MCP tool server with privacy-aware audit logging
+- health checks and data-file self-healing
+- test/lint gates across Linux, macOS, and Windows CI
+
+## Near-term priorities
+
+### 1. Keep private release readiness boring and repeatable
+
+- Maintain `CHANGELOG.md` for every meaningful behavior, privacy, packaging, or release-readiness change.
+- Keep `docs/release-checklist.md` as the gate before any tagged/public build.
+- Add or maintain smoke-test coverage for the full local companion loop:
+  - create session
+  - send chat turn
+  - close session
+  - ingest memories
+  - run active soul/growth paths
+  - confirm bridge auth does not leak tokens in URLs or logs
+
+### 2. Replace stubs with useful CLI commands one at a time
+
+Current intentional stubs:
+
+- `nell supervisor`
+- `nell rest`
+- `nell memory`
+- `nell works`
+
+Rules for stubs:
+
+- Stubs must exit non-zero.
+- Stubs must say they are not implemented.
+- Stubs must stay listed here until implemented.
+- Each implementation needs tests before the stub is removed.
+
+Suggested order:
+
+1. `nell memory` — inspect/list/search local memories safely.
+2. `nell supervisor` — expose bridge/supervisor lifecycle in one operator-facing place.
+3. `nell rest` — clarify whether this is sleep/rest cadence, bridge rest, or old-plan residue before implementing.
+4. `nell works` — define the user story before building; the name is currently ambiguous.
+
+### 3. Firm up packaging before public release automation
+
+Current packaging state:
+
+- `pyproject.toml` defines package metadata and the `nell` script.
+- Wheel packaging includes the `brain` package.
+- Release automation is intentionally deferred.
+
+Before public/tagged release:
+
+- Build and inspect wheel/sdist artifacts.
+- Install the built wheel in a clean virtual environment.
+- Run CLI smoke tests from the installed package, not just the source tree.
+- Decide whether non-Python assets need explicit package-data rules.
+- Add public contributor docs only when the project is meant to receive outside contributions.
+
+### 4. Keep audit findings reconciled with code reality
+
+The April 30 audit remains useful, but several findings have since been fixed. When remediation lands:
+
+- Update the relevant audit note or release checklist.
+- Prefer verified status over stale text.
+- Do not follow old audit ordering blindly without checking current code and tests.
+
+## Public release blockers
+
+These block a public/tagged release, but do not block private local development:
+
+- Remaining intentional CLI stubs are not fully documented in release notes.
+- No clean-install wheel/sdist smoke test has been recorded.
+- Public contributor/onboarding docs are missing.
+- Public API/CLI compatibility policy is not defined.
+- Signing/distribution story is not applicable yet because this is not a desktop app package; if that changes, write a separate release plan.
+
+## Done recently
+
+- Resolved audit reliability issues around chat persistence, soul queue reporting, soul review idempotency, bridge API validation, memory search/listing, pytest markers, MCP audit privacy, add-memory error visibility, and vocabulary crystallization.
+- Hardened cross-platform CI assumptions for Windows PID probing, POSIX-only permission assertions, and timestamp precision flakes.
+- Added `nell status` as the first non-stub operational status surface.

--- a/tests/unit/brain/test_cli.py
+++ b/tests/unit/brain/test_cli.py
@@ -2,9 +2,15 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 
 from brain import cli
+from brain.bridge.state_file import BridgeState
+from brain.bridge.state_file import write as write_bridge_state
+from brain.memory.store import MemoryStore
+from brain.persona_config import PersonaConfig
 
 
 def test_version_flag_prints_version(capsys: pytest.CaptureFixture[str]) -> None:
@@ -28,7 +34,6 @@ def test_no_args_prints_help_and_exits_nonzero(
 
 STUB_COMMANDS = [
     "supervisor",
-    "status",
     "rest",
     "memory",
     "works",
@@ -56,3 +61,74 @@ def test_stub_subcommand_help_works(
     assert exc_info.value.code == 0
     captured = capsys.readouterr()
     assert "supervisor" in captured.out.lower()
+
+
+def _make_persona(tmp_path: Path, name: str = "nell") -> Path:
+    home = tmp_path / "home"
+    persona_dir = home / "personas" / name
+    persona_dir.mkdir(parents=True)
+    return persona_dir
+
+
+def test_status_reports_missing_persona_without_creating_files(
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """`nell status` reports a missing persona and returns non-zero."""
+    home = tmp_path / "home"
+    monkeypatch.setenv("NELLBRAIN_HOME", str(home))
+
+    result = cli.main(["status", "--persona", "nell"])
+
+    assert result == 1
+    assert not (home / "personas" / "nell").exists()
+    captured = capsys.readouterr()
+    assert "companion-emergence" in captured.out
+    assert "persona: nell" in captured.out
+    assert "persona_exists: no" in captured.out
+    assert "bridge: not running" in captured.out
+
+
+def test_status_reports_persona_config_memory_and_bridge_state(
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """`nell status` summarizes local persona health without hitting providers."""
+    persona_dir = _make_persona(tmp_path)
+    monkeypatch.setenv("NELLBRAIN_HOME", str(tmp_path / "home"))
+    PersonaConfig(provider="fake", searcher="noop", mcp_audit_log_level="metadata").save(
+        persona_dir / "persona_config.json"
+    )
+    store = MemoryStore(persona_dir / "memories.db")
+    store.close()
+    write_bridge_state(
+        persona_dir,
+        BridgeState(
+            persona="nell",
+            pid=12345,
+            port=8765,
+            started_at="2026-05-03T12:00:00Z",
+            stopped_at=None,
+            shutdown_clean=False,
+            client_origin="cli",
+            auth_token="secret-token",
+        ),
+    )
+    monkeypatch.setattr(cli.state_file, "pid_is_alive", lambda pid: pid == 12345)
+
+    result = cli.main(["status", "--persona", "nell"])
+
+    assert result == 0
+    captured = capsys.readouterr()
+    assert "persona: nell" in captured.out
+    assert "persona_exists: yes" in captured.out
+    assert "provider: fake" in captured.out
+    assert "searcher: noop" in captured.out
+    assert "mcp_audit_log_level: metadata" in captured.out
+    assert "memories_active: 0" in captured.out
+    assert "bridge: running" in captured.out
+    assert "pid: 12345" in captured.out
+    assert "port: 8765" in captured.out
+    assert "secret-token" not in captured.out


### PR DESCRIPTION
## Summary
- add CHANGELOG and roadmap docs for private release readiness
- update README/release checklist to point at the roadmap
- implement non-provider `nell status --persona <name>` with persona/config/memory/bridge status
- keep bridge bearer tokens out of status output

## Test Plan
- [x] python3 -m pytest -q
- [x] python3 -m ruff check .
- [x] git diff --check
- [x] python3 -m brain.cli status --persona nell
