### PR TITLE
feat(cli): implement nell memory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,9 @@ The project is still private/local-first during development. Entries below descr
 ### Added
 
 - Local-first persona data layout under the platform-aware `NELLBRAIN_HOME` root.
-- `nell` CLI entry point with migration, chat, bridge, health, soul, growth, dream, heartbeat, reflex, research, interest, and status surfaces.
+- `nell` CLI entry point with migration, chat, bridge, health, soul, growth, dream, heartbeat, reflex, research, interest, status, and memory inspection surfaces.
 - `nell status` for checking a persona directory, provider/searcher config, memory database count, and bridge process state without contacting live providers.
+- `nell memory list/search/show` for safe local memory inspection without contacting live providers.
 - Bridge HTTP/WebSocket server with local bearer-token authentication, session lifecycle endpoints, health checks, audit-safe event streaming, and dirty-shutdown recovery hooks.
 - Chat/session flow with memory retrieval, body/emotion state context, persistence metadata, and local ingestion on session close.
 - SQLite memory store, Hebbian associations, embedding cache, and health/self-healing support for local data files.
@@ -43,6 +44,6 @@ The project is still private/local-first during development. Entries below descr
 
 ### Known incomplete surfaces
 
-- `nell supervisor`, `nell rest`, `nell memory`, and `nell works` remain intentional future-work stubs.
+- `nell supervisor`, `nell rest`, and `nell works` remain intentional future-work stubs.
 - Public release automation is deferred until the CLI/API surface is stable enough to version.
 - Public contributor documentation is not yet written because the project remains private during development.

--- a/README.md
+++ b/README.md
@@ -16,4 +16,6 @@ Known incomplete surfaces remain intentional and visible: some CLI commands are 
 
 Operational quick check: `nell status --persona nell` reports local persona/config/memory/bridge state without contacting live providers.
 
+Memory inspection is local-only and explicit: use `nell memory list --persona nell`, `nell memory search "query" --persona nell`, and `nell memory show <memory_id> --persona nell`.
+
 Reference implementation: Nell (migrates from the NellBrain OG project). Other personas arrive as forkers build them.

--- a/brain/cli.py
+++ b/brain/cli.py
@@ -8,6 +8,7 @@ surface is stable while subsequent weeks fill in functionality.
 from __future__ import annotations
 
 import argparse
+import json
 import sys
 from collections.abc import Callable
 from pathlib import Path
@@ -25,7 +26,7 @@ from brain.health.alarm import compute_pending_alarms
 from brain.health.jsonl_reader import read_jsonl_skipping_corrupt
 from brain.health.walker import walk_persona
 from brain.memory.hebbian import HebbianMatrix
-from brain.memory.store import MemoryStore
+from brain.memory.store import Memory, MemoryStore
 from brain.migrator.cli import build_parser as _build_migrate_parser
 from brain.paths import get_home, get_persona_dir
 from brain.persona_config import PersonaConfig
@@ -50,7 +51,6 @@ def _resolve_routing(persona_dir: Path, args: argparse.Namespace) -> tuple[str, 
 _STUB_COMMANDS: tuple[str, ...] = (
     "supervisor",
     "rest",
-    "memory",
     "works",
 )
 
@@ -130,6 +130,126 @@ def _print_bridge_status(state: state_file.BridgeState | None) -> None:
 
     print("bridge: stopped")
     print(f"stopped_at: {state.stopped_at or 'unknown'}")
+
+
+def _open_memory_store_for_cli(persona: str) -> tuple[MemoryStore | None, int]:
+    """Open a persona memory store for read-only CLI inspection."""
+    persona_dir = get_persona_dir(persona)
+    if not persona_dir.exists():
+        print(f"No persona directory at {persona_dir}.", file=sys.stderr)
+        return None, 1
+
+    memory_path = persona_dir / "memories.db"
+    if not memory_path.exists():
+        print(f"No memory store at {memory_path}.", file=sys.stderr)
+        return None, 1
+
+    return MemoryStore(memory_path, integrity_check=False), 0
+
+
+def _memory_preview(content: str, *, limit: int = 72) -> str:
+    """Return a compact single-line memory preview."""
+    single_line = " ".join(content.split())
+    if len(single_line) <= limit:
+        return single_line
+    return single_line[: limit - 1].rstrip() + "…"
+
+
+def _positive_int(value: str) -> int:
+    """Parse a positive integer CLI argument."""
+    try:
+        parsed = int(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("must be a positive integer") from exc
+    if parsed < 1:
+        raise argparse.ArgumentTypeError("must be a positive integer")
+    return parsed
+
+
+def _print_memory_rows(title: str, memories: list[Memory]) -> None:
+    """Print compact memory rows for list/search output."""
+    print(title)
+    if not memories:
+        print("(none)")
+        return
+
+    for memory in memories:
+        print(
+            f"{memory.id[:8]}  {memory.created_at.date().isoformat()}  "
+            f"{memory.memory_type}/{memory.domain}  "
+            f"importance={memory.importance:.2f}  {_memory_preview(memory.content)}"
+        )
+
+
+def _format_mapping(mapping: dict[str, object]) -> str:
+    """Format small dicts deterministically for CLI output."""
+    if not mapping:
+        return "(none)"
+    return ", ".join(f"{key}={float(value):.2f}" for key, value in sorted(mapping.items()))
+
+
+def _memory_list_handler(args: argparse.Namespace) -> int:
+    """List recent active memories for a persona."""
+    store, rc = _open_memory_store_for_cli(args.persona)
+    if store is None:
+        return rc
+    try:
+        memories = store.list_active(limit=args.limit)
+    finally:
+        store.close()
+
+    _print_memory_rows(f"active memories for {args.persona}", memories)
+    return 0
+
+
+def _memory_search_handler(args: argparse.Namespace) -> int:
+    """Search active memories by non-empty text query."""
+    query = args.query.strip()
+    if not query:
+        print("query must not be empty", file=sys.stderr)
+        return 2
+
+    store, rc = _open_memory_store_for_cli(args.persona)
+    if store is None:
+        return rc
+    try:
+        memories = store.search_text(query, limit=args.limit)
+    finally:
+        store.close()
+
+    _print_memory_rows(f"memory search for {args.persona}: {query}", memories)
+    return 0
+
+
+def _memory_show_handler(args: argparse.Namespace) -> int:
+    """Show one full memory record by id."""
+    store, rc = _open_memory_store_for_cli(args.persona)
+    if store is None:
+        return rc
+    try:
+        memory = store.get(args.memory_id)
+    finally:
+        store.close()
+
+    if memory is None:
+        print(f"unknown memory id: {args.memory_id}", file=sys.stderr)
+        return 1
+
+    print(f"id: {memory.id}")
+    print(f"type: {memory.memory_type}")
+    print(f"domain: {memory.domain}")
+    print(f"created_at: {memory.created_at.isoformat()}")
+    print(f"last_accessed_at: {memory.last_accessed_at.isoformat() if memory.last_accessed_at else '(never)'}")
+    print(f"importance: {memory.importance:.2f}")
+    print(f"score: {memory.score:.2f}")
+    print(f"active: {'yes' if memory.active else 'no'}")
+    print(f"protected: {'yes' if memory.protected else 'no'}")
+    print(f"tags: {', '.join(memory.tags) if memory.tags else '(none)'}")
+    print(f"emotions: {_format_mapping(memory.emotions)}")
+    print(f"metadata: {json.dumps(memory.metadata, sort_keys=True)}")
+    print("content:")
+    print(memory.content)
+    return 0
 
 
 def _dream_handler(args: argparse.Namespace) -> int:
@@ -1067,6 +1187,38 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Persona name to inspect. Defaults to nell.",
     )
     status_sub.set_defaults(func=_status_handler)
+
+    memory_sub = subparsers.add_parser(
+        "memory",
+        help="Inspect local persona memories safely.",
+    )
+    memory_actions = memory_sub.add_subparsers(dest="action", required=True)
+
+    memory_list = memory_actions.add_parser("list", help="List recent active memories.")
+    memory_list.add_argument("--persona", default="nell", help="Persona name. Defaults to nell.")
+    memory_list.add_argument(
+        "--limit",
+        type=_positive_int,
+        default=20,
+        help="Maximum active memories to show (default 20).",
+    )
+    memory_list.set_defaults(func=_memory_list_handler)
+
+    memory_search = memory_actions.add_parser("search", help="Search active memories by text.")
+    memory_search.add_argument("query", help="Non-empty text to search for.")
+    memory_search.add_argument("--persona", default="nell", help="Persona name. Defaults to nell.")
+    memory_search.add_argument(
+        "--limit",
+        type=_positive_int,
+        default=20,
+        help="Maximum matching memories to show (default 20).",
+    )
+    memory_search.set_defaults(func=_memory_search_handler)
+
+    memory_show = memory_actions.add_parser("show", help="Show one full memory by id.")
+    memory_show.add_argument("memory_id", help="Memory UUID to inspect.")
+    memory_show.add_argument("--persona", default="nell", help="Persona name. Defaults to nell.")
+    memory_show.set_defaults(func=_memory_show_handler)
 
     _build_migrate_parser(subparsers)
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -11,6 +11,7 @@ The framework is a private prototype with enough implemented surface for local s
 - bridge daemon and HTTP/WebSocket API
 - chat/session lifecycle
 - memory ingest and retrieval
+- safe memory inspection through `nell memory list/search/show`
 - body/emotion context
 - soul candidate review
 - growth scheduler/crystallizers
@@ -38,7 +39,6 @@ Current intentional stubs:
 
 - `nell supervisor`
 - `nell rest`
-- `nell memory`
 - `nell works`
 
 Rules for stubs:
@@ -50,10 +50,9 @@ Rules for stubs:
 
 Suggested order:
 
-1. `nell memory` — inspect/list/search local memories safely.
-2. `nell supervisor` — expose bridge/supervisor lifecycle in one operator-facing place.
-3. `nell rest` — clarify whether this is sleep/rest cadence, bridge rest, or old-plan residue before implementing.
-4. `nell works` — define the user story before building; the name is currently ambiguous.
+1. `nell supervisor` — expose bridge/supervisor lifecycle in one operator-facing place.
+2. `nell rest` — clarify whether this is sleep/rest cadence, bridge rest, or old-plan residue before implementing.
+3. `nell works` — define the user story before building; the name is currently ambiguous.
 
 ### 3. Firm up packaging before public release automation
 
@@ -94,3 +93,4 @@ These block a public/tagged release, but do not block private local development:
 - Resolved audit reliability issues around chat persistence, soul queue reporting, soul review idempotency, bridge API validation, memory search/listing, pytest markers, MCP audit privacy, add-memory error visibility, and vocabulary crystallization.
 - Hardened cross-platform CI assumptions for Windows PID probing, POSIX-only permission assertions, and timestamp precision flakes.
 - Added `nell status` as the first non-stub operational status surface.
+- Added `nell memory list/search/show` for safe local inspection of a persona's memory store.

--- a/tests/unit/brain/test_cli.py
+++ b/tests/unit/brain/test_cli.py
@@ -35,7 +35,6 @@ def test_no_args_prints_help_and_exits_nonzero(
 STUB_COMMANDS = [
     "supervisor",
     "rest",
-    "memory",
     "works",
 ]
 

--- a/tests/unit/brain/test_cli_memory.py
+++ b/tests/unit/brain/test_cli_memory.py
@@ -1,0 +1,200 @@
+"""Tests for the `nell memory` CLI surface."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from brain import cli
+from brain.memory.store import Memory, MemoryStore
+
+
+def _make_persona_with_memories(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    home = tmp_path / "home"
+    persona_dir = home / "personas" / "nell"
+    persona_dir.mkdir(parents=True)
+    monkeypatch.setenv("NELLBRAIN_HOME", str(home))
+    return persona_dir
+
+
+def _store_memory(persona_dir: Path, memory: Memory) -> str:
+    store = MemoryStore(persona_dir / "memories.db")
+    try:
+        return store.create(memory)
+    finally:
+        store.close()
+
+
+def test_memory_list_prints_recent_active_memories(
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """`nell memory list` shows a safe compact view of active memories."""
+    persona_dir = _make_persona_with_memories(tmp_path, monkeypatch)
+    first_id = _store_memory(
+        persona_dir,
+        Memory.create_new(
+            "Hana likes peach tea during late debugging sessions.",
+            memory_type="conversation",
+            domain="us",
+            emotions={"warmth": 7.0},
+            tags=["hana", "tea"],
+            importance=6.5,
+        ),
+    )
+    second_id = _store_memory(
+        persona_dir,
+        Memory.create_new(
+            "Nell should keep release notes honest and boring.",
+            memory_type="meta",
+            domain="craft",
+            emotions={},
+            tags=[],
+            importance=4.0,
+        ),
+    )
+
+    result = cli.main(["memory", "list", "--persona", "nell", "--limit", "5"])
+
+    assert result == 0
+    captured = capsys.readouterr()
+    assert "active memories for nell" in captured.out
+    assert second_id[:8] in captured.out
+    assert first_id[:8] in captured.out
+    assert "meta" in captured.out
+    assert "conversation" in captured.out
+    assert "Nell should keep release notes honest" in captured.out
+    assert "Hana likes peach tea" in captured.out
+
+
+def test_memory_list_rejects_negative_limit(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """`nell memory list` rejects negative limits that could dump too much."""
+    _make_persona_with_memories(tmp_path, monkeypatch)
+
+    with pytest.raises(SystemExit) as excinfo:
+        cli.main(["memory", "list", "--persona", "nell", "--limit", "-1"])
+
+    assert excinfo.value.code == 2
+
+
+def test_memory_search_requires_non_empty_query(
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """`nell memory search` rejects blank queries instead of scanning everything."""
+    _make_persona_with_memories(tmp_path, monkeypatch)
+
+    result = cli.main(["memory", "search", "", "--persona", "nell"])
+
+    assert result == 2
+    captured = capsys.readouterr()
+    assert "query must not be empty" in captured.err.lower()
+
+
+def test_memory_search_prints_matching_memories(
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """`nell memory search` uses the memory store text search."""
+    persona_dir = _make_persona_with_memories(tmp_path, monkeypatch)
+    matching_id = _store_memory(
+        persona_dir,
+        Memory.create_new(
+            "The bridge status command must never print bearer tokens.",
+            memory_type="security",
+            domain="craft",
+            importance=8.0,
+        ),
+    )
+    _store_memory(
+        persona_dir,
+        Memory.create_new(
+            "Peaches slept on the laptop again.",
+            memory_type="conversation",
+            domain="us",
+        ),
+    )
+
+    result = cli.main(["memory", "search", "bearer", "--persona", "nell"])
+
+    assert result == 0
+    captured = capsys.readouterr()
+    assert "memory search for nell" in captured.out
+    assert matching_id[:8] in captured.out
+    assert "bearer tokens" in captured.out
+    assert "Peaches" not in captured.out
+
+
+def test_memory_show_prints_full_memory_details(
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """`nell memory show` prints one complete memory record by id."""
+    persona_dir = _make_persona_with_memories(tmp_path, monkeypatch)
+    memory_id = _store_memory(
+        persona_dir,
+        Memory.create_new(
+            "Hana trusts small surgical commits more than sprawling rewrites.",
+            memory_type="preference",
+            domain="craft",
+            emotions={"trust": 8.0, "focus": 6.0},
+            tags=["coding", "style"],
+            importance=9.0,
+            metadata={"source": "test"},
+        ),
+    )
+
+    result = cli.main(["memory", "show", memory_id, "--persona", "nell"])
+
+    assert result == 0
+    captured = capsys.readouterr()
+    assert f"id: {memory_id}" in captured.out
+    assert "type: preference" in captured.out
+    assert "domain: craft" in captured.out
+    assert "importance: 9.00" in captured.out
+    assert "tags: coding, style" in captured.out
+    assert "emotions: focus=6.00, trust=8.00" in captured.out
+    assert 'metadata: {"source": "test"}' in captured.out
+    assert "Hana trusts small surgical commits" in captured.out
+
+
+def test_memory_show_unknown_id_returns_nonzero(
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """`nell memory show` reports unknown ids cleanly."""
+    persona_dir = _make_persona_with_memories(tmp_path, monkeypatch)
+    store = MemoryStore(persona_dir / "memories.db")
+    store.close()
+
+    result = cli.main(["memory", "show", "missing-id", "--persona", "nell"])
+
+    assert result == 1
+    captured = capsys.readouterr()
+    assert "unknown memory id" in captured.err.lower()
+
+
+def test_memory_missing_persona_returns_nonzero(
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """`nell memory` does not create persona folders as a side effect."""
+    home = tmp_path / "home"
+    monkeypatch.setenv("NELLBRAIN_HOME", str(home))
+
+    result = cli.main(["memory", "list", "--persona", "nell"])
+
+    assert result == 1
+    assert not (home / "personas" / "nell").exists()
+    captured = capsys.readouterr()
+    assert "no persona directory" in captured.err.lower()


### PR DESCRIPTION
## Summary
- implement `nell memory list/search/show` for safe local persona memory inspection
- keep list/search output compact and require explicit `show <memory_id>` for full memory content
- reject blank searches and non-positive limits so broad dumps stay intentional
- update README, changelog, and roadmap to mark `nell memory` complete

## Test Plan
- [x] `python3 -m pytest tests/unit/brain/test_cli.py tests/unit/brain/test_cli_memory.py -q`
- [x] `python3 -m pytest -q`
- [x] `python3 -m ruff check .`
- [x] `git diff --check`
- [x] `python3 -m brain.cli memory list --persona nell --limit 3`
