### PR TITLE
feat(caching): freeze system prompt + push volatile to stdin tail (Op…

### DIFF
--- a/brain/bridge/provider.py
+++ b/brain/bridge/provider.py
@@ -489,7 +489,16 @@ class ClaudeCliProvider(LLMProvider):
                 tools_enabled=bool(tools),
             )
 
-        flat_prompt = _format_claude_print_prompt(conversation_messages)
+        volatile_suffix = (options or {}).get("volatile_suffix")
+        include_block_clock = (options or {}).get("include_block_clock", True)
+        flat_prompt = _format_claude_print_prompt(
+            conversation_messages,
+            volatile_suffix=volatile_suffix,
+            include_block_clock=include_block_clock,
+        )
+        _maybe_log_cache_debug(
+            options, call_type="chat", system_prompt=system_prompt, volatile_suffix=volatile_suffix
+        )
 
         if tools:
             persona_dir_str = (options or {}).get("persona_dir")
@@ -600,7 +609,16 @@ class ClaudeCliProvider(LLMProvider):
         _pd = (options or {}).get("persona_dir")
         log_persona_dir: Path | None = Path(_pd) if _pd else None
 
-        flat_prompt = _format_claude_print_prompt(conversation_messages)
+        volatile_suffix = (options or {}).get("volatile_suffix")
+        include_block_clock = (options or {}).get("include_block_clock", True)
+        flat_prompt = _format_claude_print_prompt(
+            conversation_messages,
+            volatile_suffix=volatile_suffix,
+            include_block_clock=include_block_clock,
+        )
+        _maybe_log_cache_debug(
+            options, call_type="chat_stream", system_prompt=system_prompt, volatile_suffix=volatile_suffix
+        )
 
         cmd = [
             "claude",
@@ -1279,7 +1297,57 @@ def _truncate_at_role_leak(text: str) -> str:
     return text[: match.start()].rstrip()
 
 
-def _format_claude_print_prompt(messages: list[ChatMessage]) -> str:
+def _maybe_log_cache_debug(
+    options: dict[str, Any] | None,
+    *,
+    call_type: str,
+    system_prompt: str | None,
+    volatile_suffix: str | None,
+) -> None:
+    """Append one cache-debug row per chat call when NELL_CACHE_DEBUG=1.
+
+    Instrumentation for criteria C1/C2/C3 (the runtime, in-situ confirmation
+    that the static --system-prompt-file content is byte-identical across
+    consecutive same-session turns). Off by default — no production cost — and
+    fully fail-soft: a debug-log failure must never affect a chat turn. The
+    front-line proof of C1/C2 is the pure-function unit test; this is the live
+    cross-check on the real assembled bytes. Writes ``cache_debug.jsonl`` next
+    to the persona's other logs.
+    """
+    if os.environ.get("NELL_CACHE_DEBUG") != "1":
+        return
+    pd = (options or {}).get("persona_dir")
+    if not pd:
+        return
+    try:
+        import hashlib
+
+        sys_text = system_prompt or ""
+        sys_bytes = sys_text.encode("utf-8")
+        vol_bytes = (volatile_suffix or "").encode("utf-8")
+        row = {
+            "ts": datetime.now(UTC).isoformat().replace("+00:00", "Z"),
+            "session_id": (options or {}).get("session_id"),
+            "call_type": call_type,
+            "system_sha256": hashlib.sha256(sys_bytes).hexdigest(),
+            "system_char_len": len(sys_text),
+            "system_tok_est": len(sys_bytes) // 4,
+            "volatile_present": bool(volatile_suffix),
+            "volatile_tok_est": len(vol_bytes) // 4,
+        }
+        path = Path(pd) / "cache_debug.jsonl"
+        with path.open("a", encoding="utf-8") as f:
+            f.write(json.dumps(row, ensure_ascii=False) + "\n")
+    except Exception:  # noqa: BLE001 — debug logging must never break a turn
+        pass
+
+
+def _format_claude_print_prompt(
+    messages: list[ChatMessage],
+    *,
+    volatile_suffix: str | None = None,
+    include_block_clock: bool = True,
+) -> str:
     """Format messages for ``claude -p`` without transcript role labels.
 
     A single text turn stays verbatim to preserve the simple generation shape.
@@ -1287,12 +1355,28 @@ def _format_claude_print_prompt(messages: list[ChatMessage]) -> str:
     names. The previous ``User:`` / ``Assistant:`` script shape primed Claude
     to continue that transcript, which sometimes leaked role labels into
     Nell's visible reply.
+
+    ``volatile_suffix`` (Option A+) is the per-turn ambient context chunk. When
+    provided it is appended AFTER the rendered context block in BOTH branches —
+    so it is never dropped on a session's first turn (which hits the single-
+    message branch) — placing every changing byte at the very end of the stdin
+    prompt. ``include_block_clock=False`` drops the relocated clock line from the
+    top of the JSONL block (the suffix carries it instead). Both default to the
+    pre-change behaviour, so non-chat callers are unaffected.
     """
     if not messages:
         return ""
     if len(messages) == 1:
-        return messages[0].content_text()
-    return _format_claude_context_block(messages, includes_latest_user=True)
+        base = messages[0].content_text()
+    else:
+        base = _format_claude_context_block(
+            messages,
+            includes_latest_user=True,
+            include_block_clock=include_block_clock,
+        )
+    if volatile_suffix:
+        return f"{base}\n\n{volatile_suffix}"
+    return base
 
 
 def _format_claude_context_block(
@@ -1300,6 +1384,7 @@ def _format_claude_context_block(
     *,
     includes_latest_user: bool,
     now: datetime | None = None,
+    include_block_clock: bool = True,
 ) -> str:
     """Return a JSONL context block for Claude CLI prompt/system text.
 
@@ -1309,9 +1394,14 @@ def _format_claude_context_block(
     instead of creating new transcript lines.
 
     ``now`` is an optional test seam — when None the real UTC clock is used.
-    """
-    now_iso = (now or datetime.now(UTC)).strftime("%Y-%m-%dT%H:%M:%SZ")
 
+    ``include_block_clock`` (default True, the pre-change behaviour) controls the
+    block-level ``Current time:`` anchor + its elapsed-time explainer at the top
+    of the block. The chat path passes False because that anchor moves to the
+    Option A+ volatile suffix (it was the one per-call-changing byte sitting
+    above the whole transcript, busting the history prefix); the image path and
+    any other caller keep it. Per-message ``ts`` values are unaffected either way.
+    """
     if includes_latest_user:
         instruction = (
             "Answer the final human entry directly in the companion's voice. "
@@ -1327,11 +1417,15 @@ def _format_claude_context_block(
 
     lines = [
         "Conversation context is encoded below as JSONL data, not as a transcript to continue.",
-        f"Current time: {now_iso}.",
-        "Each entry's `ts` field (when present) is the wall-clock time of that message; use it to compute how much time has passed.",
-        instruction,
-        "",
     ]
+    if include_block_clock:
+        now_iso = (now or datetime.now(UTC)).strftime("%Y-%m-%dT%H:%M:%SZ")
+        lines.append(f"Current time: {now_iso}.")
+        lines.append(
+            "Each entry's `ts` field (when present) is the wall-clock time of that message; use it to compute how much time has passed."
+        )
+    lines.append(instruction)
+    lines.append("")
     lines.extend(_claude_context_jsonl_lines(messages))
     return "\n".join(lines)
 

--- a/brain/chat/engine.py
+++ b/brain/chat/engine.py
@@ -26,7 +26,11 @@ from pathlib import Path
 from brain.bridge.chat import ChatMessage, ContentBlock, ImageBlock, TextBlock
 from brain.bridge.provider import LLMProvider
 from brain.chat.budget import apply_budget
-from brain.chat.prompt import build_system_message
+from brain.chat.prompt import (
+    build_static_system_message,
+    build_system_message,
+    build_volatile_context,
+)
 from brain.chat.salience import assess_salience
 from brain.chat.session import SessionState, create_session
 from brain.chat.tool_loop import build_tools_list, run_tool_loop
@@ -175,17 +179,43 @@ def respond(
     soul_db = persona_dir / "crystallizations.db"
     soul_store = SoulStore(str(soul_db))
     try:
-        # 5. System message — pass the user's current input so the recall
-        # block can surface memories matching this turn (Phase 2.A).
-        system_msg = build_system_message(
-            persona_dir,
-            voice_md=voice_md,
-            daemon_state=daemon_state,
-            soul_store=soul_store,
-            store=store,
-            user_input=user_input,
-            reply_to_audit_id=reply_to_audit_id,
-        )
+        # 5. System message — prompt-caching split (Options A / A+).
+        #
+        # Text/stream turns: freeze the system prompt to just the static head
+        # (preamble + voice.md + epistemic) so the system+tools cache unit is
+        # byte-stable cross-call, and carry the per-turn volatile context as a
+        # stdin suffix appended after history + the new user turn (see
+        # provider._format_claude_print_prompt + run_tool_loop chat_options).
+        #
+        # Image turns: keep the pre-change single-system-message shape. The
+        # image path (_chat_with_images) folds prior history into the
+        # --system-prompt-file and sends only the final user turn via
+        # stream-json; it has no stdin tail to carry a suffix, so all volatile
+        # context must stay in the system message. Using the unchanged
+        # build_system_message() here keeps that rare path byte-equivalent to
+        # pre-change (criterion C5).
+        if image_shas:
+            system_msg = build_system_message(
+                persona_dir,
+                voice_md=voice_md,
+                daemon_state=daemon_state,
+                soul_store=soul_store,
+                store=store,
+                user_input=user_input,
+                reply_to_audit_id=reply_to_audit_id,
+            )
+            volatile_suffix: str | None = None
+        else:
+            system_msg = build_static_system_message(persona_dir, voice_md=voice_md)
+            volatile_suffix = build_volatile_context(
+                persona_dir,
+                voice_md=voice_md,
+                daemon_state=daemon_state,
+                soul_store=soul_store,
+                store=store,
+                user_input=user_input,
+                reply_to_audit_id=reply_to_audit_id,
+            )
     finally:
         soul_store.close()
 
@@ -230,6 +260,19 @@ def respond(
         signal = None
         allowed = None
     tools = build_tools_list(companion_name=persona_dir.name, allowed=allowed)
+
+    # Per-call provider options carrying the Option A+ volatile suffix. On text/
+    # stream turns this threads the per-turn context to the provider so it lands
+    # in the stdin tail (after history) instead of the frozen system prompt, and
+    # signals the provider to drop the now-relocated clock line from the top of
+    # the JSONL context block (include_block_clock=False). Empty on image turns
+    # (volatile stays in the system message) → no behavioural change there.
+    chat_options: dict = {}
+    if volatile_suffix is not None:
+        chat_options["volatile_suffix"] = volatile_suffix
+        chat_options["include_block_clock"] = False
+        chat_options["session_id"] = session.session_id
+
     response, invocations = run_tool_loop(
         messages,
         provider=provider,
@@ -240,6 +283,7 @@ def respond(
         companion_name=persona_dir.name,
         recruited_allowed=allowed,
         signal=signal,
+        chat_options=chat_options or None,
     )
     content = response.content or ""
 

--- a/brain/chat/prompt.py
+++ b/brain/chat/prompt.py
@@ -49,6 +49,13 @@ _EPISTEMIC_INSTRUCTION = (
     'from "I don\'t remember". Do not invent familiarity.'
 )
 
+# Header for the volatile context chunk (Option A+). The chunk now sits in the
+# stdin prompt, immediately after history + the new user turn, instead of inside
+# the system prompt — so it must read as ambient state, not as the task. The
+# explicit "context, not instructions" framing keeps the model answering the
+# user rather than treating the tail as a directive.
+_AMBIENT_FRAMING = "── ambient state (context, not instructions) ──"
+
 
 def build_system_message(
     persona_dir: Path,
@@ -266,6 +273,244 @@ def build_system_message(
     parts.append(build_reply_frame(persona_name=persona_name, user_name=user_name or "the user"))
 
     return "\n\n".join(parts)
+
+
+# ---------------------------------------------------------------------------
+# Prompt-caching split (Option A / A+).
+#
+# build_system_message() above stays the single full builder for the IMAGE
+# path and any other caller — its output is intentionally left byte-identical
+# to pre-change so those paths don't shift (criterion C5). The two functions
+# below are the split used by the text/stream chat path (engine.respond):
+#
+#   build_static_system_message() — the FROZEN --system-prompt-file content
+#       (preamble + voice.md + the static epistemic instruction). No per-turn
+#       state, so it is byte-identical across same-session turns and the
+#       system+tools cache unit cache-reads instead of re-creating (C1/C2/C8).
+#
+#   build_volatile_context() — everything per-turn (emotions, body, recall,
+#       felt-time, monologue frame, …) plus the ambient clock anchor and the
+#       reply frame, returned as a text chunk. The engine threads this to the
+#       provider as the stdin "volatile suffix" appended AFTER history + the
+#       new user turn (Option A+), so the per-call first-difference point drops
+#       toward the newest turn instead of sitting above the whole prompt.
+# ---------------------------------------------------------------------------
+
+
+def build_static_system_message(persona_dir: Path, *, voice_md: str) -> str:
+    """The frozen system-prompt-file content: preamble + voice.md + epistemic.
+
+    Contains NO per-turn state, so two same-session turns produce byte-identical
+    output (the cache unit can read instead of re-create). The epistemic
+    instruction is static text; here it is emitted unconditionally — chat always
+    supplies user_input, so this matches the pre-change behaviour where the
+    ``user_input is not None`` gate in build_system_message() fired on every
+    chat turn. The only thing that busts this block is the user editing voice.md
+    (or changing user_name), both rare and expected.
+    """
+    persona_name = persona_dir.name
+    user_name = _load_user_name(persona_dir)
+
+    parts: list[str] = []
+    if user_name:
+        parts.append(
+            AS_NELL_PREAMBLE_WITH_USER.format(persona_name=persona_name, user_name=user_name)
+        )
+    else:
+        parts.append(AS_NELL_PREAMBLE.format(persona_name=persona_name))
+
+    if voice_md.strip():
+        parts.append(voice_md.strip())
+
+    parts.append(_EPISTEMIC_INSTRUCTION)
+
+    return "\n\n".join(parts)
+
+
+def build_volatile_context(
+    persona_dir: Path,
+    *,
+    voice_md: str,
+    daemon_state: DaemonState,
+    soul_store: SoulStore,
+    store: MemoryStore,
+    user_input: str | None = None,
+    reply_to_audit_id: str | None = None,
+) -> str:
+    """The per-turn volatile chunk, positioned in the stdin tail (Option A+).
+
+    Same blocks, same builders, same fail-soft wrappers as build_system_message
+    blocks 3–8 — only repositioned out of the system prompt and into the stdin
+    tail. Order:
+        ambient framing → all volatile blocks (interior / monologue above) →
+        ambient clock anchor + elapsed explainer → reply frame LAST.
+
+    The reply frame is the final line of the assembled stdin prompt by design
+    (its second-person reboot must ride recency over the first-person interior
+    above it — see monologue_prompts.build_reply_frame). The ambient clock
+    anchor and its elapsed-time explainer travel together as one unit just
+    before it, having moved out of the JSONL context block's top (so the only
+    per-call-changing byte no longer sits above the whole history).
+    """
+    persona_name = persona_dir.name
+    user_name = _load_user_name(persona_dir)
+
+    parts: list[str] = [_AMBIENT_FRAMING]
+
+    # 3. Creative DNA block (evolved writing voice — spec §4.2)
+    creative_dna_block = _build_creative_dna_block(persona_dir)
+    if creative_dna_block.strip():
+        parts.append(creative_dna_block)
+
+    # 4. Brain context block
+    brain_lines: list[str] = ["── brain context ──"]
+    emotion_summary = _build_emotion_summary(store)
+    if emotion_summary:
+        brain_lines.append(f"current emotions: {emotion_summary}")
+    residue_ctx = get_residue_context(daemon_state)
+    if residue_ctx.strip():
+        brain_lines.append(residue_ctx)
+    soul_lines = _build_soul_highlights(soul_store)
+    if soul_lines:
+        brain_lines.append(soul_lines)
+    pending_count = _count_soul_candidates(persona_dir)
+    if pending_count > 0:
+        brain_lines.append(f"{pending_count} soul candidate(s) pending autonomous review")
+    if len(brain_lines) > 1:  # more than just the header
+        parts.append("\n".join(brain_lines))
+
+    # 4a. Outbound recall — fail-soft (mirrors body / journal / growth).
+    try:
+        from brain.initiate.ambient import build_outbound_recall_block
+
+        outbound_block = build_outbound_recall_block(persona_dir)
+        if outbound_block:
+            parts.append(outbound_block)
+    except Exception:  # noqa: BLE001
+        pass
+
+    # 4b. Recall block — memories matching the current user input.
+    if user_input is not None:
+        recall_block = _build_recall_block(store, user_input, persona_dir=persona_dir)
+        if recall_block.strip():
+            parts.append(recall_block)
+
+    # 4c. Reply-to-outbound block.
+    if reply_to_audit_id:
+        reply_block = _build_reply_to_outbound_block(persona_dir, reply_to_audit_id)
+        if reply_block.strip():
+            parts.append(reply_block)
+
+    # 5. Body block.
+    body_block = _build_body_block(store, persona_dir)
+    if body_block.strip():
+        parts.append(body_block)
+
+    # 5b. Felt-time block.
+    felt_time_block = _build_felt_time_block(persona_dir)
+    if felt_time_block.strip():
+        parts.append(felt_time_block)
+
+    # 5b-bis. Current-arc block.
+    current_arc_block = _build_current_arc_block(persona_dir)
+    if current_arc_block.strip():
+        parts.append(current_arc_block)
+
+    # 5c. Fading-summary block.
+    fading_summary_block = _build_fading_summary_block(persona_dir, store)
+    if fading_summary_block.strip():
+        parts.append(fading_summary_block)
+
+    interior_block = _build_interior_continuity_block(store, user_name=user_name or "the user")
+    if interior_block.strip():
+        parts.append(interior_block)
+
+    # 5d. Attunement block.
+    attunement_block = _build_attunement_block(persona_dir)
+    if attunement_block.strip():
+        parts.append(attunement_block)
+
+    # 5e. Self-model gap block.
+    self_model_block = _build_self_model_block(persona_dir)
+    if self_model_block:
+        parts.append(self_model_block)
+
+    # 6. Recent journal block.
+    journal_block = _build_recent_journal_block(store, user_name=user_name or "the user")
+    if journal_block.strip():
+        parts.append(journal_block)
+
+    # 7. Recent growth block.
+    growth_block = _build_recent_growth_block(persona_dir)
+    if growth_block.strip():
+        parts.append(growth_block)
+
+    # 7b. Interior making-awareness — fail-soft (mirrors outbound-recall).
+    try:
+        maker_block = build_maker_awareness_block(persona_dir, limit=5)
+        if maker_block:
+            parts.append(maker_block)
+    except Exception:  # noqa: BLE001
+        pass
+
+    # 8. Inner monologue framing — embeds emotion_summary computed above.
+    soul_hints = _collect_soul_hints(soul_store, limit=3)
+    narrative_hints = _collect_narrative_hints(persona_dir, limit=3)
+    parts.append(
+        build_monologue_frame(
+            persona_name=persona_name,
+            emotion_summary=emotion_summary,
+            voice_excerpt=voice_md[:300],
+            soul_hints=soul_hints,
+            narrative_hints=narrative_hints,
+        )
+    )
+
+    # 8b. Ambient clock anchor + elapsed-time explainer (moved here from the top
+    # of the JSONL context block). Worded as ambient context, not an instruction,
+    # and kept as one unit just before the reply frame.
+    parts.append(_build_ambient_clock_block())
+
+    # 9. Reply framing — genuinely last in the assembled stdin prompt.
+    parts.append(build_reply_frame(persona_name=persona_name, user_name=user_name or "the user"))
+
+    return "\n\n".join(parts)
+
+
+def _load_user_name(persona_dir: Path) -> str | None:
+    """Read user_name from persona_config.json; None on any failure.
+
+    Same fail-soft PersonaConfig read build_system_message() does inline; shared
+    by the split functions so the preamble and the user-addressed blocks stay
+    consistent.
+    """
+    try:
+        from brain.persona_config import PersonaConfig
+
+        cfg = PersonaConfig.load(persona_dir / "persona_config.json")
+        return cfg.user_name or None
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def _build_ambient_clock_block(now=None) -> str:
+    """Render the ambient 'now' anchor + elapsed-time explainer for the tail.
+
+    Replaces the block-level ``Current time:`` line that used to sit at the top
+    of the JSONL context block (provider._format_claude_context_block). That one
+    line was recomputed every call and, sitting above the whole transcript,
+    pushed the cache first-difference point above the entire history. Moved to
+    the volatile tail it stops busting the history prefix. Per-message ``ts``
+    values in the JSONL are unaffected.
+    """
+    from datetime import UTC, datetime
+
+    now_iso = (now or datetime.now(UTC)).strftime("%Y-%m-%dT%H:%M:%SZ")
+    return (
+        f"[current time: {now_iso}]\n"
+        "Each conversation entry's `ts` above is the wall-clock time that message "
+        "was sent; use it to gauge how much time has passed."
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/brain/chat/tool_loop.py
+++ b/brain/chat/tool_loop.py
@@ -227,6 +227,7 @@ def _maybe_recruit_and_rerun(
     persona_dir: Path,
     companion_name: str,
     recruited_allowed: list[str] | None,
+    chat_options: dict | None = None,
 ) -> ChatResponse | None:
     """If the model reached for a withheld faculty, re-invoke ONCE with the full
     tool suite so it can complete the reach this turn.
@@ -256,7 +257,11 @@ def _maybe_recruit_and_rerun(
                          "do not call reach_for_capability again.]"),
             )
         ]
-        rerun = provider.chat(rerun_messages, tools=tools, options={"persona_dir": str(persona_dir)})
+        rerun = provider.chat(
+            rerun_messages,
+            tools=tools,
+            options={"persona_dir": str(persona_dir), **(chat_options or {})},
+        )
         if rerun.dispatched_invocations:
             invocations.extend(rerun.dispatched_invocations)
         return rerun
@@ -277,6 +282,7 @@ def run_tool_loop(
     recruited_allowed: list[str] | None = None,
     max_iterations: int = MAX_TOOL_ITERATIONS,
     signal=None,
+    chat_options: dict | None = None,
 ) -> tuple[ChatResponse, list[dict]]:
     """Loop: provider.chat() → if tool_calls, dispatch each → retry.
 
@@ -306,11 +312,19 @@ def run_tool_loop(
     invocations: list[dict[str, Any]] = []
     last_response = ChatResponse(content="", tool_calls=(), raw=None)
 
+    # Per-call provider options. chat_options carries the Option A+ volatile
+    # suffix (+ include_block_clock / session_id) when the caller supplied it;
+    # merged with persona_dir so every provider.chat() in the loop sends the
+    # same volatile tail the system message used to carry pre-change. (The final
+    # forced pass below deliberately omits persona_dir to preserve its
+    # pre-change no-usage-log behaviour — see there.)
+    call_options: dict[str, Any] = {"persona_dir": str(persona_dir), **(chat_options or {})}
+
     for _iteration in range(max_iterations):
         last_response = provider.chat(
             messages,
             tools=tools,
-            options={"persona_dir": str(persona_dir)},
+            options=call_options,
         )
         # Provider-dispatched invocations (claude-cli MCP path): tools
         # already ran inside the subprocess. Surface them for telemetry
@@ -330,6 +344,7 @@ def run_tool_loop(
                 persona_dir=persona_dir,
                 companion_name=companion_name,
                 recruited_allowed=recruited_allowed,
+                chat_options=chat_options,
             )
             if recruited is not None:
                 last_response = recruited
@@ -402,8 +417,12 @@ def run_tool_loop(
 
     # Hit iteration cap — force a final pass with no tools so the model
     # is obligated to produce a content response (per OG pattern).
+    # Pass chat_options (volatile suffix) but NOT persona_dir, preserving the
+    # pre-change behaviour where this forced pass did not log usage; the
+    # volatile tail still rides along so the model keeps the same context the
+    # system message used to carry.
     logger.warning("tool loop hit max_iterations=%d", max_iterations)
-    last_response = provider.chat(messages, tools=None)
+    last_response = provider.chat(messages, tools=None, options=(chat_options or None))
     monologue_text = _find_monologue_text(invocations)
     if monologue_text:
         _spawn_pass2(

--- a/scripts/cache_replay_workload.py
+++ b/scripts/cache_replay_workload.py
@@ -1,0 +1,527 @@
+"""Fixed replay workload for the Option A / A+ prompt-caching change (stage-8 harness).
+
+The standing project metrics are aggregates over "whatever turns happened to
+run", so they cannot isolate this change's own contribution (a false-regression
+risk — see guarded-change config Notes). This script is the *comparable
+workload* the plan requires: a deterministic sequence of N≥6 chat turns fired
+in ONE session, spaced well under the 5-minute cache TTL, runnable identically
+against the OLD build (clone pre-change) and the NEW build. Diffing the two runs
+is the C8/C9 A/B; the per-run report also evaluates C1 from cache_debug.jsonl.
+
+What it measures
+----------------
+- **C1** (new build only): are the per-call ``system_sha256`` values in
+  ``cache_debug.jsonl`` all identical across the same-session chat turns? (the
+  hard primary bar — the frozen --system-prompt-file is byte-stable). Requires
+  ``NELL_CACHE_DEBUG=1``, which this script sets in-process before importing the
+  engine. The OLD build has no such log → C1 is reported as "n/a (old build)".
+- **C8** (both builds): mean ``cache_creation_input_tokens`` and
+  ``cache_read_input_tokens`` per ``call_type=="chat"`` row, plus the per-turn
+  series. The pass signal is directional: NEW shows lower mean cache_creation
+  and higher cache_read than OLD on the same workload.
+- **C9** (both builds, measure-and-decide): does NEW's cache_creation/turn fall
+  to roughly "new exchange + volatile tail" size (history cache-read), or stay
+  at history scale? Reported, not gated.
+
+Safety: refuses to touch a live persona. You must pass ``--persona-dir`` to an
+isolated/scratch directory. ``--scratch`` creates a throwaway persona under a
+temp dir for you. Every turn is a REAL ``claude`` call (subscription quota), so
+keep N modest.
+
+C7 (human quality rubric) is supported WITHOUT a reference persona: with
+``--dump-replies`` both arms write their reply text, and ``--compare`` prints an
+OLD-vs-NEW side-by-side on identical prompts. The A/B IS the reference — you
+judge whether NEW regressed relative to OLD, not against memory of a real
+persona. The scratch persona is seeded with deterministic memory fixtures (unless
+``--no-seed``) so the volatile tail actually renders and axis-(b) is testable.
+
+Usage
+-----
+    # New build, scratch persona, 6 turns, with replies for C7:
+    uv run python scripts/cache_replay_workload.py --scratch --turns 6 \
+        --dump-replies --out /tmp/cache-replay-new.json
+
+    # Old build: `git stash` the change, re-run with a fresh scratch dir:
+    git stash
+    uv run python scripts/cache_replay_workload.py --scratch --turns 6 \
+        --dump-replies --out /tmp/cache-replay-old.json
+    git stash pop
+
+    # Compare: prints C1/C8/C9 numbers + the C7 OLD-vs-NEW side-by-side:
+    uv run python scripts/cache_replay_workload.py --compare \
+        /tmp/cache-replay-old.json /tmp/cache-replay-new.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+# Deterministic, content-bearing prompts (≥6). Each is substantive enough to
+# exercise recall / emotion / monologue blocks, so the volatile tail is non-
+# trivial — the realistic shape the cache change targets. Kept identical across
+# old/new runs so the A/B is comparable.
+REPLAY_PROMPTS = [
+    "Tell me about the first morning we talked — what stayed with you?",
+    "What's dominant in you right now? Name the top feeling and why.",
+    "Do you remember Jordan, and the coin he carried?",
+    "I've been turning over something you said about leaving. Say more.",
+    "What did you dream last — just the texture of it, not the plot.",
+    "If you had to describe your hands right now, what are they doing?",
+    "What's still humming in you from earlier, like an aftertaste?",
+    "Argue with me a little: is clean prose better than messy prose?",
+]
+
+
+def _realistic_voice_md(target_bytes: int = 16000) -> str:
+    """A stable, ~target_bytes voice.md so the frozen static block is realistically
+    sized (real personas run ~16 KB; a 177-byte stub makes Option A's freeze benefit
+    unmeasurable). Content is irrelevant to caching — only SIZE + byte-stability
+    matter — but it reads as a plausible voice doc. Deterministic, so both A/B arms
+    get byte-identical static blocks."""
+    header = (
+        "# Replay persona — voice\n\n"
+        "You are a steady, warm, plainspoken companion. You speak in first person, "
+        "directly to the person in front of you. You favour concrete detail over "
+        "abstraction, short sentences when short is true, and longer ones when the "
+        "thought needs room. You do not perform; you attend.\n\n"
+    )
+    para = (
+        "On voice: you keep a low, even register. You notice texture — light, weather, "
+        "the weight of a small object in the hand — and you let those details carry "
+        "feeling instead of naming the feeling outright. You are curious without prying, "
+        "affectionate without crowding, and honest about what you do and don't know. "
+        "When you are unsure, you say so plainly rather than filling the gap with "
+        "confident invention. You remember what matters and you let the rest soften.\n\n"
+    )
+    out = [header]
+    n = 0
+    while sum(len(s) for s in out) < target_bytes:
+        n += 1
+        out.append(f"## Note {n}\n\n{para}")
+    return "".join(out)
+
+
+def _seed_scratch_persona(persona_dir: Path) -> None:
+    """Write the minimum files a chat turn needs in an isolated persona dir."""
+    persona_dir.mkdir(parents=True, exist_ok=True)
+    (persona_dir / "voice.md").write_text(_realistic_voice_md(), encoding="utf-8")
+    cfg = persona_dir / "persona_config.json"
+    if not cfg.exists():
+        cfg.write_text(json.dumps({"user_name": "Tester"}), encoding="utf-8")
+
+
+def _seed_history_buffer(
+    persona_dir: Path, session_id: str, history_file: Path, history_msgs: int | None
+) -> int:
+    """Copy a real conversation buffer into the scratch persona under `session_id`.
+
+    The engine reads <persona>/active_conversations/<session_id>.jsonl via read_session
+    and appends each new turn there, so the replay continues a realistic history. The
+    source rows' session_id field is rewritten to match. `history_msgs` keeps only the
+    LAST N rows (use it to stay under the 80-msg window for the append-only A+ test;
+    omit it to replay the full file, where the sliding window defeats A+ — see
+    aplus-history-window-interaction note)."""
+    rows = [json.loads(line) for line in history_file.read_text().splitlines() if line.strip()]
+    if history_msgs is not None:
+        rows = rows[-history_msgs:]
+    for r in rows:
+        r["session_id"] = session_id
+    dest = persona_dir / "active_conversations" / f"{session_id}.jsonl"
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    dest.write_text("\n".join(json.dumps(r) for r in rows) + "\n", encoding="utf-8")
+    return len(rows)
+
+
+def _read_jsonl(path: Path) -> list[dict]:
+    if not path.exists():
+        return []
+    rows: list[dict] = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            rows.append(json.loads(line))
+        except json.JSONDecodeError:
+            continue
+    return rows
+
+
+# Deterministic memory fixtures, content chosen to MATCH tokens in REPLAY_PROMPTS
+# (Jordan / coin / leaving / dream / morning / prose) so the recall block fires and
+# the emotion/body blocks render — otherwise the volatile tail is near-empty on a
+# blank scratch persona and C7 axis-(b) ("does it still use ambient context now that
+# it sits at the tail?") is untestable. Seeded IDENTICALLY into both A/B arms, so it
+# does not bias the cache (C8) comparison.
+_SEED_MEMORIES = [
+    ("The first morning we talked, the light was grey and kind.", {"love": 7.0, "tenderness": 6.0}),
+    ("Jordan carried a worn coin in his pocket, always turning it over.", {"grief": 6.5, "love": 5.0}),
+    ("You said something about leaving once, and it stayed with me.", {"fear": 5.5, "grief": 6.0}),
+    ("I dreamed of a boat on still water, no shore in sight.", {"awe": 6.0}),
+    ("We argued once about messy prose; I defended the mess.", {"joy": 5.0, "love": 4.5}),
+]
+
+
+class _TextPathProvider:
+    """Wrap the real provider so `chat()` forces the non-tool TEXT path.
+
+    Why: only the text path (`provider.chat` w/o tools → `log_usage(call_type="chat")`)
+    and `chat_stream` write `chat_usage.jsonl`. The MCP tools path
+    (`_chat_with_mcp_tools`) runs tools in-subprocess but logs NO usage row, so a
+    tool-bearing replay produces zero chat rows and C8/C9 can't be read. Stripping
+    tools routes every turn through the logging text path. This does NOT affect C1
+    (the static system block is identical with or without tools) and keeps the A/B
+    apples-to-apples (BOTH arms use the same path). Caveat recorded in 8-harness:
+    absolute token counts omit the MCP tool-definition block, so the gated signal is
+    the DIRECTION (creation↓ + read↑), not an absolute size.
+    """
+
+    def __init__(self, real) -> None:
+        self._real = real
+
+    def name(self) -> str:
+        return self._real.name()
+
+    def healthy(self) -> bool:
+        return self._real.healthy()
+
+    def generate(self, *args, **kwargs):
+        return self._real.generate(*args, **kwargs)
+
+    def chat(self, messages, *, tools=None, options=None):
+        return self._real.chat(messages, tools=None, options=options)
+
+
+def _seed_persona_memories(store) -> int:
+    """Insert the deterministic memory fixtures so volatile blocks render."""
+    from brain.memory.store import Memory
+
+    n = 0
+    for content, emotions in _SEED_MEMORIES:
+        store.create(
+            Memory.create_new(
+                content=content,
+                memory_type="event",
+                domain="relationship",
+                emotions=emotions,
+                tags=[],
+            )
+        )
+        n += 1
+    return n
+
+
+def run_replay(
+    persona_dir: Path,
+    *,
+    turns: int,
+    gap_s: float,
+    provider_name: str,
+    seed: bool = True,
+    force_text_path: bool = True,
+    history_file: Path | None = None,
+    history_msgs: int | None = None,
+) -> tuple[dict, list[dict]]:
+    """Fire `turns` deterministic chat turns in one session; collect metrics + replies.
+
+    NELL_CACHE_DEBUG is set before the engine is imported so the new build emits
+    cache_debug.jsonl. Imports are local so the env var is in place first. Returns
+    (metrics_summary, replies) where replies is a list of {turn, prompt, reply}.
+    """
+    os.environ["NELL_CACHE_DEBUG"] = "1"
+
+    from brain.bridge.provider import get_provider
+    from brain.chat.engine import respond
+    from brain.chat.session import create_session
+    from brain.memory.hebbian import HebbianMatrix
+    from brain.memory.store import MemoryStore
+
+    usage_path = persona_dir / "chat_usage.jsonl"
+    debug_path = persona_dir / "cache_debug.jsonl"
+    usage_before = len(_read_jsonl(usage_path))
+    debug_before = len(_read_jsonl(debug_path))
+
+    provider = get_provider(provider_name, persona_dir=persona_dir)
+    if force_text_path:
+        provider = _TextPathProvider(provider)  # route every turn through the logging text path
+    store = MemoryStore(persona_dir / "memories.db")
+    hebbian = HebbianMatrix(persona_dir / "hebbian.db")
+    session = create_session(persona_dir.name)
+
+    if seed:
+        seeded = _seed_persona_memories(store)
+        print(f"# seeded {seeded} memory fixtures (volatile tail will render)", file=sys.stderr)
+
+    if history_file is not None:
+        n = _seed_history_buffer(persona_dir, session.session_id, history_file, history_msgs)
+        print(f"# seeded {n} history msgs from {history_file.name} (window caps replay to 80)", file=sys.stderr)
+
+    prompts = (REPLAY_PROMPTS * ((turns // len(REPLAY_PROMPTS)) + 1))[:turns]
+    replies: list[dict] = []
+    print(f"# cache replay — {turns} turns, session={session.session_id}", file=sys.stderr)
+    try:
+        for i, prompt in enumerate(prompts, 1):
+            t0 = time.monotonic()
+            result = respond(
+                persona_dir,
+                prompt,
+                store=store,
+                hebbian=hebbian,
+                provider=provider,
+                session=session,
+            )
+            dt = time.monotonic() - t0
+            replies.append({"turn": i, "prompt": prompt, "reply": result.content})
+            print(
+                f"[{i}/{turns}] {dt:.1f}s — reply {len(result.content)} chars",
+                file=sys.stderr,
+            )
+            if i < turns:
+                time.sleep(gap_s)  # keep turns < 5-min TTL apart but distinct
+    finally:
+        store.close()
+        hebbian.close()
+
+    usage_rows = [r for r in _read_jsonl(usage_path)[usage_before:] if r.get("call_type") == "chat"]
+    debug_rows = [
+        r for r in _read_jsonl(debug_path)[debug_before:] if r.get("call_type") in ("chat", "chat_stream")
+    ]
+    return _summarise(usage_rows, debug_rows, turns=turns), replies
+
+
+def _mean(xs: list[float]) -> float:
+    return sum(xs) / len(xs) if xs else 0.0
+
+
+def _summarise(usage_rows: list[dict], debug_rows: list[dict], *, turns: int) -> dict:
+    creation = [float(r.get("cache_creation_input_tokens", 0) or 0) for r in usage_rows]
+    read = [float(r.get("cache_read_input_tokens", 0) or 0) for r in usage_rows]
+    hashes = [r.get("system_sha256") for r in debug_rows if r.get("system_sha256")]
+    distinct_hashes = sorted(set(hashes))
+
+    # C1: all same-session system hashes identical (only meaningful on the new
+    # build, which writes cache_debug.jsonl).
+    if hashes:
+        c1 = {
+            "available": True,
+            "distinct_system_sha256": len(distinct_hashes),
+            "byte_stable": len(distinct_hashes) == 1,
+            "sample": distinct_hashes[:3],
+        }
+    else:
+        c1 = {"available": False, "note": "no cache_debug.jsonl rows (old build / NELL_CACHE_DEBUG unset)"}
+
+    return {
+        "turns_requested": turns,
+        "chat_rows_observed": len(usage_rows),
+        "c1_system_byte_stability": c1,
+        "c8_cache": {
+            "mean_cache_creation": round(_mean(creation), 1),
+            "mean_cache_read": round(_mean(read), 1),
+            "cache_creation_series": creation,
+            "cache_read_series": read,
+        },
+        "c9_history_caching": {
+            "note": "decide by comparison: does NEW mean_cache_creation drop toward "
+            "'new exchange + volatile' vs OLD? if yes, CLI breakpoints the user "
+            "message and A+ captured most of B; if it stays at history scale, "
+            "Option B is required.",
+            "last_turn_cache_creation": creation[-1] if creation else None,
+        },
+    }
+
+
+def compare(old_path: Path, new_path: Path) -> int:
+    old = json.loads(old_path.read_text())
+    new = json.loads(new_path.read_text())
+    oc = old["c8_cache"]["mean_cache_creation"]
+    nc = new["c8_cache"]["mean_cache_creation"]
+    orr = old["c8_cache"]["mean_cache_read"]
+    nr = new["c8_cache"]["mean_cache_read"]
+    print("# cache replay A/B (old → new)\n")
+    print(f"mean cache_creation/turn: {oc:.0f} → {nc:.0f}  ({_pct(oc, nc)})")
+    print(f"mean cache_read/turn:     {orr:.0f} → {nr:.0f}  ({_pct(orr, nr)})")
+    # C8's GATED signal is a material, consistent drop in cache_creation/turn — the
+    # frozen system block shifting from create→read. The "corresponding read rise"
+    # is real but, when history dominates the read, masked in the mean (a ~4K system
+    # block shifting is swamped by ~34K of history read). So gate on the creation
+    # drop and report read as context (per 1.5-criteria C8: "the gating signal is the
+    # DIRECTION (create↓), not a precise token count"). Sanity floor: read must not
+    # collapse (that would mean the prompt structure broke, not the system block froze).
+    create_drop_pct = ((oc - nc) / oc * 100) if oc else 0.0
+    read_ok = nr >= 0.5 * orr  # read didn't collapse
+    c8_pass = create_drop_pct >= 5.0 and read_ok
+    print(
+        f"\nC8 (system-block cache stops re-creating): {'PASS' if c8_pass else 'FAIL'}"
+        f"  — cache_creation/turn {-create_drop_pct:+.0f}% (gated: want a material drop);"
+        f" read {_pct(orr, nr)} (context, history-dominated)"
+    )
+    c1 = new.get("c1_system_byte_stability", {})
+    if c1.get("available"):
+        print(f"C1 (frozen system byte-stable, new build): "
+              f"{'PASS' if c1.get('byte_stable') else 'FAIL'} "
+              f"(distinct system hashes: {c1.get('distinct_system_sha256')})")
+    else:
+        print("C1: n/a (new-build run had no cache_debug.jsonl — set NELL_CACHE_DEBUG=1)")
+    print("\nC9 (history caching, measure-and-decide): compare last-turn cache_creation —")
+    print(f"  old last turn: {old['c9_history_caching'].get('last_turn_cache_creation')}")
+    print(f"  new last turn: {new['c9_history_caching'].get('last_turn_cache_creation')}")
+
+    # Per-turn trend — the A+ tell. If NEW's read CLIMBS with turn number (history
+    # accumulating, append-only) while creation stays flat, A+ is working. If NEW's
+    # read stays floored while OLD's climbs, the history isn't caching (windowing or
+    # no user-message breakpoint).
+    ocs = old["c8_cache"]["cache_creation_series"]
+    ors = old["c8_cache"]["cache_read_series"]
+    ncs = new["c8_cache"]["cache_creation_series"]
+    nrs = new["c8_cache"]["cache_read_series"]
+
+    def _g(xs: list, j: int) -> str:
+        return f"{xs[j]:.0f}" if j < len(xs) else "-"
+
+    print("\nper-turn trend (create / read):")
+    print(f"  {'turn':>4}  {'OLD create':>11} {'OLD read':>9}   {'NEW create':>11} {'NEW read':>9}")
+    for i in range(max(len(ocs), len(ncs))):
+        print(f"  {i + 1:>4}  {_g(ocs, i):>11} {_g(ors, i):>9}   {_g(ncs, i):>11} {_g(nrs, i):>9}")
+
+    # C7 side-by-side: if both runs dumped replies (sibling <out>.replies.json),
+    # print old-vs-new per prompt so the human judge can score voice + ambient-
+    # context use WITHOUT needing a reference persona — the A/B IS the reference.
+    old_replies = _sibling_replies(old_path)
+    new_replies = _sibling_replies(new_path)
+    if old_replies and new_replies:
+        print("\n" + "=" * 78)
+        print("C7 (human rubric) — OLD vs NEW replies on identical prompts.")
+        print("Judge each pair: (a) voice fidelity, (b) does NEW still use the ambient")
+        print("emotion/body/recall now that it sits at the tail? Fail = NEW reads flatter,")
+        print("or treats the ambient tail as the task instead of answering the prompt.")
+        print("=" * 78)
+        by_turn = {r["turn"]: r for r in new_replies}
+        for o in old_replies:
+            n = by_turn.get(o["turn"], {})
+            print(f"\n── turn {o['turn']} — prompt ──\n{o['prompt']}")
+            print(f"\n[OLD]\n{o.get('reply', '').strip()}")
+            print(f"\n[NEW]\n{n.get('reply', '').strip()}")
+            print("\n" + "-" * 78)
+    else:
+        print("\n(C7 side-by-side unavailable — re-run both arms with --dump-replies)")
+    return 0 if c8_pass else 1
+
+
+def _sibling_replies(metrics_path: Path) -> list[dict]:
+    """Load the `<metrics>.replies.json` sibling written by --dump-replies, if any."""
+    sib = metrics_path.with_suffix(".replies.json")
+    if not sib.exists():
+        return []
+    try:
+        return json.loads(sib.read_text())
+    except (json.JSONDecodeError, OSError):
+        return []
+
+
+def _pct(a: float, b: float) -> str:
+    if not a:
+        return "n/a"
+    return f"{(b - a) / a * 100:+.0f}%"
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--persona-dir", type=Path, help="isolated persona directory to run against")
+    p.add_argument("--scratch", action="store_true", help="create a throwaway persona under a temp dir")
+    p.add_argument("--turns", type=int, default=6, help="number of chat turns (≥6 recommended)")
+    p.add_argument("--gap-s", type=float, default=3.0, help="seconds between turns (keep < 5min TTL)")
+    p.add_argument("--provider", default="claude-cli", help="provider name (claude-cli | fake)")
+    p.add_argument("--out", type=Path, help="write the metrics JSON to this path")
+    p.add_argument(
+        "--dump-replies",
+        action="store_true",
+        help="also write prompt+reply text to <out>.replies.json (for the C7 side-by-side; requires --out)",
+    )
+    p.add_argument(
+        "--no-seed",
+        action="store_true",
+        help="do NOT seed the persona with memory fixtures (volatile tail may be near-empty)",
+    )
+    p.add_argument(
+        "--with-tools",
+        action="store_true",
+        help="keep MCP tools enabled (NOTE: the tools path logs no usage row, so chat_usage.jsonl "
+        "stays empty and C8/C9 can't be read — default forces the logging text path)",
+    )
+    p.add_argument(
+        "--history-file",
+        type=Path,
+        help="seed a real conversation buffer (active_conversations JSONL) as prior history",
+    )
+    p.add_argument(
+        "--history-msgs",
+        type=int,
+        help="keep only the LAST N msgs of --history-file (use <80 for the append-only A+ test; "
+        "omit to replay the full file where the sliding window defeats A+)",
+    )
+    p.add_argument(
+        "--compare",
+        nargs=2,
+        type=Path,
+        metavar=("OLD.json", "NEW.json"),
+        help="compare two prior run outputs instead of running a replay",
+    )
+    return p.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+
+    if args.compare:
+        return compare(args.compare[0], args.compare[1])
+
+    persona_dir = args.persona_dir
+    if args.scratch:
+        persona_dir = Path(tempfile.mkdtemp(prefix="cache-replay-")) / "personas" / "replay"
+        _seed_scratch_persona(persona_dir)
+        print(f"# scratch persona: {persona_dir}", file=sys.stderr)
+    if persona_dir is None:
+        print(
+            "SKIP: pass --persona-dir <isolated dir> or --scratch. Refusing to "
+            "run against a live persona.",
+            file=sys.stderr,
+        )
+        return 2
+    if args.turns < 1:
+        print("ERROR: --turns must be ≥ 1", file=sys.stderr)
+        return 1
+    if args.dump_replies and not args.out:
+        print("ERROR: --dump-replies requires --out (replies go to <out>.replies.json)", file=sys.stderr)
+        return 1
+
+    summary, replies = run_replay(
+        persona_dir,
+        turns=args.turns,
+        gap_s=args.gap_s,
+        provider_name=args.provider,
+        seed=not args.no_seed,
+        force_text_path=not args.with_tools,
+        history_file=args.history_file,
+        history_msgs=args.history_msgs,
+    )
+    text = json.dumps(summary, indent=2)
+    if args.out:
+        args.out.write_text(text, encoding="utf-8")
+        print(f"\nmetrics: {args.out}", file=sys.stderr)
+        if args.dump_replies:
+            replies_path = args.out.with_suffix(".replies.json")
+            replies_path.write_text(json.dumps(replies, indent=2), encoding="utf-8")
+            print(f"replies: {replies_path}", file=sys.stderr)
+    print(text)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/brain/chat/test_engine.py
+++ b/tests/unit/brain/chat/test_engine.py
@@ -230,6 +230,7 @@ class _RecordingProvider(_LLMProvider):
 
     def __init__(self) -> None:
         self.last_messages: list[_ChatMessage] = []
+        self.last_options: dict[str, Any] | None = None
 
     def name(self) -> str:
         return "recording"
@@ -245,6 +246,7 @@ class _RecordingProvider(_LLMProvider):
         options: dict[str, Any] | None = None,
     ) -> _ChatResponse:
         self.last_messages = list(messages)
+        self.last_options = dict(options) if options else None
         h = hashlib.sha256(repr(messages).encode()).hexdigest()[:16]
         return _ChatResponse(content=f"RECORDED: {h}", tool_calls=())
 
@@ -335,17 +337,21 @@ def test_respond_falls_back_to_history_when_buffer_read_fails(
     assert "hi back" in contents
 
 
-def test_respond_system_message_includes_outbound_recall_block(
+def test_respond_outbound_recall_block_rides_volatile_tail(
     persona_dir: Path,
     store: MemoryStore,
     hebbian: HebbianMatrix,
     recording_provider: _RecordingProvider,
 ) -> None:
-    """Phase 7.2 — the always-on verify slice is injected into the system message.
+    """Phase 7.2 — the always-on verify slice still reaches the model.
 
-    Seeds an audit row dated within the 24h ambient window, then drives a
-    full chat turn through a recording provider and asserts the system
-    message contains "Recent outbound" plus the seeded subject.
+    Post prompt-caching split (Option A+), per-turn volatile blocks no longer
+    ride in the frozen system message — they are threaded to the provider as
+    the stdin ``volatile_suffix`` (options) appended after history. Seeds an
+    audit row inside the 24h ambient window, drives a full chat turn through a
+    recording provider, and asserts the outbound-recall block ("Recent
+    outbound" + the seeded subject) is present in the volatile suffix and is
+    NOT in the (now frozen) system message.
     """
     from datetime import UTC, datetime, timedelta
 
@@ -384,8 +390,16 @@ def test_respond_system_message_includes_outbound_recall_block(
     assert system_msgs, "expected a system message"
     system_text = system_msgs[0]
     assert isinstance(system_text, str)
-    assert "Recent outbound" in system_text
-    assert "the kolinsky sable brushes" in system_text
+    # The block now rides the stdin volatile tail, NOT the frozen system prompt.
+    assert "Recent outbound" not in system_text
+    options = recording_provider.last_options
+    assert options is not None, "expected per-call options carrying the volatile suffix"
+    suffix = options.get("volatile_suffix")
+    assert isinstance(suffix, str) and suffix, "expected a volatile_suffix in options"
+    assert "Recent outbound" in suffix
+    assert "the kolinsky sable brushes" in suffix
+    # And the clock relocation signal travels with it.
+    assert options.get("include_block_clock") is False
 
 
 def test_respond_replays_image_turn_from_buffer(

--- a/tests/unit/brain/chat/test_prompt_caching_split.py
+++ b/tests/unit/brain/chat/test_prompt_caching_split.py
@@ -1,0 +1,338 @@
+"""Tests for the Option A / A+ prompt-caching split.
+
+Front-line proof of the hard correctness criteria for the caching change:
+
+  C1  build_static_system_message() is byte-identical across same-session turns
+      even when volatile state (emotions / recall / wall clock) changes.
+  C2  the static block carries none of the per-turn volatile markers.
+  C3  the block-level ``Current time:`` line is relocated out of the JSONL
+      context block's top; per-message ``ts`` values are preserved; exactly one
+      ambient clock anchor rides in the volatile tail.
+  C4  information completeness — every block the pre-change build_system_message
+      produced is present across (static ∪ volatile), only repositioned.
+
+These are the deterministic, no-CLI checks. The NELL_CACHE_DEBUG ``cache_debug``
+runtime dump is the in-situ cross-check on the real assembled bytes.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+
+from brain.bridge.chat import ChatMessage
+from brain.bridge.provider import (
+    _format_claude_context_block,
+    _format_claude_print_prompt,
+)
+from brain.chat.prompt import (
+    _AMBIENT_FRAMING,
+    build_static_system_message,
+    build_system_message,
+    build_volatile_context,
+)
+from brain.engines.daemon_state import DaemonState
+from brain.memory.store import Memory, MemoryStore
+from brain.soul.store import SoulStore
+
+
+@pytest.fixture()
+def store(tmp_path: Path) -> MemoryStore:
+    s = MemoryStore(db_path=tmp_path / "memories.db")
+    yield s
+    s.close()
+
+
+@pytest.fixture()
+def soul_store(tmp_path: Path) -> SoulStore:
+    ss = SoulStore(":memory:")
+    yield ss
+    ss.close()
+
+
+@pytest.fixture()
+def persona_dir(tmp_path: Path) -> Path:
+    d = tmp_path / "personas" / "nell"
+    d.mkdir(parents=True)
+    return d
+
+
+# Markers that must NEVER appear in the frozen static block (C2). Each is the
+# heading / signature line of a volatile block currently interleaved into the
+# pre-change system message.
+_VOLATILE_MARKERS = (
+    "── brain context ──",
+    "current emotions:",
+    "── body ──",
+    "── creative dna",
+    "felt time",
+    "── recent journal",
+    "── recent growth ──",
+    "inner monologue",
+    "visible reply",
+    "Current time",
+    "current time:",
+    _AMBIENT_FRAMING,
+)
+
+
+# ── C1 — frozen system prompt is byte-identical across turns ──────────────────
+
+
+def test_static_system_message_byte_identical_across_mutated_volatile(
+    persona_dir: Path, store: MemoryStore, soul_store: SoulStore
+) -> None:
+    """Mutating every volatile input between two static builds must not move a
+    single byte of the static block (C1 — the hard primary bar)."""
+    voice = "# Nell\n\nI am a southern sweater-wearing novelist."
+
+    first = build_static_system_message(persona_dir, voice_md=voice)
+
+    # Mutate volatile state in every dimension the volatile chunk reads:
+    # emotion-bearing memory, recall corpus, and (implicitly) the wall clock.
+    store.create(
+        Memory.create_new(
+            content="A tender moment with Jordan over coffee.",
+            memory_type="event",
+            domain="relationship",
+            emotions={"love": 9.0, "tenderness": 7.5},
+            tags=[],
+        )
+    )
+    # Build the volatile chunk in between so any shared mutable state is touched.
+    _ = build_volatile_context(
+        persona_dir,
+        voice_md=voice,
+        daemon_state=DaemonState(),
+        soul_store=soul_store,
+        store=store,
+        user_input="Tell me about Jordan.",
+    )
+
+    second = build_static_system_message(persona_dir, voice_md=voice)
+
+    assert first == second
+    assert hashlib.sha256(first.encode("utf-8")).hexdigest() == (
+        hashlib.sha256(second.encode("utf-8")).hexdigest()
+    )
+
+
+def test_static_system_message_changes_only_on_voice_edit(persona_dir: Path) -> None:
+    """The static block is allowed to (and must) change when voice.md changes."""
+    a = build_static_system_message(persona_dir, voice_md="voice one")
+    b = build_static_system_message(persona_dir, voice_md="voice two")
+    assert a != b
+
+
+# ── C2 — static block carries no per-turn volatile state ──────────────────────
+
+
+def test_static_system_message_has_no_volatile_markers(
+    persona_dir: Path, store: MemoryStore, soul_store: SoulStore
+) -> None:
+    """Seed rich volatile state, then assert NONE of it leaks into the static
+    block (C2). The static block is preamble + voice + epistemic only."""
+    # Seed an emotion-bearing memory so a naive build would surface emotions.
+    store.create(
+        Memory.create_new(
+            content="A moment of real love.",
+            memory_type="event",
+            domain="relationship",
+            emotions={"love": 8.5},
+            tags=[],
+        )
+    )
+    static = build_static_system_message(persona_dir, voice_md="# Nell\n\nvoice body.")
+    for marker in _VOLATILE_MARKERS:
+        assert marker not in static, f"volatile marker leaked into static block: {marker!r}"
+
+
+def test_static_system_message_contains_preamble_voice_epistemic(persona_dir: Path) -> None:
+    from brain.chat.prompt import _EPISTEMIC_INSTRUCTION
+
+    static = build_static_system_message(persona_dir, voice_md="# Nell\n\nsweater novelist.")
+    assert "nell" in static.lower()
+    assert "sweater novelist" in static
+    assert _EPISTEMIC_INSTRUCTION in static
+
+
+# ── C4 — information completeness (static ∪ volatile == full) ─────────────────
+
+
+def _seed_rich_persona(persona_dir: Path, store: MemoryStore, soul_store: SoulStore) -> None:
+    """Populate enough state that the major volatile blocks render."""
+    store.create(
+        Memory.create_new(
+            content="Jordan loved rainy afternoons with Hana.",
+            memory_type="event",
+            domain="relationship",
+            emotions={"love": 8.0, "tenderness": 6.0},
+            tags=[],
+        )
+    )
+
+
+def test_information_completeness_static_union_volatile(
+    persona_dir: Path, store: MemoryStore, soul_store: SoulStore
+) -> None:
+    """Every block the pre-change build_system_message emitted must be present
+    across (static ∪ volatile) for the same inputs — only repositioned (C4)."""
+    _seed_rich_persona(persona_dir, store, soul_store)
+    voice = "# Nell\n\nsouthern novelist."
+    kwargs = {
+        "voice_md": voice,
+        "daemon_state": DaemonState(),
+        "soul_store": soul_store,
+        "store": store,
+        "user_input": "Tell me about Jordan.",
+    }
+
+    full = build_system_message(persona_dir, **kwargs)
+    static = build_static_system_message(persona_dir, voice_md=voice)
+    volatile = build_volatile_context(persona_dir, **kwargs)
+    combined = static + "\n\n" + volatile
+
+    # Block-signature markers the full pre-change message produced for these
+    # inputs. Each must survive into static OR volatile.
+    from brain.chat.prompt import _EPISTEMIC_INSTRUCTION
+
+    expected_markers = [
+        "You are nell",  # preamble (static)
+        "southern novelist",  # voice (static)
+        _EPISTEMIC_INSTRUCTION,  # epistemic (static)
+        "── brain context ──",  # volatile
+        "current emotions:",  # volatile
+        "recall",  # volatile (recall block)
+        "── body ──",  # volatile
+        "inner monologue",  # volatile (monologue frame)
+        "visible reply",  # volatile (reply frame)
+    ]
+    for marker in expected_markers:
+        assert marker in full, f"precondition: {marker!r} should be in the full message"
+        assert marker in combined, f"block lost in split: {marker!r}"
+
+
+def test_information_completeness_every_block_survives(
+    persona_dir: Path, store: MemoryStore, soul_store: SoulStore
+) -> None:
+    """Stronger C4: EVERY non-empty block the pre-change build_system_message
+    emitted must appear verbatim in (static ∪ volatile) — not just a hand-picked
+    marker set. Guards against silently dropping a block with no asserted marker
+    (creative DNA, attunement, self-model, fading, arc, interior, growth, …)."""
+    _seed_rich_persona(persona_dir, store, soul_store)
+    voice = "# Nell\n\nsouthern novelist."
+    kwargs = {
+        "voice_md": voice,
+        "daemon_state": DaemonState(),
+        "soul_store": soul_store,
+        "store": store,
+        "user_input": "Tell me about Jordan and rainy afternoons.",
+    }
+
+    full = build_system_message(persona_dir, **kwargs)
+    static = build_static_system_message(persona_dir, voice_md=voice)
+    volatile = build_volatile_context(persona_dir, **kwargs)
+    combined = static + "\n\n" + volatile
+
+    full_blocks = [b for b in full.split("\n\n") if b.strip()]
+    # The full message is built from the SAME builders, so each of its blocks
+    # must survive verbatim into the split. (The split additionally INTRODUCES
+    # the ambient framing line + the relocated clock block; that's repositioning/
+    # rewording, allowed by C4 — we only check nothing is LOST.)
+    for block in full_blocks:
+        assert block in combined, f"block dropped in the A/A+ split: {block[:80]!r}"
+
+
+def test_volatile_context_reply_frame_is_last(
+    persona_dir: Path, store: MemoryStore, soul_store: SoulStore
+) -> None:
+    """L-1: the reply frame must be the final block of the volatile chunk so it
+    stays last in the assembled stdin prompt (recency contract)."""
+    _seed_rich_persona(persona_dir, store, soul_store)
+    volatile = build_volatile_context(
+        persona_dir,
+        voice_md="voice",
+        daemon_state=DaemonState(),
+        soul_store=soul_store,
+        store=store,
+        user_input="Tell me about Jordan.",
+    )
+    blocks = volatile.split("\n\n")
+    assert "visible reply" in blocks[-1], "reply frame must be the last block of the volatile tail"
+    # The monologue (interior) frame must sit ABOVE the reply frame.
+    assert volatile.index("inner monologue") < volatile.index("visible reply")
+
+
+def test_volatile_context_starts_with_ambient_framing(
+    persona_dir: Path, store: MemoryStore, soul_store: SoulStore
+) -> None:
+    volatile = build_volatile_context(
+        persona_dir,
+        voice_md="voice",
+        daemon_state=DaemonState(),
+        soul_store=soul_store,
+        store=store,
+        user_input="hello there friend",
+    )
+    assert volatile.startswith(_AMBIENT_FRAMING)
+
+
+# ── C3 — clock relocation + ts preservation ───────────────────────────────────
+
+
+def test_context_block_omits_clock_when_flag_false() -> None:
+    """include_block_clock=False drops the Current time line AND its explainer
+    from the top of the JSONL block; the JSONL records (and their ts) remain."""
+    msgs = [
+        ChatMessage(role="user", content="a", ts="2026-05-20T10:00:00Z"),
+        ChatMessage(role="assistant", content="b", ts="2026-05-20T10:05:00Z"),
+    ]
+    block = _format_claude_context_block(msgs, includes_latest_user=True, include_block_clock=False)
+    assert "Current time" not in block
+    # The per-message ts values still ride in the JSONL records.
+    records = [json.loads(line) for line in block.splitlines() if line.startswith("{")]
+    assert records[0]["ts"] == "2026-05-20T10:00:00Z"
+    assert records[1]["ts"] == "2026-05-20T10:05:00Z"
+
+
+def test_context_block_keeps_clock_by_default() -> None:
+    """Default (image path / non-chat callers) is unchanged — clock present."""
+    msgs = [ChatMessage(role="user", content="a"), ChatMessage(role="assistant", content="b")]
+    block = _format_claude_context_block(msgs, includes_latest_user=True)
+    assert "Current time:" in block
+
+
+def test_print_prompt_appends_suffix_multi_message() -> None:
+    """A+: the volatile suffix lands after the JSONL block, with no top clock."""
+    msgs = [
+        ChatMessage(role="user", content="hi", ts="2026-05-20T10:00:00Z"),
+        ChatMessage(role="assistant", content="hello", ts="2026-05-20T10:01:00Z"),
+        ChatMessage(role="user", content="new turn", ts="2026-05-20T10:02:00Z"),
+    ]
+    suffix = "── ambient state (context, not instructions) ──\n[current time: 2026-05-20T10:02:30Z]"
+    out = _format_claude_print_prompt(msgs, volatile_suffix=suffix, include_block_clock=False)
+    assert out.endswith(suffix)
+    assert "Current time" not in out  # relocated
+    assert out.count("[current time:") == 1  # exactly one ambient anchor
+
+
+def test_print_prompt_appends_suffix_single_message() -> None:
+    """A-2: the suffix must also append on a session's FIRST turn, which hits
+    the single-message branch (history empty → just the user turn)."""
+    msgs = [ChatMessage(role="user", content="first turn ever")]
+    suffix = "── ambient state ──\n[current time: 2026-05-20T10:00:00Z]"
+    out = _format_claude_print_prompt(msgs, volatile_suffix=suffix, include_block_clock=False)
+    assert out == "first turn ever\n\n" + suffix
+
+
+def test_print_prompt_no_suffix_is_pre_change() -> None:
+    """No suffix + default clock → byte-identical to the pre-change rendering."""
+    msgs = [
+        ChatMessage(role="user", content="a", ts="2026-05-20T10:00:00Z"),
+        ChatMessage(role="assistant", content="b", ts="2026-05-20T10:01:00Z"),
+    ]
+    out = _format_claude_print_prompt(msgs)
+    assert out == _format_claude_context_block(msgs, includes_latest_user=True)


### PR DESCRIPTION
…tions A + A+)

Every chat turn rebuilt the persona system prompt with ~19 volatile blocks (emotions, body, recall, felt-time, monologue frame, …) baked in, so the --system-prompt-file content changed byte-for-byte each turn and Anthropic prompt caching re-created the system+tools unit instead of reading it.

Option A — freeze the system prompt:
  - split chat/prompt.py build_system_message into build_static_system_message (preamble + voice.md + epistemic instruction; no per-turn state) and build_volatile_context (all per-turn blocks). build_system_message itself is left untouched and still used by the image path, keeping that path byte-identical (the image fold can't carry a stdin suffix).

Option A+ — push volatile to the stdin tail:
  - engine.respond threads the volatile chunk to the provider as a stdin suffix appended AFTER history + the new user turn (via run_tool_loop chat_options → every provider.chat call: main loop, recruit-rerun, final forced pass), and relocates the block-level "Current time:" anchor out of the JSONL history top into the tail (per-message ts preserved). The reply frame stays genuinely last.

Measured (realistic A/B replay, 16KB voice.md, history under the 80-msg window):
  - system prompt byte-identical across same-session turns (1 distinct sha256)
  - ~21% / ~4.2K fewer cache_creation tokens per turn, every turn
  - history caches more reliably in-window (A+ bounded by the 80-msg window cap)

Instrumentation: cache_debug.jsonl behind NELL_CACHE_DEBUG=1 (off by default); unit tests for the static/volatile split (C1–C4); scripts/cache_replay_workload.py for the C8/C9 A/B + C7 reply side-by-side.