### PR TITLE
fix(ui): dark base for error/boot screens

### DIFF
--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -34,7 +34,12 @@
   --rose: #c89890;               /* keep: initiate-banner / pending-write family */
   --mauve: var(--text-mute);
   --ash: var(--track);
-  --bg-scene: transparent;
+  /* Opaque ember-dark base. Was transparent — which relied on the webview's
+   * default page background being dark (true on macOS dark-mode, WHITE on
+   * Linux GTK-webkit / light appearance). Panel-less screens (BootScreen,
+   * BridgeErrorScreen) then rendered light text on white. Dark-only design →
+   * paint our own base so every platform reads dark. */
+  --bg-scene: #191214;
   --bubble-nell: var(--bubble-in);
   --bubble-user: var(--accent);
   --font-ui: -apple-system, BlinkMacSystemFont, 'SF Pro Text', 'Segoe UI', system-ui, sans-serif;
@@ -66,7 +71,7 @@ body,
 #root {
   width: 100%;
   height: 100%;
-  background: transparent;
+  background: var(--bg-scene);
   font-family: var(--font-ui);
   font-size: 13px;
   line-height: 1.5;


### PR DESCRIPTION
## Problem

The error screen (and BootScreen) render as white on Linux/non-dark webviews — light text on white, unreadable. Screenshot came from a bridge-start failure ("could not start the bridge for Phoebe").

## Root cause

`--bg-scene` was `transparent` and `html/body/#root` had `background: transparent`. The dark look relied on the webview's **default** page background being dark — true on macOS dark-mode, **white** on Linux GTK-webkit / light appearance. The Ready view masks it with glass panels; panel-less screens (BootScreen, BridgeErrorScreen) reveal the white.

## Fix

Design is dark-only → paint our own opaque ember-dark base (`#191214`) instead of inheriting it. One CSS change, presentation-only.

## Verification

- body computed `background-color: rgb(25,18,20)` = `#191214`
- Preview screenshot: dark fills whole viewport, no white in empty regions
- Glass panels / rail / avatar unchanged — no regression
- Zero console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)