### PR TITLE
fix(harness): unbreak windows-latest — utf-8 reads, posix fingerprint keys

### DIFF
--- a/tests/harness/sandbox.py
+++ b/tests/harness/sandbox.py
@@ -336,7 +336,12 @@ def _fingerprint(
             entry: tuple = (st.st_size, st.st_mtime_ns)
             if hash_content:
                 entry = (st.st_size, st.st_mtime_ns, _content_hash(f))
-            fp[str(f.relative_to(root))] = entry
+            # as_posix(), not str(): str(Path) gives OS-native separators, so the same tree
+            # keyed 'keep/present.txt' here and 'keep\present.txt' on Windows. The map is only
+            # ever compared against another map from the same run, so the logic never cared —
+            # but the spelling leaked into assertions, and a platform-dependent key is a trap
+            # for anything that ever reports or persists one. No-op off Windows.
+            fp[f.relative_to(root).as_posix()] = entry
     return fp
 
 

--- a/tests/unit/harness/test_live_service_precheck.py
+++ b/tests/unit/harness/test_live_service_precheck.py
@@ -516,11 +516,16 @@ def test_every_run_path_routes_through_sandbox() -> None:
     example calls `sandbox(`; no harness helper stands up a BridgeServer outside a `sandbox()`."""
     harness_dir = Path(__file__).resolve().parents[2] / "harness"
     example = harness_dir / "examples" / "test_generic_run.py"
-    assert "sandbox(" in example.read_text(), "the worked example must run inside sandbox()"
+    # encoding= is not optional: read_text() resolves to cp1252 on Windows, and the worked
+    # example has a ⚠️ in its docstring — 0x8F has no cp1252 codepoint, so this raised
+    # UnicodeDecodeError on windows-latest while passing everywhere else.
+    assert "sandbox(" in example.read_text(encoding="utf-8"), (
+        "the worked example must run inside sandbox()"
+    )
 
     # No module under tests/harness/ should construct BridgeServer without importing sandbox.
     for py in harness_dir.rglob("*.py"):
-        text = py.read_text()
+        text = py.read_text(encoding="utf-8")
         if "BridgeServer(" in text and py.name != "engine.py":
             assert "sandbox" in text, f"{py.name} builds a bridge but does not reference sandbox()"
 


### PR DESCRIPTION
## Windows CI has been red on main since #70

`windows-latest` fails on every PR opened against main since the harness merge — including #73 and #68. Every other job (ubuntu, macOS, frontend, tauri, marker-scan) is green. #58 is only green because it sits on an older base.

Both failures are Windows-only and neither reproduces locally, which is why they got in:

```
tests/unit/harness/test_live_service_precheck.py::test_every_run_path_routes_through_sandbox
  UnicodeDecodeError: 'charmap' codec can't decode byte 0x8f in position 589

tests/unit/harness/test_sandbox_isolation.py::test_fingerprint_exclude_single_subtree_still_prunes
  assert 'keep/present.txt' in {'keep\present.txt': (7, ...)}
```

## What they actually are

**`read_text()` takes the platform default codec — cp1252 on Windows.** The worked example `test_generic_run.py` has a `⚠️` in its docstring; cp1252 has no 0x8F codepoint, so the source-scanning assert died on the emoji rather than on anything it was testing. This is the project's existing subprocess-encoding gotcha, one layer out: nobody had written it down for file reads.

Confirmed without a Windows host — `Path(f).read_text(encoding="cp1252")` reproduces it exactly on macOS (byte 581 locally vs 589 in CI; the 8-byte gap is Windows checking out CRLF).

**`str(Path)` is OS-native.** `_fingerprint` keyed on `str(f.relative_to(root))`, so the map came back `{'keep\present.txt': ...}` and an assertion spelling it `keep/present.txt` failed. The map is only ever compared against another map from the same run, so the logic never cared — but the spelling leaked into a test, and a platform-dependent key is a trap for anything that ever reports or persists one. `as_posix()` is a no-op off Windows.

## Why there's no linter rule

`scripts/lint_windows_pitfalls.py` looked like the right home, but it isn't:

- its encoding rule is `subprocess.run/Popen/...` only — it never inspects `read_text()`, so widening its root to `tests/` would not have caught this;
- a bare `read_text()`-without-`encoding=` rule fires **638×** in `tests/` alone, while only **7** files are actually non-ASCII. That's noise, not a guard.

A rule that can't be sharp isn't worth the false positives. The gotcha is documented at the fix sites and in the project's Windows footgun list instead.

## Verification

- The two CI tests pass locally; full harness suite 140 passed / 1 skipped. The one failure (`test_generic_live_run`) is pre-existing — it fails identically on `main` with these changes stashed, and it needs a live service.
- ruff clean.
- **`windows-latest` on this PR is the real proof** — that's the check that's been red, and it runs here.

Unblocks #73 and #68.

@ThinkerOfThoughts — these are your harness files (#70). Both fixes are one line each and I've left the reasoning in comments at each site; happy to hand it over if you'd rather take it.
