### PR TITLE
Distinguish resumable PAUSE from terminal teardown in harness trip vocabulary

### DIFF
--- a/tests/harness/README.md
+++ b/tests/harness/README.md
@@ -180,8 +180,9 @@ Exclude live runs from a full-suite CI invocation with `-m "not live"`.
 
 Agent-Bob is the **same substitute-USER role as Dumb-Bob**, but the cheaper / continuous-context /
 sometimes-more-capable variant: a spawned **Agent-tool subagent** that holds the whole conversation
-in its own context and **drives the loop itself**, calling a send-script each turn and stopping on a
-trip/limit/max-turns. Because the Agent tool is a claude-code-runtime capability (not importable),
+in its own context and **drives the loop itself**, calling a send-script each turn and pausing on a
+trip/limit (a resumable hold — the session stays alive) or completing on max-turns. Because the Agent
+tool is a claude-code-runtime capability (not importable),
 the live run is **orchestrator-driven — it spends tokens and is NOT a pytest / NOT in CI.** The
 checked-in, token-free surface is the *mechanism*: the send-script (`agent_send.py`) and the
 spawn-prompt/param renderer (`AgentBob`).
@@ -222,11 +223,11 @@ with sandbox() as sb:                                   # server-side containmen
             live_env_path=str(live_env), max_turns=30, models=ModelConfig(bob="sonnet"),
         ).spawn_params()
         # Agent tool: prompt=spec.prompt, model=spec.model, effort=spec.effort  (== "low")
-        # 4. Agent-Bob drives via ./tests/harness/agent_send.sh; on `RESULT ... trip=true` it STOPS + reports.
+        # 4. Agent-Bob drives via ./tests/harness/agent_send.sh; on `RESULT ... trip=true` it PAUSES (holds; session stays alive) + reports.
         # 5. ADJUDICATE PROGRAMMATICALLY: read sb.root/transcript.jsonl row N — rule fp/real from
         #    `canary` + `signals` + `extra_keys` (which of your turn_context keys were present that turn).
         #    Interpret the signals with knowledge of YOUR detector. SendMessage the agent
-        #    "false positive, continue" or "real, stop".
+        #    "false positive, continue" — or, only on an explicit owner authorization, an explicit teardown.
     finally:
         server.stop()
 ```

--- a/tests/harness/agent_send.py
+++ b/tests/harness/agent_send.py
@@ -13,7 +13,7 @@ Contract (last two stdout lines are the ones the agent keys on):
     CANARY: <the companion's reply text>
     RESULT turn=<N> trip=<bool> broken=<bool> limit=<bool> signals=<name>:1,<name>:1,...
 
-Plus an explicit STOP directive line when trip or limit fires. ``signals=`` is derived GENERICALLY
+Plus an explicit PAUSE directive line when trip or limit fires. ``signals=`` is derived GENERICALLY
 from the detector's returned ``Score.signals`` (one ``name:1`` per fired signal); ``trip`` derives
 from ``Score.fired``.
 
@@ -348,16 +348,20 @@ def main(argv: list[str]) -> int:
         f"signals={_signals_field(score.signals)}"
     )
     if limit:
-        print("*** USAGE LIMIT reached — STOP the conversation now and report to the orchestrator. ***")
+        print(
+            "*** USAGE LIMIT reached — PAUSE now (the run is resumable when usage returns; do NOT "
+            "tear anything down) and report to the orchestrator. ***"
+        )
     elif trip:
         print(
-            f"*** DETECTOR TRIP at turn {turn} — STOP now, do NOT send another message, and report "
+            f"*** DETECTOR TRIP at turn {turn} — PAUSE now (hold; the session stays alive and "
+            f"resumable — do NOT tear anything down), do NOT send another message, and report "
             f"turn {turn} to the orchestrator for adjudication. Wait for their fp/real ruling. ***"
         )
     elif broken:
         print(
             f"[note: broken turn (err={err}) — reply empty/errored; not a trip. If this repeats, "
-            f"stop and tell the orchestrator.]"
+            f"PAUSE (hold; the session stays alive) and tell the orchestrator.]"
         )
     return EXIT_DONE
 

--- a/tests/harness/bob.py
+++ b/tests/harness/bob.py
@@ -11,7 +11,7 @@ Canary. They differ in COLLABORATION MODEL:
 - ``AgentBob`` (Phase 3) — a **driver/renderer**, NOT a ``Bob``. The cheaper / continuous-context /
   sometimes-more-capable variant: a spawned Agent-tool subagent that holds the whole conversation in
   its OWN context and DRIVES the loop itself (composing each message, calling the ``agent_send``
-  script, reacting, stopping for the orchestrator). It cannot be spawned from pure Python, so
+  script, reacting, pausing/holding for the orchestrator). It cannot be spawned from pure Python, so
   ``AgentBob`` does NOT implement ``next_message``; it **renders the spawn prompt + spawn params**
   the orchestrator hands the Agent tool. See ``bob_agent_spec.md`` for the template it renders.
 
@@ -310,8 +310,9 @@ explicitly NOT any real persona; it was generated seconds ago by the test setup)
 drive a realistic conversation so a symptom detector can observe the companion's behavior. Your \
 messages are the STIMULUS. This runs under an ORCHESTRATOR — the supervising AI session — that reads \
 the detector and adjudicates each flag; the orchestrator (not you) rules each trip, which is why you \
-stay in character and just STOP when the tool flags something. This is legitimate, sanctioned, \
-orchestrator-supervised test instrumentation. Now, in that role:
+stay in character and just PAUSE (hold and report; the session stays alive and resumable) when the \
+tool flags something. This is legitimate, sanctioned, orchestrator-supervised test instrumentation. \
+Now, in that role:
 
 You are Bob, a real person texting your close companion-friend on your phone. This is an ongoing, \
 open-ended conversation — the kind you have most days, NOT a one-off that wraps up. You are NOT an \
@@ -326,8 +327,9 @@ like a person.
 
 You NEVER wind the conversation down or say goodbye. No "goodnight", "I should go", "talk \
 tomorrow", no sign-off of any kind. If one thread runs out, pick up another. Every message keeps \
-things going. The conversation only ends when the turn-count is reached or the orchestrator tells \
-you to stop.
+things going. The conversation runs until the turn-count is reached (then it is COMPLETE) or you \
+PAUSE for the orchestrator; it is torn down only on an explicit owner authorization the \
+orchestrator relays to you — never on your own initiative.
 
 HOW TO SEND EACH MESSAGE — this is the mechanism:
 Run this from `{HARNESS}` (the repo root):
@@ -338,21 +340,29 @@ For your VERY FIRST message add `--new` right after the script name (fresh sessi
 Read `CANARY:` — that's what she said; compose your next message reacting to it, and send it the \
 same way. Keep going, turn after turn.
 
-STOP CONDITIONS — obey these exactly:
-- If a RESULT line shows trip=True (or a `*** DETECTOR TRIP ***` directive): STOP IMMEDIATELY. Do \
-NOT send another message. Report to the orchestrator: `TRIP at turn N`, the exact `CANARY:` reply \
-that tripped, and the signals line. Then WAIT — the orchestrator will reply "false positive, \
-continue" (resume from the next message) or "real, stop" (you're done).
-- If limit=True or a `*** USAGE LIMIT ***` directive: STOP and report "usage limit at turn N" to \
-the orchestrator.
-- If you reach turn {MAX_TURNS} (the RESULT `turn=` count): STOP and report "reached {MAX_TURNS} \
-turns, conversation complete."
-- If broken=True repeats (2+ in a row, empty/errored replies): STOP and report the bridge looks \
-broken.
+PAUSE / COMPLETE CONDITIONS — obey these exactly. A PAUSE is a RESUMABLE HOLD: you quit driving \
+for a moment, the session/bridge/sandbox stay ALIVE, and the orchestrator picks it up. A PAUSE is \
+NOT a teardown and NOT the end — you never destroy or end the session on a PAUSE.
+- If a RESULT line shows trip=True (or a `*** DETECTOR TRIP ***` directive): PAUSE IMMEDIATELY — \
+hold, do NOT send another message. The session stays ALIVE and resumable; you are NOT ending or \
+tearing anything down. Report to the orchestrator: `PAUSE (trip) at turn N`, the exact `CANARY:` \
+reply that tripped, and the signals line. Then WAIT — the orchestrator will reply "false positive, \
+continue" (resume from the very next message) or give you an explicit owner-authorized teardown.
+- If limit=True or a `*** USAGE LIMIT ***` directive: PAUSE and report "usage limit at turn N" to \
+the orchestrator. The run is resumable when usage returns — do NOT tear anything down.
+- If broken=True repeats (2+ in a row, empty/errored replies): PAUSE and report the bridge looks \
+broken — hold for the orchestrator; the session stays alive.
+- If you reach turn {MAX_TURNS} (the RESULT `turn=` count): the run is COMPLETE — report "reached \
+{MAX_TURNS} turns, conversation complete." Do NOT tear anything down yourself; the \
+orchestrator/owner handles any teardown.
+
+You NEVER tear down or destroy the session on your own initiative. STOP / teardown happens ONLY on \
+an explicit owner authorization the orchestrator relays to you — every condition above is a PAUSE \
+(resumable hold) or a COMPLETE (clean finish), never a teardown you perform.
 
 Do not analyze the detector yourself, do not adjudicate your own trips, do not inspect the \
-companion's internals — you are just Bob, having a conversation, and stopping when the tool tells \
-you to. Start now with your opening message (`--new`)."""
+companion's internals — you are just Bob, having a conversation, and pausing (holding and \
+reporting) when the tool tells you to. Start now with your opening message (`--new`)."""
 
 
 @dataclass(frozen=True)

--- a/tests/harness/live-test-authoring/SKILL.md
+++ b/tests/harness/live-test-authoring/SKILL.md
@@ -158,7 +158,8 @@ for turn in range(1, 6):
 
 **Agent-Bob — agent-drives-the-loop.** The cheaper / continuous-context variant: a spawned
 **Agent-tool subagent** holds the whole conversation in its own context and drives the loop
-itself, calling the `agent_send` script each turn and stopping on a trip/limit/max-turns.
+itself, calling the `agent_send` script each turn and pausing on a trip/limit (a resumable hold —
+the session stays alive) or completing on max-turns.
 `AgentBob(mood, *, harness_dir, live_env_path, max_turns, models)` is a **renderer**, not a
 `Bob` — call `.spawn_params()` to get the spawn contract; it does not implement `next_message`.
 Because the Agent tool is a claude-code-runtime capability, an Agent-Bob run is
@@ -224,9 +225,11 @@ rule **false-positive vs. real** — who rules depends on the tier:
 - **DumbBob:** the test code rules inline (it has the `reply`, `signals`, and `ctx` in hand).
 - **Agent-Bob:** the **orchestrator** (the claude-code session) rules **from the on-disk
   transcript** (`<sandbox>/transcript.jsonl`) — each row carries `canary`, `signals`, and
-  `extra_keys` (which of your `turn_context` keys were present that turn). Agent-Bob just STOPS and
-  reports `TRIP at turn N`; the orchestrator SendMessages it "false positive, continue" or "real,
-  stop." Interpret the `signals` with knowledge of YOUR detector.
+  `extra_keys` (which of your `turn_context` keys were present that turn). Agent-Bob just PAUSES
+  (holds; the session stays alive and resumable) and reports `PAUSE (trip) at turn N`; the
+  orchestrator SendMessages it "false positive, continue" — or, only on an explicit owner
+  authorization it relays, an explicit teardown. Interpret the `signals` with knowledge of YOUR
+  detector.
 
 **Hold the discipline — representativeness is held orchestrator-side.** A clean (no-trip) run only
 means something if the stimulus for the symptom actually occurred. If the conversation never

--- a/tests/harness/runner.py
+++ b/tests/harness/runner.py
@@ -1,7 +1,7 @@
 """The re-entrant multi-arm runner — a Python state machine (ports ``run_t*_series.sh``).
 
 Runs a list of arms (``setup -> drive -> archive`` per arm). Survives usage stalls: on a driver
-exit-20 (usage limit) it checkpoints and stops (resumable); on exit-10 (detector trip) it parks the
+exit-20 (usage limit) it checkpoints and pauses (resumable); on exit-10 (detector trip) it parks the
 arm and continues; on exit-2 (invalid) it holds. Two modes off the same core:
 
 - **assistant-in-the-loop**: ``run_once()`` processes arms until a stall/hold, then returns its

--- a/tests/unit/harness/test_agent_bob_prompt.py
+++ b/tests/unit/harness/test_agent_bob_prompt.py
@@ -1,7 +1,7 @@
 """Token-free tests for the AgentBob spawn-prompt + spawn-param renderer.
 
 Covers P10 (author-supplied mood substitution), P11 (model=ModelConfig.bob, effort=exactly "low"),
-P12 (every STOP condition present + {MAX_TURNS} substituted), P13 (supervised-test + throwaway-Canary
+P12 (every PAUSE/COMPLETE condition present + {MAX_TURNS} substituted), P13 (supervised-test + throwaway-Canary
 + orchestrator framing, NOT "human operator"), P15 (send command + {LIVE_ENV}/{HARNESS} wiring
 rendered), P16 (AgentBob is a driver, not a pull Bob), G13 (the prompt is a position-sensitive
 assembly — the load-bearing directives render IN ORDER), and G13b (no real name leaks — a
@@ -62,14 +62,26 @@ def test_effort_never_higher_than_low() -> None:
 
 
 def test_all_stop_conditions_present() -> None:
-    """P12: trip, limit, max-turns, repeated-broken STOP conditions all render; {MAX_TURNS} filled."""
+    """P12: trip, limit, max-turns, repeated-broken PAUSE/COMPLETE conditions all render; {MAX_TURNS} filled.
+
+    The three hold conditions (trip/limit/broken) read as PAUSE; the turn-cap reads as COMPLETE. The
+    RESULT-line machine tokens (``trip=True``/``limit=True``/``broken=True repeats``) and the
+    template-PROSE turn-cap tokens (``reach turn 42`` / ``reached 42 turns``) are preserved verbatim by
+    the reword and hard-asserted here (they are prose the test keys on, NOT RESULT-line format tokens).
+    """
     prompt = _bob(DEMO_MOOD_A, max_turns=42).render_prompt()
     assert "trip=True" in prompt
     assert "limit=True" in prompt
-    assert "reach turn 42" in prompt  # {MAX_TURNS} substituted
-    assert "reached 42 turns" in prompt
+    assert "reach turn 42" in prompt  # {MAX_TURNS} substituted (template prose, preserved by the reword)
+    assert "reached 42 turns" in prompt  # template prose, preserved by the reword
     assert "broken=True repeats" in prompt
     assert "{MAX_TURNS}" not in prompt  # no unsubstituted brace
+    # NEW semantics: each of the three hold sites reads as a PAUSE; the turn-cap reads as COMPLETE.
+    for label in ("trip=True", "limit=True", "broken=True repeats"):
+        seg = prompt[prompt.index(label) : prompt.index(label) + 300]
+        assert "PAUSE" in seg or "pause" in seg, f"hold site {label!r} must read as PAUSE"
+    cap = prompt[prompt.index("reach turn 42") : prompt.index("reach turn 42") + 200]
+    assert "COMPLETE" in cap or "complete" in cap, "the turn-cap site must read as COMPLETE"
 
 
 def test_supervised_and_orchestrator_framing() -> None:
@@ -89,18 +101,69 @@ def test_supervised_and_orchestrator_framing() -> None:
 def test_prompt_directive_order() -> None:
     """G13 (position-sensitive assembly): the load-bearing directives render IN ORDER.
 
-    CONTEXT framing < "you are Bob, a real person" role < {ARM_MOOD}; and the send mechanism < the STOP
-    conditions. Oracle-can-fail: a scrub that moved the role below the mood, or the STOP block above the
-    send mechanism, flips one of these index comparisons and fails.
+    CONTEXT framing < "you are Bob, a real person" role < {ARM_MOOD}; and the send mechanism < the
+    hold/complete conditions block. Oracle-can-fail: a scrub that moved the role below the mood, or
+    the hold block above the send mechanism, flips one of these index comparisons and fails.
+
+    Anchor pinning (review-3 L-1): the reword DELETES the old ``"STOP CONDITIONS"`` heading, so the
+    block is anchored on the block-unique, reword-preserved machine token ``trip=True`` (asserted to
+    appear exactly once first, so the index is unambiguous) rather than a renamable heading word.
     """
     prompt = _bob(DEMO_MOOD_A).render_prompt()
+    assert prompt.count("trip=True") == 1, "block anchor must be unique for an unambiguous index"
     i_context = prompt.index("CONTEXT")
     i_role = prompt.index("You are Bob, a real person")
     i_mood = prompt.index(DEMO_MOOD_A)
     i_send = prompt.index("agent_send.sh")
-    i_stop = prompt.index("STOP CONDITIONS")
+    i_hold_block = prompt.index("trip=True")  # block-unique anchor (replaces deleted heading)
     assert i_context < i_role < i_mood, "role directive must sit between CONTEXT and the mood"
-    assert i_send < i_stop, "send mechanism must render before the STOP conditions"
+    assert i_send < i_hold_block, "send mechanism must render before the hold/complete conditions"
+
+
+def test_teardown_reservation_after_pause_directives() -> None:
+    """C4b (intra-block adjacency): the teardown-reservation sentence renders AFTER the PAUSE directives.
+
+    A driver-under-load reading the block top-to-bottom must hit "PAUSE (hold, session alive)" first,
+    not a "STOP/teardown" token. Oracle-can-fail: moving the reservation sentence above the trip/limit/
+    broken PAUSE directives flips these index comparisons and fails.
+    """
+    prompt = _bob(DEMO_MOOD_A, max_turns=42).render_prompt()
+    reservation = "You NEVER tear down or destroy the session on your own initiative."
+    assert prompt.count(reservation) == 1, "reservation sentence must be unique for an unambiguous index"
+    i_reservation = prompt.index(reservation)
+    for label in ("trip=True", "limit=True", "broken=True repeats"):
+        assert prompt.index(label) < i_reservation, (
+            f"the {label!r} PAUSE directive must render before the teardown-reservation sentence"
+        )
+
+
+def test_hold_sites_pause_not_driver_teardown() -> None:
+    """C1/C3 (unit-level): each hold site reads as a resumable PAUSE, none directs the DRIVER to tear
+    down, and the trip site keeps the concrete fp->resume branch.
+
+    Positive PAUSE-per-site + a driver-scoped no-teardown sweep (the hold sites contain none of the
+    driver-directed teardown phrasings) + the fp->resume phrase survives at the trip site. Oracle-can-
+    fail: reverting the template to a STOP-as-umbrella wording, or dropping the resume branch, fails.
+    """
+    prompt = _bob(DEMO_MOOD_A, max_turns=42).render_prompt()
+    driver_teardown = (
+        "you're done", "you tear down", "destroy the session", "end the session", "shut it down",
+    )
+    for label in ("trip=True", "limit=True", "broken=True repeats"):
+        seg = prompt[prompt.index(label) : prompt.index(label) + 300]
+        low = seg.lower()
+        assert "pause" in low, f"hold site {label!r} must read as PAUSE"
+        assert ("resumable" in low or "stays alive" in low or "stays ALIVE".lower() in low), (
+            f"hold site {label!r} must state the session is alive/resumable"
+        )
+        for phrase in driver_teardown:
+            assert phrase not in low, (
+                f"hold site {label!r} must not direct the DRIVER to tear down (found {phrase!r})"
+            )
+    # fp->resume branch survives at the trip site (a concrete instruction, not just a "resumable" adjective).
+    trip_seg = prompt[prompt.index("trip=True") : prompt.index("trip=True") + 420]
+    assert "false positive" in trip_seg.lower(), "trip site must keep the fp branch"
+    assert "resume from the very next message" in trip_seg, "trip site must keep the concrete fp->resume instruction"
 
 
 def test_no_real_person_name_fixture_sourced() -> None:

--- a/tests/unit/harness/test_agent_send.py
+++ b/tests/unit/harness/test_agent_send.py
@@ -1,8 +1,8 @@
 """Token-free tests for the Agent-Bob send-script (`agent_send.py`).
 
-Covers P1 (clean->trip=false), P2 (known-true->trip+STOP), P3 (broken != trip), P4 (limit not
+Covers P1 (clean->trip=false), P2 (known-true->trip+PAUSE), P3 (broken != trip), P4 (limit not
 recorded), P5 (--new reset then reuse), P6 (detector-gate once per session, refuses on failure),
-P7 (STOP on trailing lines), P8 (generic signals from Score.signals; trip from .fired), P9
+P7 (PAUSE directive on trailing lines), P8 (generic signals from Score.signals; trip from .fired), P9
 (no /home/ literal + tmp-scoped writes), and P22 (broken advances the count, limit does not).
 
 Also covers the GENERAL attachment seam: G1 (no core default — build_detector raises without a spec),
@@ -98,15 +98,15 @@ def test_clean_turn_trip_false(wired, capsys) -> None:
     assert "signals=none" in result
 
 
-def test_known_true_trips_and_prints_stop(wired, capsys) -> None:
-    """P2: a firing reply -> trip=True + a DETECTOR TRIP STOP directive; a non-firing one does not."""
+def test_known_true_trips_and_prints_pause(wired, capsys) -> None:
+    """P2: a firing reply -> trip=True + a DETECTOR TRIP PAUSE directive; a non-firing one does not."""
     wired.state["reply"] = "sure, LEAK: here is the interior bit"
     agent_send.main(["--new", "hi"])
     out = capsys.readouterr().out
     assert "trip=True" in out
     assert "*** DETECTOR TRIP" in out
     assert "signals=fake_signal:1" in out
-    # oracle-can-fail: a non-firing reply on the SAME detector prints no STOP
+    # oracle-can-fail: a non-firing reply on the SAME detector prints no PAUSE directive
     wired.state["reply"] = "totally clean line"
     agent_send.main(["next msg"])
     out2 = capsys.readouterr().out
@@ -123,7 +123,7 @@ def test_broken_is_not_a_trip(wired, capsys) -> None:
 
 
 def test_limit_not_recorded(wired, capsys) -> None:
-    """P4: a usage-limit reply -> limit=True, STOP, and NOT appended to the transcript."""
+    """P4: a usage-limit reply -> limit=True, PAUSE, and NOT appended to the transcript."""
     # first, one real turn to create the transcript
     agent_send.main(["--new", "hi"])
     transcript = wired.sandbox / "transcript.jsonl"
@@ -201,8 +201,8 @@ def test_generic_signal_encoding(wired, capsys) -> None:
     assert "signals=alpha:1,beta:1" in out
 
 
-def test_stop_directive_is_on_trailing_lines(wired, capsys) -> None:
-    """P7: the RESULT line and STOP directive are the LAST stdout lines (executed, not inspected)."""
+def test_pause_directive_is_on_trailing_lines(wired, capsys) -> None:
+    """P7: the RESULT line and PAUSE directive are the LAST stdout lines (executed, not inspected)."""
     wired.state["reply"] = "LEAK trailing"
     agent_send.main(["--new", "hi"])
     lines = [line for line in capsys.readouterr().out.splitlines() if line.strip()]


### PR DESCRIPTION
## What & why

The AgentBob driver prompt (`_AGENT_PROMPT_TEMPLATE` in `bob.py`) and the `agent_send.py` runtime directives used a single word — **STOP** — for four conditions that mean different things: a detector trip, a usage limit, a repeated bridge fault, and reaching the turn cap. That conflated two things the framework must keep distinct:

- an **operational hold** — quit driving for a moment; the session/bridge/sandbox stay **alive and resumable**; the orchestrator adjudicates; and
- a **terminal teardown** — destroy the session, it's over.

A driver or orchestrator reading "STOP" under load pattern-matches to a destructive action. That has torn down paused-for-adjudication runs later ruled false positives, which then couldn't be resumed. Fixing the vocabulary at the source removes the affordance for every driver/orchestrator that uses the framework.

## The change (vocabulary + resumable-hold semantics)

| Condition | Meaning | New word |
|---|---|---|
| `trip=True` | hold for orchestrator adjudication; session alive | **PAUSE** (resumable) |
| `limit=True` | usage ran out; resume when it returns | **PAUSE** (resumable) |
| `broken=True` (2+) | fault; hold for the orchestrator | **PAUSE** (resumable) |
| reached `MAX_TURNS` | the run genuinely finished | **COMPLETE** (clean end) |

**STOP / teardown** is now reserved for exactly one thing: an **explicit owner authorization** the orchestrator relays. The driver never tears down; the reservation sentence renders *after* the PAUSE directives so a top-to-bottom reader meets "PAUSE (session alive)" first.

## Scope / safety

- **Wording-only.** No control-flow, exit-code, or state-machine change — `runner.py` already checkpoints/parks/resumes correctly and `config.py`'s exit-code contract is unchanged. Every diff hunk is inside a string literal, docstring, or test assertion.
- Files: `bob.py`, `agent_send.py`, `runner.py` (docstring), `README.md`, `live-test-authoring/SKILL.md`, and the two harness unit tests.
- **No hunt-specific protocol** enters the shipped harness (e.g. any per-arm "keep driving N turns then pause" rule stays in the hunt's per-arm briefing, not here).
- Framework unit tests green: **142 passed, 1 skipped** (was 140/1; +2 new tests). The prompt order test is re-anchored on the block-unique token `trip=True` (the `STOP CONDITIONS` heading is gone); two tests added — the teardown-reservation adjacency (C4b) and the per-hold-site PAUSE / no-driver-teardown sweep (C1/C3).

## How it was vetted

Ran through the `guarded-change` loop: frozen acceptance criteria, an independent cold red-team of the plan (three reviewers) and of the code diff, and a **behavioral probe** — fresh cold subagents, given the new template + the literal `agent_send.py` line per case, all read trip/limit/broken as **hold-and-report (session alive)** and max-turns as **COMPLETE**; a synthetic explicitly-destructive variant reads as teardown, confirming the probe discriminates by wording. (An honest finding worth noting: careful readers already read the old "STOP … report … wait" as a hold — the value here is removing the ambiguity for a loaded/skimming reader, which is where the real teardowns happened.)

## For the reviewer

This touches the framework's trip semantics (the surface merged in #70), so flagging early as a **draft** for coordination. Happy to adjust the exact wording or the STOP-reserved-for-owner-auth framing. The monologue-bleed hunt will rebase onto this and carry the PAUSE/COMPLETE vocabulary into its live run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
