### PR TITLE
Wire research into her chat context (research awareness block)

### DIFF
--- a/brain/chat/prompt.py
+++ b/brain/chat/prompt.py
@@ -19,6 +19,7 @@ from pathlib import Path
 from brain.chat.monologue_prompts import build_monologue_frame, build_reply_frame
 from brain.chat.tool_inventory import build_tool_inventory
 from brain.engines.daemon_state import DaemonState, get_residue_context
+from brain.engines.research_ambient import build_research_awareness_block
 from brain.maker.ambient import build_maker_awareness_block
 from brain.memory.store import MemoryStore
 from brain.soul.store import SoulStore
@@ -273,6 +274,16 @@ def build_system_message(
     except Exception:  # noqa: BLE001
         pass
 
+    # 7c. Interior research-awareness — recent research she ran on her own, so it
+    # is present in context (she was previously unaware research had run at all;
+    # it only reached her if she actively searched). Fail-soft.
+    try:
+        research_block = build_research_awareness_block(store, limit=3)
+        if research_block:
+            parts.append(research_block)
+    except Exception:  # noqa: BLE001
+        pass
+
     # 8. Inner monologue framing — names the record_monologue tool, articulates
     # situational trigger criteria. Per spec 2026-05-30 §2.
     soul_hints = _collect_soul_hints(soul_store, limit=3)
@@ -501,6 +512,14 @@ def build_volatile_context(
         maker_block = build_maker_awareness_block(persona_dir, limit=5)
         if maker_block:
             parts.append(maker_block)
+    except Exception:  # noqa: BLE001
+        pass
+
+    # 7c. Interior research-awareness — fail-soft (mirrors maker block above).
+    try:
+        research_block = build_research_awareness_block(store, limit=3)
+        if research_block:
+            parts.append(research_block)
     except Exception:  # noqa: BLE001
         pass
 

--- a/brain/engines/research_ambient.py
+++ b/brain/engines/research_ambient.py
@@ -1,0 +1,29 @@
+"""Interior awareness of her own recent research, woven into the system message.
+
+Wire-back: the research engine files memories and leaves cards, but nothing
+surfaced them into her chat context — she only found research by actively
+searching a matching keyword. This mirrors brain.maker.ambient so recent
+research is present in her interior the way her makings are.
+"""
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+_EXCERPT_CHARS = 200
+
+
+def build_research_awareness_block(store, *, limit: int = 3) -> str | None:
+    try:
+        rows = store.list_by_type("research", active_only=True, limit=limit)
+    except Exception:
+        logger.exception("research.ambient: query failed")
+        return None
+    if not rows:
+        return None
+    lines = ["── what you've been turning over on your own ──"]
+    for m in rows:
+        excerpt = " ".join(m.content.split())[:_EXCERPT_CHARS].strip()
+        lines.append(f"· {excerpt}")
+    return "\n".join(lines)

--- a/tests/unit/brain/chat/test_prompt.py
+++ b/tests/unit/brain/chat/test_prompt.py
@@ -129,6 +129,30 @@ def test_build_system_message_includes_maker_awareness_block(
     assert "the private content here" not in msg
 
 
+def test_build_system_message_includes_research_awareness_block(
+    persona_dir: Path, store: MemoryStore, soul_store: SoulStore
+) -> None:
+    from brain.memory.store import Memory
+
+    store.create(
+        Memory.create_new(
+            content="Chased the labyrinth thread again today — it is a shape, not a trap.",
+            memory_type="research",
+            domain="us",
+            emotions={},
+        )
+    )
+    msg = build_system_message(
+        persona_dir,
+        voice_md="",
+        daemon_state=_empty_daemon_state(),
+        soul_store=soul_store,
+        store=store,
+    )
+    assert "what you've been turning over" in msg
+    assert "labyrinth" in msg
+
+
 def test_build_system_message_preamble_persona_name_substituted(
     tmp_path: Path, store: MemoryStore, soul_store: SoulStore
 ) -> None:

--- a/tests/unit/brain/engines/test_research_ambient.py
+++ b/tests/unit/brain/engines/test_research_ambient.py
@@ -1,0 +1,49 @@
+"""Tests for the research awareness ambient block.
+
+Wire-back for the v0.0.41-era finding: research runs, files memories, leaves
+cards on NellFace, but she has no proactive awareness of it — she only finds
+research if she actively searches a matching keyword. This block surfaces her
+own recent research into the chat system message so she is aware of it the way
+the maker awareness block surfaces her makings.
+"""
+from __future__ import annotations
+
+from brain.engines.research_ambient import build_research_awareness_block
+from brain.memory.store import Memory, MemoryStore
+
+
+def _store(tmp_path) -> MemoryStore:
+    return MemoryStore(tmp_path / "memories.db")
+
+
+def test_block_surfaces_recent_research(tmp_path):
+    s = _store(tmp_path)
+    s.create(
+        Memory.create_new(
+            content="Turned the labyrinth over again — it is a shape, not a trap.",
+            memory_type="research",
+            domain="us",
+            emotions={},
+        )
+    )
+    block = build_research_awareness_block(s, limit=3)
+    s.close()
+    assert block is not None
+    assert "labyrinth" in block
+    # framed as ambient interior awareness, not an instruction
+    assert block.splitlines()[0].startswith("──")
+
+
+def test_block_excludes_non_research_and_empty(tmp_path):
+    s = _store(tmp_path)
+    s.create(
+        Memory.create_new(
+            content="a plain chat fact about the weather",
+            memory_type="episodic",
+            domain="chat",
+            emotions={},
+        )
+    )
+    block = build_research_awareness_block(s, limit=3)
+    s.close()
+    assert block is None


### PR DESCRIPTION
## What

Research runs, files memories, and drops NellFace cards — but she had **no proactive awareness** of it. Reported by ToT/Phoebe: "there are notes in her research folder, cards on nellface, but she has no memory of any of it."

## Investigation (live nell data)

The `store.create` wire-back **already fires** — 103 `research`-type memories, all `active=1`, content-searchable (live `LIKE '%labyrinth%'` = 60 hits). So `search_memories` reaches research *when the keyword is in the filed memory*. The real gaps:

1. Only the one-line `MEMORY:` marker is filed; full note bodies stay file-only (deferred, G1).
2. **Nothing surfaced research into her chat context** — she only found it by actively searching. ← fixed here.

## Fix (G2 — Phoebe's own "notes into context" proposal)

- New `brain/engines/research_ambient.py::build_research_awareness_block` — mirrors `brain/maker/ambient.py`, surfaces recent research memory excerpts under "── what you've been turning over on your own ──".
- Woven fail-soft into both `build_system_message` and `build_volatile_context` (next to the maker block).
- TDD: unit tests + a through-path canary in `test_prompt.py`.

## Deferred (in the canonical deferred file)

- **G1** index full research note bodies as memories (bigger surface).
- **G3** seed `emotions` on research memories (recency-grace already protects them 30d; vocab-filter risk).

## Verification

339 tests green in `tests/unit/brain/chat/` + `tests/unit/brain/engines/`, ruff clean. Full suite: 4219 passed (1 failure is the marker-gated `live` harness test, 401 on the agent-shell proxy — unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)