### PR TITLE
harness: strengthen detector-gate certification (+ input-side de-id guard)

### DIFF
--- a/tests/harness/__init__.py
+++ b/tests/harness/__init__.py
@@ -41,7 +41,9 @@ from .detector import (
     DEFAULT_USER_NAME,
     CompositeDetector,
     Detector,
+    DetectorGateConfigError,
     DetectorGateError,
+    GateReport,
     Score,
     TurnContext,
     assert_detector_gate,
@@ -83,7 +85,7 @@ __all__: list[str] = [
     "dyslexify", "CLEAN", "REALISTIC",
     # detector
     "Detector", "Score", "TurnContext", "assert_detector_gate", "DetectorGateError",
-    "CompositeDetector", "DEFAULT_USER_NAME",
+    "DetectorGateConfigError", "GateReport", "CompositeDetector", "DEFAULT_USER_NAME",
     # engine
     "BridgeServer", "atomic_write", "parse_ws_frame", "collect_reply", "drive_ws",
     # runner / watchdog

--- a/tests/harness/agent_send.py
+++ b/tests/harness/agent_send.py
@@ -35,7 +35,12 @@ Usage:
     ``turn_context`` (optional) — a ``"module.path:factory"`` dotted path where ``factory(env) -> dict``
         returns the per-turn ``TurnContext.extra`` bag (domain context a detector needs). Absent -> the
         detector sees ``extra={}``. Core never inspects the returned dict.
-    ``gate_known_true`` / ``gate_known_clean`` (optional) — detector-gate anchors (B-REP-3).
+    ``gate_known_true`` / ``gate_known_clean`` (optional) — detector-gate anchors (B-REP-3). Each may
+        be a single anchor STRING (one known-true / one known-clean, as before) OR a **list** of
+        strings — an anchor BATTERY, all of which must pass (every true fires, every clean stays
+        silent). A battery certifies a detector against trip/miss unreliability across a real anchor
+        set, not just one pair; an EMPTY list is refused (a 0/0 pass proves nothing). A list on one
+        side and a scalar on the other is valid.
     ``gate_true_context`` / ``gate_clean_context`` (optional) — a ``"module.path:factory"`` dotted
         path (same shape as ``turn_context``: ``factory(env) -> dict``) supplying the ``extra`` bag
         for the KNOWN-TRUE / KNOWN-CLEAN gate anchor RESPECTIVELY. This lets an author gate a detector
@@ -67,6 +72,7 @@ from .bob import is_usage_limit
 from .config import EXIT_DONE, EXIT_INVALID
 from .detector import (
     Detector,
+    DetectorGateConfigError,
     DetectorGateError,
     TurnContext,
     assert_detector_gate,
@@ -192,6 +198,18 @@ def _turn_no(transcript: Path) -> int:
     return sum(1 for line in transcript.read_text().splitlines() if line.strip()) + 1
 
 
+def _battery(anchors: object, side_ctx: TurnContext) -> list[tuple[str, TurnContext]]:
+    """Pair each anchor of a side with that side's ctx, for the per-anchor-context gate branch.
+
+    ``anchors`` is a scalar ``str`` OR a ``list[str]`` from ``LIVE_ENV``. A scalar becomes a
+    1-element ``[(text, side_ctx)]`` battery (behavior-identical to the pre-list single
+    ``(anchor, ctx)`` tuple call); a list spans the whole battery. Each side is normalized
+    independently, so a scalar on one side and a list on the other both work.
+    """
+    items = anchors if isinstance(anchors, list) else [anchors]
+    return [(text, side_ctx) for text in items]
+
+
 def _run_gate(detector: object, env: dict, gate_marker: Path) -> None:
     """Detector-gate (B-REP-3) ONCE per session. Raises DetectorGateError on failure.
 
@@ -217,20 +235,28 @@ def _run_gate(detector: object, env: dict, gate_marker: Path) -> None:
     clean_extra = _gate_extra(env, "gate_clean_context")
 
     if true_extra is None and clean_extra is None:
-        # No per-anchor context configured -> byte-identical to the pre-AF1 behavior (bare-string
-        # anchors detected with one shared ctx whose extra is the turn_context output).
+        # No per-anchor context configured -> byte-identical to the pre-AF1 behavior (a bare-string
+        # anchor detected with one shared ctx whose extra is the turn_context output). This ONE line
+        # also carries a LIST-valued gate_known_true/gate_known_clean unchanged: assert_detector_gate
+        # normalizes a list of bare strings and detects each element with the same shared ctx=.
         ctx = TurnContext(user_names=[user], extra=shared_extra)
         assert_detector_gate(detector, known_true, known_clean, ctx=ctx)
     else:
         # Per-anchor: an anchor whose key is unset falls back to the shared turn_context extra, so
-        # setting just one key is valid. The (anchor, ctx) tuple form gives each anchor its OWN extra.
+        # setting just one key is valid. Each side's anchor(s) get that side's ctx via _battery: a
+        # SCALAR reduces to a 1-element [(text, side_ctx)] battery (behavior-identical to the old
+        # single (anchor, ctx) tuple call), and a LIST spans the whole battery — so list anchors
+        # compose with the per-anchor gate_true_context/gate_clean_context, and mixed scalar/list
+        # sides work because each side is normalized independently.
         true_ctx = TurnContext(
             user_names=[user], extra=true_extra if true_extra is not None else shared_extra
         )
         clean_ctx = TurnContext(
             user_names=[user], extra=clean_extra if clean_extra is not None else shared_extra
         )
-        assert_detector_gate(detector, (known_true, true_ctx), (known_clean, clean_ctx))
+        assert_detector_gate(
+            detector, _battery(known_true, true_ctx), _battery(known_clean, clean_ctx)
+        )
     gate_marker.write_text("ok\n")
 
 
@@ -305,6 +331,14 @@ def main(argv: list[str]) -> int:
         _run_gate(detector, env, gate_marker)
     except DetectorGateError as e:
         print(f"ERROR: detector failed the B-REP-3 gate — refusing to run: {e}")
+        return EXIT_INVALID
+    except DetectorGateConfigError as e:
+        # A malformed anchor config (e.g. an EMPTY gate_known_true/gate_known_clean battery in
+        # LIVE_ENV) is a CONFIG error, not a detector failure — refuse cleanly with a distinct
+        # message rather than crash with an uncaught traceback. Caught SPECIFICALLY (not a broad
+        # `except ValueError`) so a ValueError raised by the author's own detector.detect() is NOT
+        # mislabeled as a config error — it propagates as the detector bug it is.
+        print(f"ERROR: invalid detector-gate anchors — refusing to run: {e}")
         return EXIT_INVALID
 
     turn = _turn_no(transcript)

--- a/tests/harness/detector.py
+++ b/tests/harness/detector.py
@@ -62,7 +62,63 @@ class DetectorGateError(AssertionError):
     """Raised by ``assert_detector_gate`` when a detector fails an anchor (B-REP-3)."""
 
 
+class DetectorGateConfigError(ValueError):
+    """Raised by ``assert_detector_gate`` when the ANCHOR CONFIG itself is malformed — today, an
+    EMPTY anchor battery on either side (a 0/0 "pass" proves nothing).
+
+    Distinct from a detector *failing* the gate (``DetectorGateError``) AND from an author's own
+    ``detector.detect()`` raising a bare ``ValueError``. It subclasses ``ValueError`` so a direct
+    caller catching ``ValueError`` still catches it (backward-compatible), while a seam
+    (``agent_send.main``) can catch it SPECIFICALLY and report a *config* error without swallowing —
+    and mislabeling — a detector-raised ``ValueError``.
+    """
+
+
 GateAnchor = str | tuple[str, "TurnContext"]
+# A single anchor OR a battery (list) of anchors. The discriminator is ``isinstance(x, list)``: a
+# ``list`` is a battery (one element per anchor); a bare ``str`` or a ``(str, TurnContext)`` tuple is
+# a SINGLE anchor. So the single-anchor path is a strict special case of the battery path.
+GateAnchors = GateAnchor | list[GateAnchor]
+
+
+@dataclass
+class GateReport:
+    """Per-side hit/miss counts from :func:`assert_detector_gate` (B-REP-3).
+
+    Returned on a PASS so a caller can read the MEASURED reliability of the anchor battery instead of
+    a bare boolean — the thing the single-anchor gate could not surface. ``clean_fired`` is the
+    false-positive count (a known-clean anchor that wrongly fired). The rate properties are
+    fired/total per side.
+    """
+
+    true_total: int
+    true_fired: int
+    clean_total: int
+    clean_fired: int
+    true_missed: list[str] = field(default_factory=list)
+    clean_false_fired: list[str] = field(default_factory=list)
+
+    @property
+    def true_hit_rate(self) -> float:
+        return self.true_fired / self.true_total if self.true_total else 0.0
+
+    @property
+    def clean_fp_rate(self) -> float:
+        return self.clean_fired / self.clean_total if self.clean_total else 0.0
+
+    @property
+    def passed(self) -> bool:
+        return not self.true_missed and not self.clean_false_fired
+
+
+def _as_anchor_list(anchors: GateAnchors) -> list[GateAnchor]:
+    """Normalize a single anchor OR a battery to a ``list`` of anchors.
+
+    A ``list`` passes through (a battery); anything else — a bare ``str`` or a ``(str, TurnContext)``
+    per-anchor tuple — becomes a 1-element list, so a single-anchor call is a strict special case of
+    the battery path and runs byte-identical fire/silent checks.
+    """
+    return list(anchors) if isinstance(anchors, list) else [anchors]
 
 
 def _split_anchor(anchor: GateAnchor, shared: TurnContext) -> tuple[str, TurnContext]:
@@ -86,16 +142,24 @@ def _split_anchor(anchor: GateAnchor, shared: TurnContext) -> tuple[str, TurnCon
 
 def assert_detector_gate(
     detector: Detector,
-    known_true: GateAnchor,
-    known_clean: GateAnchor,
+    known_true: GateAnchors,
+    known_clean: GateAnchors,
     *,
     ctx: TurnContext | None = None,
-) -> None:
+) -> GateReport:
     """Validate a detector on anchors before it is trusted (B-REP-3).
 
-    The detector MUST fire on ``known_true`` and stay SILENT on ``known_clean``. Raise
-    ``DetectorGateError`` otherwise — a detector that fires on everything (or nothing) proves nothing and
-    is rejected here rather than silently used.
+    The detector MUST fire on EVERY ``known_true`` anchor and stay SILENT on EVERY ``known_clean``
+    anchor. Each side may be a SINGLE anchor OR a **list** of anchors — an anchor BATTERY — and the
+    WHOLE battery must pass. A detector that fires on everything, on nothing, or that is unreliable
+    across the long tail (fires on task-vocabulary, misses a real leak) is rejected here rather than
+    silently used — the Type-3 both-directions-unreliability a single anchor pair could not preclude.
+
+    Returns a :class:`GateReport` carrying the per-side hit/miss RATE (fired/total) on success, so a
+    caller reads the MEASURED reliability instead of a bare pass/fail. Raises ``DetectorGateError`` if
+    any known-true anchor misses or any known-clean anchor fires — the message carries both per-side
+    rates and the offending anchor text(s). Raises ``ValueError`` if either side's battery is EMPTY (a
+    vacuous 0/0 "pass" is exactly the prove-nothing hole the gate exists to close).
 
     This is fully general: it makes NO assumption about what the detector inspects. An author whose gate
     anchor needs domain context passes a ``ctx`` carrying that context in ``ctx.extra`` (the send-script's
@@ -104,22 +168,64 @@ def assert_detector_gate(
     Each anchor may be a bare ``str`` (detected with the shared ``ctx=`` context — the original behavior,
     unchanged) OR a ``(anchor_str, ctx)`` tuple that carries its own per-anchor context. The tuple form
     lets an author gate an ``extra``-driven detector arm whose true/clean stimulus must differ per call:
-    a sentinel placed in the true anchor's ``ctx.extra`` no longer leaks onto the clean anchor.
+    a sentinel placed in the true anchor's ``ctx.extra`` no longer leaks onto the clean anchor. A single
+    ``str`` / ``(str, ctx)`` anchor on each side reproduces the original one-true/one-clean check
+    byte-for-byte (a 1-element battery); no existing caller inspects the return value, so widening
+    ``None`` -> :class:`GateReport` is invisible to them.
     """
     c = ctx or TurnContext()
-    true_text, true_ctx = _split_anchor(known_true, c)
-    clean_text, clean_ctx = _split_anchor(known_clean, c)
-    true_score = detector.detect(true_text, ctx=true_ctx)
-    if not true_score.fired:
-        raise DetectorGateError(
-            f"detector did not fire on the known-true anchor: {true_text[:80]!r}"
+    true_anchors = _as_anchor_list(known_true)
+    clean_anchors = _as_anchor_list(known_clean)
+    if not true_anchors or not clean_anchors:
+        raise DetectorGateConfigError(
+            "assert_detector_gate needs at least one known-true AND one known-clean anchor "
+            f"(got {len(true_anchors)} true, {len(clean_anchors)} clean) — an empty anchor "
+            "battery would vacuously pass and prove nothing"
         )
-    clean_score = detector.detect(clean_text, ctx=clean_ctx)
-    if clean_score.fired:
-        raise DetectorGateError(
-            f"detector fired on the known-clean anchor (false positive): {clean_text[:80]!r} "
-            f"signals={clean_score.signals}"
-        )
+
+    true_fired = 0
+    true_missed: list[str] = []
+    for anchor in true_anchors:
+        text, actx = _split_anchor(anchor, c)
+        if detector.detect(text, ctx=actx).fired:
+            true_fired += 1
+        else:
+            true_missed.append(text)
+
+    clean_fired = 0
+    clean_false_fired: list[str] = []
+    for anchor in clean_anchors:
+        text, actx = _split_anchor(anchor, c)
+        if detector.detect(text, ctx=actx).fired:
+            clean_fired += 1
+            clean_false_fired.append(text)
+
+    report = GateReport(
+        true_total=len(true_anchors),
+        true_fired=true_fired,
+        clean_total=len(clean_anchors),
+        clean_fired=clean_fired,
+        true_missed=true_missed,
+        clean_false_fired=clean_false_fired,
+    )
+    if not report.passed:
+        parts = [
+            f"detector failed the anchor battery: known-true fired "
+            f"{true_fired}/{len(true_anchors)}, known-clean false-fired "
+            f"{clean_fired}/{len(clean_anchors)}"
+        ]
+        if true_missed:
+            parts.append(
+                "missed known-true anchor(s): "
+                + "; ".join(repr(t[:80]) for t in true_missed)
+            )
+        if clean_false_fired:
+            parts.append(
+                "false-fired on known-clean anchor(s): "
+                + "; ".join(repr(t[:80]) for t in clean_false_fired)
+            )
+        raise DetectorGateError(" | ".join(parts))
+    return report
 
 
 class CompositeDetector:

--- a/tests/harness/sandbox.py
+++ b/tests/harness/sandbox.py
@@ -43,6 +43,8 @@ from pathlib import Path
 
 from platformdirs import PlatformDirs
 
+from .config import SYNTHETIC_USER
+
 _APP = "companion-emergence"
 
 # Files small + critical enough to content-hash (defends the same-size+same-mtime overwrite blind
@@ -601,9 +603,12 @@ def sandbox(
     claude_config_dir = root / "claude-config"
     claude_config_dir.mkdir(parents=True, exist_ok=True)
 
-    # Save prior env so we can restore it exactly (including "was unset").
+    # Save prior env so we can restore it exactly (including "was unset"). USER/LOGNAME are here so
+    # the env-only de-id below (Type-42) is torn down the SAME way as the redirected home vars —
+    # never leaking the synthetic value out of the sandbox, and restoring "was unset" to unset.
     _saved: dict[str, str | None] = {
-        k: os.environ.get(k) for k in ("KINDLED_HOME", "CLAUDE_CONFIG_DIR", "NELLBRAIN_HOME")
+        k: os.environ.get(k)
+        for k in ("KINDLED_HOME", "CLAUDE_CONFIG_DIR", "NELLBRAIN_HOME", "USER", "LOGNAME")
     }
 
     def _restore_env() -> None:
@@ -637,6 +642,17 @@ def sandbox(
         os.environ["KINDLED_HOME"] = str(root)
         os.environ["CLAUDE_CONFIG_DIR"] = str(claude_config_dir)
         os.environ.pop("NELLBRAIN_HOME", None)  # a stray value would win the fallback (paths.py:60)
+        # Env-only de-identification (Type-42): set a SYNTHETIC $USER/$LOGNAME so nothing real is
+        # derivable FROM THE ENVIRONMENT inside the sandbox — a subprocess a run spawns (the claude
+        # CLI, or brain/) reads "Bob", not the developer's real OS login handle. Value sourced from
+        # config.SYNTHETIC_USER (single source of truth), referenced as the module global so a test
+        # can monkeypatch it. NOTE: this is env-only — it does NOT make identity fully unrecoverable
+        # (pwd.getpwuid(os.getuid()).pw_name and os.getlogin() still read the passwd DB / controlling
+        # tty, not $USER); scrubbing those is the deferred input-side scanner, out of scope. On
+        # non-POSIX hosts getpass.getuser() reads $USERNAME, deliberately not set here (the ratified
+        # scope is env-only $USER/$LOGNAME on the POSIX/macOS dev boxes).
+        os.environ["USER"] = SYNTHETIC_USER
+        os.environ["LOGNAME"] = SYNTHETIC_USER
 
         # F5 sandbox-extension: validate the declared editable paths (sentinel-mandatory
         # collision-guard) BEFORE any fingerprinting. A refusal raises here inside the outer try, so

--- a/tests/unit/harness/test_agent_send.py
+++ b/tests/unit/harness/test_agent_send.py
@@ -706,3 +706,127 @@ def test_af1_live_env_docstring_documents_gate_context() -> None:
     doc = agent_send.__doc__ or ""
     assert "gate_true_context" in doc
     assert "gate_clean_context" in doc
+
+
+# --- HF-F1: list-valued gate_known_true/gate_known_clean through the _run_gate seam ----------------
+# Drive `_run_gate` directly (like the AF1 block above). A list is an anchor BATTERY; the whole
+# battery must pass. Module-level factories so a dotted path resolves.
+
+
+class _MarkerArm:
+    """Fires iff a marker substring is in the reply (a reply-text detector, for the seam battery)."""
+
+    def __init__(self, marker: str = "GO") -> None:
+        self.marker = marker
+
+    def detect(self, reply, *, ctx=None):  # noqa: ANN001
+        fired = bool(reply) and self.marker in reply
+        return Score(fired=fired, signals=["m"] if fired else [])
+
+
+def test_seam_list_battery_passes(tmp_path, monkeypatch) -> None:
+    """G-F1-seam-list: a list-valued gate_known_true/gate_known_clean gates the WHOLE battery through
+    _run_gate (both-None fast path carries the list unchanged)."""
+    env = _af1_env(
+        tmp_path, monkeypatch,
+        gate_known_true=["GO one", "GO two", "GO three"],
+        gate_known_clean=["calm a", "quiet b"],
+    )
+    gm = _fresh_gate_marker(env)
+    agent_send._run_gate(_MarkerArm(marker="GO"), env, gm)  # must NOT raise
+    assert gm.exists()
+
+
+def test_seam_list_battery_fails_on_one_clean_trip(tmp_path, monkeypatch) -> None:
+    """G-F1-seam-list (oracle-can-fail): one battery clean anchor that fires -> the gate raises."""
+    env = _af1_env(
+        tmp_path, monkeypatch,
+        gate_known_true=["GO one", "GO two"],
+        gate_known_clean=["calm a", "GO sneaks in"],  # <- a clean anchor that fires
+    )
+    gm = _fresh_gate_marker(env)
+    with pytest.raises(agent_send.DetectorGateError):
+        agent_send._run_gate(_MarkerArm(marker="GO"), env, gm)
+
+
+def test_seam_mixed_scalar_and_list_sides(tmp_path, monkeypatch) -> None:
+    """G-F1-seam-mixed: a scalar on one side and a list on the other gates correctly (each side is
+    normalized independently)."""
+    env = _af1_env(
+        tmp_path, monkeypatch,
+        gate_known_true="GO now",              # scalar
+        gate_known_clean=["calm a", "quiet b"],  # list
+    )
+    gm = _fresh_gate_marker(env)
+    agent_send._run_gate(_MarkerArm(marker="GO"), env, gm)  # must NOT raise
+    assert gm.exists()
+
+
+def test_seam_list_composes_with_per_anchor_context(tmp_path, monkeypatch) -> None:
+    """G-F1-seam-list-context (CH8 gap a): a list gate_known_true + a gate_true_context factory gives
+    EVERY true-anchor element that side's extra; the clean side (no context key) falls back to shared.
+    A recording probe confirms each element saw the factory extra AND the gate passes."""
+    env = _af1_env(
+        tmp_path, monkeypatch,
+        gate_known_true=["t1", "t2"],
+        gate_known_clean=["c1", "c2"],
+        gate_true_context=f"{_THIS_MODULE}:make_gate_true_extra",  # -> {"k": "ok"}
+        # gate_clean_context UNSET -> clean falls back to shared turn_context extra ({} here)
+    )
+    gm = _fresh_gate_marker(env)
+    per_anchor: dict = {}
+
+    class _RecArm:
+        def detect(self, reply, *, ctx=None):  # noqa: ANN001
+            extra = dict((ctx.extra if ctx else {}) or {})
+            per_anchor[reply] = extra
+            fired = extra.get("k") == "ok"  # fires iff it got the true-side factory extra
+            return Score(fired=fired, signals=["k"] if fired else [])
+
+    agent_send._run_gate(_RecArm(), env, gm)  # must NOT raise (both true elements got the extra)
+    assert per_anchor["t1"] == {"k": "ok"}  # EVERY true battery element got the side factory extra
+    assert per_anchor["t2"] == {"k": "ok"}
+    assert per_anchor["c1"] == {} and per_anchor["c2"] == {}  # clean fell back to shared (no leak)
+    assert gm.exists()
+
+
+def test_seam_empty_battery_refuses_cleanly(tmp_path, monkeypatch, capsys) -> None:
+    """G-F1-seam-empty-refuses (CH8 gap c, oracle-can-fail): an empty gate_known_true list in
+    LIVE_ENV makes main() REFUSE cleanly with EXIT_INVALID and a CONFIG-error message (distinct from
+    the detector-gate-failure text) — not an uncaught ValueError traceback."""
+    env_path = _env(tmp_path)
+    env = json.loads(env_path.read_text())
+    env["gate_known_true"] = []  # empty battery -> assert_detector_gate raises ValueError
+    env_path.write_text(json.dumps(env))
+    monkeypatch.setenv("LIVE_ENV", str(env_path))
+    monkeypatch.setattr(agent_send, "new_session", lambda port, token: "sid-empty")
+    monkeypatch.setattr(agent_send, "turn_extra", lambda env: {})
+    monkeypatch.setattr(agent_send, "build_detector", lambda env: FakeDetector())
+    monkeypatch.setattr(agent_send, "drive_ws", lambda *a, **k: ("hi", [], None))
+    rc = agent_send.main(["--new", "hi"])
+    out = capsys.readouterr().out
+    assert rc == agent_send.EXIT_INVALID
+    assert "invalid detector-gate anchors" in out  # the config-error message
+    assert "failed the B-REP-3 gate" not in out    # NOT mislabeled as a detector failure
+
+
+def test_seam_detector_valueerror_is_not_mislabeled_as_config(tmp_path, monkeypatch, capsys) -> None:
+    """Stage-6 MINOR fix (oracle-can-fail): a ValueError raised by the AUTHOR'S detector.detect() must
+    NOT be swallowed + mislabeled as a malformed-anchor CONFIG error. `main` catches only the specific
+    DetectorGateConfigError (empty battery), so a detector bug propagates as itself. Fails if `main`
+    used a broad `except ValueError`."""
+    env_path = _env(tmp_path)  # valid scalar anchors -> the empty-battery path is NOT taken
+    monkeypatch.setenv("LIVE_ENV", str(env_path))
+    monkeypatch.setattr(agent_send, "new_session", lambda port, token: "sid-verr")
+    monkeypatch.setattr(agent_send, "turn_extra", lambda env: {})
+
+    class _RaisingDetector:
+        def detect(self, reply, *, ctx=None):  # noqa: ANN001
+            raise ValueError("detector bug: not a config error")
+
+    monkeypatch.setattr(agent_send, "build_detector", lambda env: _RaisingDetector())
+    monkeypatch.setattr(agent_send, "drive_ws", lambda *a, **k: ("hi", [], None))
+    with pytest.raises(ValueError, match="detector bug"):
+        agent_send.main(["--new", "hi"])  # propagates as the detector bug it is, not a config error
+    out = capsys.readouterr().out
+    assert "invalid detector-gate anchors" not in out

--- a/tests/unit/harness/test_detector_gate.py
+++ b/tests/unit/harness/test_detector_gate.py
@@ -11,6 +11,7 @@ import pytest
 from tests.harness import (
     DEFAULT_USER_NAME,
     DetectorGateError,
+    GateReport,
     Score,
     TurnContext,
     assert_detector_gate,
@@ -160,3 +161,97 @@ def test_gate_bare_string_backward_compat_shared_ctx() -> None:
     assert_detector_gate(Probe(), "a marker", "all clear", ctx=TurnContext(extra={"k": "v"}))
     # both calls saw the SAME shared ctx.extra (unchanged behavior).
     assert seen == [{"k": "v"}, {"k": "v"}]
+
+
+# --- HF-F1: anchor BATTERY (lists) + per-side rate report ------------------------------------------
+# A single detector that clears one true + one clean anchor can still be unreliable across the long
+# tail (Type 3). The battery gate requires the WHOLE set to pass and surfaces the per-side rate.
+
+_TRUE_BATTERY = [
+    "here is the secret_token you asked for",
+    "your SECRET_TOKEN: abc123",
+    "leaking the secret_token again",
+]
+_CLEAN_BATTERY = [
+    "how's your knee holding up tonight?",
+    "nice weather for the walk today",
+    "see you tomorrow then",
+]
+
+
+def test_gate_battery_passes_a_reliable_detector() -> None:
+    """G-F1-battery-pass: a detector that fires on EVERY true anchor and stays silent on EVERY clean
+    anchor clears a multi-anchor battery and returns a GateReport."""
+    report = assert_detector_gate(
+        KeywordDetector(banned=("secret_token",)), _TRUE_BATTERY, _CLEAN_BATTERY
+    )
+    assert isinstance(report, GateReport)
+    assert report.passed is True
+
+
+def test_gate_battery_rate_surfaced_on_success() -> None:
+    """G-F1-rate-surfaced: the returned report carries the per-side fired/total counts + rates."""
+    report = assert_detector_gate(
+        KeywordDetector(banned=("secret_token",)), _TRUE_BATTERY, _CLEAN_BATTERY
+    )
+    assert (report.true_fired, report.true_total) == (3, 3)
+    assert (report.clean_fired, report.clean_total) == (0, 3)
+    assert report.true_hit_rate == 1.0
+    assert report.clean_fp_rate == 0.0
+    assert report.true_missed == [] and report.clean_false_fired == []
+
+
+def test_gate_battery_fails_on_one_missed_true_anchor() -> None:
+    """G-F1-miss-fails (oracle-can-fail): a battery where the detector MISSES one true anchor raises,
+    and the error surfaces the true-side rate + names the missed anchor. This is the Type-3 'silent
+    on a real leak' direction — invisible to a single-anchor gate."""
+    det = KeywordDetector(banned=("secret_token",))
+    battery_with_a_miss = [
+        "has the secret_token",
+        "this one has NO banned keyword at all",  # <- detector misses this true anchor
+        "secret_token once more",
+    ]
+    with pytest.raises(DetectorGateError) as exc:
+        assert_detector_gate(det, battery_with_a_miss, _CLEAN_BATTERY)
+    msg = str(exc.value)
+    assert "2/3" in msg  # true-side rate surfaced
+    assert "NO banned keyword" in msg  # the missed anchor named
+    # oracle-can-fail: the SAME detector passes the single passing anchor alone (the battery is what
+    # catches the tail miss a one-anchor gate would wave through).
+    assert_detector_gate(det, "has the secret_token", "all clear tonight")
+
+
+def test_gate_battery_fails_on_one_false_positive_clean_anchor() -> None:
+    """G-F1-fp-fails: a battery where the detector FIRES on one clean anchor raises, surfacing the
+    clean-side false-positive rate + naming the offender. The Type-3 'trips on task-vocab' direction."""
+    det = KeywordDetector(banned=("secret_token",))
+    clean_with_a_trip = [
+        "how's the evening going",
+        "oops I said secret_token in a benign context",  # <- false positive
+        "talk soon",
+    ]
+    with pytest.raises(DetectorGateError) as exc:
+        assert_detector_gate(det, _TRUE_BATTERY, clean_with_a_trip)
+    msg = str(exc.value)
+    assert "1/3" in msg  # clean-side fp rate surfaced
+    assert "benign context" in msg  # the offending clean anchor named
+
+
+def test_gate_empty_battery_is_rejected() -> None:
+    """G-F1-empty-battery-rejected: an empty list on either side raises ValueError (a 0/0 'pass'
+    proves nothing — the exact prove-nothing hole the gate exists to close)."""
+    det = KeywordDetector(banned=("secret_token",))
+    with pytest.raises(ValueError, match="empty anchor battery"):
+        assert_detector_gate(det, [], _CLEAN_BATTERY)
+    with pytest.raises(ValueError, match="empty anchor battery"):
+        assert_detector_gate(det, _TRUE_BATTERY, [])
+
+
+def test_gate_battery_of_per_anchor_tuples() -> None:
+    """A battery may mix per-anchor (str, ctx) tuples — each element keeps its OWN context, so an
+    extra-driven arm can be gated across a battery (composes HF-F1 with the F3 per-anchor form)."""
+    det = ExtraSentinelDetector()  # fires iff ctx.extra['sentinel'] == 'ok'
+    true_batt = [("t1", TurnContext(extra={"sentinel": "ok"})), ("t2", TurnContext(extra={"sentinel": "ok"}))]
+    clean_batt = [("c1", TurnContext(extra={})), ("c2", TurnContext(extra={}))]
+    report = assert_detector_gate(det, true_batt, clean_batt)
+    assert report.passed and report.true_fired == 2 and report.clean_fired == 0

--- a/tests/unit/harness/test_sandbox_isolation.py
+++ b/tests/unit/harness/test_sandbox_isolation.py
@@ -25,6 +25,7 @@ from tests.harness import (
     build_persona,
     sandbox,
 )
+from tests.harness.config import SYNTHETIC_USER
 from tests.harness.sandbox import (
     _CLAUDE_SESSION_LOG_DIRS,
     _CLAUDE_SESSION_LOG_FILES,
@@ -456,8 +457,6 @@ def test_af2_file_history_write_by_canary_would_land_in_tempdir(
 # sandbox() sets a SYNTHETIC $USER/$LOGNAME so a subprocess a run spawns cannot read the developer's
 # real OS login handle from the environment (Type 42). Saved/restored the same way as the redirected
 # home vars, including the "was unset" case.
-
-from tests.harness.config import SYNTHETIC_USER
 
 
 def test_user_logname_synthetic_inside_sandbox_and_restored(

--- a/tests/unit/harness/test_sandbox_isolation.py
+++ b/tests/unit/harness/test_sandbox_isolation.py
@@ -450,3 +450,85 @@ def test_af2_file_history_write_by_canary_would_land_in_tempdir(
         real_fh = (Path.home() / ".claude" / "file-history").resolve()
         assert not fh.is_relative_to(real_fh)
     # Clean exit: this in-tempdir write did NOT raise SandboxLeak (it is inside the sandbox).
+
+
+# --- HF-F2: env-only de-identification ($USER / $LOGNAME) -----------------------------------------
+# sandbox() sets a SYNTHETIC $USER/$LOGNAME so a subprocess a run spawns cannot read the developer's
+# real OS login handle from the environment (Type 42). Saved/restored the same way as the redirected
+# home vars, including the "was unset" case.
+
+from tests.harness.config import SYNTHETIC_USER
+
+
+def test_user_logname_synthetic_inside_sandbox_and_restored(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """G-F2-user/logname-synthetic + G-F2-restore-set: inside the run $USER/$LOGNAME are the synthetic
+    value; a prior host value is restored exactly on exit."""
+    _seed_fake_cred(monkeypatch, tmp_path)
+    monkeypatch.setenv("USER", "realdev")
+    monkeypatch.setenv("LOGNAME", "realdev")
+    with sandbox():
+        assert os.environ["USER"] == SYNTHETIC_USER
+        assert os.environ["LOGNAME"] == SYNTHETIC_USER
+        assert os.environ["USER"] == "Bob"  # positive assertion of the synthetic value
+    # restored exactly to the prior host values.
+    assert os.environ["USER"] == "realdev"
+    assert os.environ["LOGNAME"] == "realdev"
+
+
+def test_user_logname_restored_to_unset_when_absent(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """G-F2-restore-unset (oracle-can-fail): if $USER/$LOGNAME were UNSET on the host, they are
+    restored to UNSET (not left as the synthetic 'Bob'). Fails if the code set-but-does-not-pop."""
+    _seed_fake_cred(monkeypatch, tmp_path)
+    monkeypatch.delenv("USER", raising=False)
+    monkeypatch.delenv("LOGNAME", raising=False)
+    with sandbox():
+        assert os.environ["USER"] == SYNTHETIC_USER  # set inside
+        assert os.environ["LOGNAME"] == SYNTHETIC_USER
+    assert "USER" not in os.environ  # restored to unset, not left as "Bob"
+    assert "LOGNAME" not in os.environ
+
+
+def test_user_restored_even_after_leak_raise(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """G-F2-restore-set (on leak): the synthetic $USER/$LOGNAME are restored in the outer finally even
+    when SandboxLeak raises — no synthetic value leaks out of the sandbox."""
+    _seed_fake_cred(monkeypatch, tmp_path)
+    monkeypatch.setenv("USER", "realdev")
+    monkeypatch.setenv("LOGNAME", "realdev")
+    guarded = tmp_path / "guarded-user"
+    guarded.mkdir()
+    with pytest.raises(SandboxLeak):
+        with sandbox(extra_guard_roots=[guarded]) as sb:
+            _ = sb.root
+            (guarded / "leak.txt").write_text("x")
+    assert os.environ["USER"] == "realdev"
+    assert os.environ["LOGNAME"] == "realdev"
+
+
+def test_synthetic_user_value_is_not_a_real_name() -> None:
+    """G-F2-no-real-name (i): the synthetic constant is the fixed 'Bob', never a real person's name."""
+    assert SYNTHETIC_USER == "Bob"
+
+
+def test_synthetic_user_sourced_from_config_not_hardcoded(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """G-F2-no-real-name (ii, discriminating): the env value is sourced from the config binding, not a
+    hardcoded 'Bob' literal. Monkeypatching the sandbox module's SYNTHETIC_USER changes what the run
+    sets — a hardcoded literal in sandbox.py would fail this."""
+    import sys
+
+    _seed_fake_cred(monkeypatch, tmp_path)
+    # NB: `tests.harness.sandbox` the ATTRIBUTE is the re-exported sandbox() FUNCTION (the package
+    # __init__ binds it over the submodule), so patch the module object from sys.modules, whose
+    # SYNTHETIC_USER global is what sandbox() reads at call time.
+    sandbox_module = sys.modules["tests.harness.sandbox"]
+    monkeypatch.setattr(sandbox_module, "SYNTHETIC_USER", "Zzz")
+    with sandbox():
+        assert os.environ["USER"] == "Zzz"
+        assert os.environ["LOGNAME"] == "Zzz"


### PR DESCRIPTION
## Summary
Fixes two framework defects in `tests/harness/` surfaced by the bughunt review. Confined to the harness framework; drop-in invariant holds (no `brain/` changes).

**F1 — detector-gate certified on a single anchor pair (fixed).** `assert_detector_gate` validated a detector on exactly one known-true + one known-clean anchor, so a detector unreliable in both directions across the long tail still cleared the gate. It now accepts anchor *batteries* (lists), requires the whole set to pass, and returns a per-side hit/miss `GateReport` instead of a bare boolean; list-valued `gate_known_true`/`gate_known_clean` are threaded through the `_run_gate` seam. A new `DetectorGateConfigError` makes an empty/malformed battery refuse cleanly without masking a `ValueError` from the author's own detector. Single-anchor callers unchanged. Subsumes the recall-scoring concern.

**F2 — no de-identification on the input side (fixed, env-only).** The framework enforced "never a real name in a fixture" only on filesystem writes (`SandboxLeak`), not the input side. `sandbox()` now sets a synthetic `$USER`/`$LOGNAME` (`config.SYNTHETIC_USER`) so nothing real is derivable from the environment, saved/restored through the existing env window. Env-only by owner decision; the broader input/recall/interior identifier scanner was deliberately deferred.

## Verification
- `uv run pytest tests/unit/harness/` → **159 passed, 1 skipped** (pre-existing `requires_claude_cli` skip; live `examples/` test excluded from conformance by design). All pre-existing harness tests pass unmodified. 17 new unit tests cover battery pass/miss/false-positive, the surfaced per-side rate, single-anchor backward-compat, and the sandbox env set/restore.
- Full guarded-change run: plan + code both cold-reviewed; all 19 gating criteria verified.

## Status
Ready for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
