### PR TITLE
Tier A: append separator, emotion delta cap, cold-start strings, invocation outcome

### DIFF
--- a/brain/bridge/provider.py
+++ b/brain/bridge/provider.py
@@ -1432,8 +1432,8 @@ def _read_audit_lines_since(
     """Read audit log lines newly appended after `offset` bytes.
 
     Returns a list of invocation records in the engine's tool_invocations
-    shape: ``{name, arguments, result_summary, error?}``. Malformed lines
-    are skipped silently — telemetry should never break a chat response.
+    shape: ``{name, arguments, result_summary, error?, outcome?}``. Malformed
+    lines are skipped silently — telemetry should never break a chat response.
     """
     try:
         # Rotation guard (bug #5): audit._rotate_if_needed renames the log to
@@ -1498,6 +1498,8 @@ def _read_audit_lines_since(
         }
         if entry.get("error"):
             record["error"] = entry["error"]
+        if entry.get("outcome"):
+            record["outcome"] = entry["outcome"]
         if entry.get("monologue_text"):
             record["monologue_text"] = entry["monologue_text"]
         records.append(record)

--- a/brain/chat/extractor.py
+++ b/brain/chat/extractor.py
@@ -367,6 +367,16 @@ def _filter_to_registered(emotions: dict[str, float]) -> dict[str, float]:
         return emotions
 
 
+# A pass-2 emotion_delta is a NUDGE, not a set. The x10 mapping below turns the
+# validated [-1.0, 1.0] delta into a 0..10 MemoryStore intensity; without a
+# ceiling a single extraction mints 10.0 and wins aggregate_state's max-pool
+# outright against a whole history (#94). test_extractor_schema.py already
+# states this intent — "so a malformed extractor can't slam the vector" — but
+# bounds the delta, not what the delta becomes. Sustained feeling still climbs
+# across turns; one turn cannot peak her.
+_MAX_DELTA_INTENSITY: float = 3.0
+
+
 def _apply_emotion_delta(delta: dict[str, float], persona_dir: Path) -> None:
     """Apply emotion deltas via MemoryStore influence — a tiny emotion-carrying
     memory is committed per the system's existing aggregation model.
@@ -391,7 +401,11 @@ def _apply_emotion_delta(delta: dict[str, float], persona_dir: Path) -> None:
     store = MemoryStore(persona_dir / "memories.db")
     try:
         registered_delta = _filter_to_registered(delta)
-        emotions = {ch: abs(v) * 10.0 for ch, v in registered_delta.items() if abs(v) > 1e-9}
+        emotions = {
+            ch: min(abs(v) * 10.0, _MAX_DELTA_INTENSITY)
+            for ch, v in registered_delta.items()
+            if abs(v) > 1e-9
+        }
         if not emotions:
             return
         # Build a brief descriptive content string from the non-zero emotion channels.

--- a/brain/chat/extractor.py
+++ b/brain/chat/extractor.py
@@ -389,8 +389,10 @@ def _apply_emotion_delta(delta: dict[str, float], persona_dir: Path) -> None:
     the engine's normal accounting.
 
     Deltas are on a [-1.0, 1.0] scale from the extractor. We map them to
-    importance = abs(delta) * 10 so a 0.15 nudge becomes importance 1.5 on
-    the 0..10 MemoryStore scale.
+    importance = abs(delta) * 10, capped at _MAX_DELTA_INTENSITY, so a 0.15
+    nudge becomes importance 1.5 on the 0..10 MemoryStore scale — a maximal
+    1.0 delta caps at _MAX_DELTA_INTENSITY rather than the uncapped 10.0;
+    one extraction can't peg a channel to the full clamp (#94).
 
     Channel names are constrained to the registered emotion vocabulary before
     writing — LLM-invented names are silently dropped here (mirrors the

--- a/brain/chat/tool_loop.py
+++ b/brain/chat/tool_loop.py
@@ -50,6 +50,21 @@ MAX_TOOL_ITERATIONS = 4
 # It is independent of the time-based reflection debounce in reflection_gate.py.
 _ATTUNEMENT_WINDOW = 8
 
+# #93: re-offering one of these after it already fired this turn duplicates a
+# real artefact — a second monologue trace, a second pending write, a second
+# memory/journal/work row. Read-only tools are safe to call again with
+# different arguments and stay available. reach_for_capability is here for a
+# different reason: the rerun prompt explicitly tells her not to reach again,
+# so the toolset should agree with the instruction.
+_NEVER_REOFFER: frozenset[str] = frozenset({
+    "add_journal",
+    "add_memory",
+    "propose_write",
+    "record_monologue",
+    "save_work",
+    "reach_for_capability",
+})
+
 
 def _spawn_pass2(
     *,
@@ -256,7 +271,19 @@ def _maybe_recruit_and_rerun(
             None,
         )
         capability = (reach_inv.get("arguments") or {}).get("capability", "") if reach_inv else ""
-        allowed_now = tools_for_capability(capability)
+        # #93: only already-fired tools that are ALSO in _NEVER_REOFFER get
+        # excluded — read-only tools (search_memories, etc.) stay offered even
+        # if already called this turn. tools_for_capability itself is left
+        # alone: its unknown-capability → full-suite branch is the agency
+        # safety-valve, and it still applies, minus whatever must not repeat.
+        already_fired = {inv.get("name") for inv in invocations}
+        allowed_now = [
+            t
+            for t in tools_for_capability(capability)
+            if t not in already_fired or t not in _NEVER_REOFFER
+        ]
+        if not allowed_now:
+            return None
         tools = build_tools_list(companion_name, allowed=allowed_now)
         # Tell the model it already reached, so it uses the real tool now instead of re-reaching.
         rerun_messages = list(messages) + [
@@ -318,7 +345,11 @@ def run_tool_loop(
     -------
     (final_response, invocations)
       - final_response: ChatResponse with content set (tool_calls may be empty)
-      - invocations: list of dicts, each: {name, arguments, result_summary, error?}
+      - invocations: list of dicts, each:
+        {name, arguments, result_summary, outcome, error?}
+        outcome is one of "ok" (dispatched and returned normally), "refused"
+        (returned an {"error": ...} result — e.g. a write_guard denial — rather
+        than raising), or "error" (dispatch raised; record["error"] is set).
     """
     invocations: list[dict[str, Any]] = []
     last_response = ChatResponse(content="", tool_calls=(), raw=None)
@@ -427,6 +458,13 @@ def run_tool_loop(
                     session_id=session_id,
                 )
                 record["result_summary"] = _summarize_result(result)
+                # #96: a tool that RETURNS {"error": ...} is a refusal, not a
+                # success — write_guard denials come back this way rather than
+                # raising, so a refused propose_write was indistinguishable
+                # from a committed one in the invocation record.
+                record["outcome"] = (
+                    "refused" if isinstance(result, dict) and result.get("error") else "ok"
+                )
                 # record_monologue returns {"ok": True, "monologue_text": ...} on
                 # success so _find_monologue_text can locate it and spawn pass 2.
                 if isinstance(result, dict) and result.get("monologue_text"):
@@ -436,6 +474,7 @@ def run_tool_loop(
                 logger.warning("tool dispatch error: %s — %s", tc.name, exc)
                 record["error"] = str(exc)
                 record["result_summary"] = f"error: {exc}"
+                record["outcome"] = "error"
                 tool_content = json.dumps({"error": str(exc)})
 
             invocations.append(record)

--- a/brain/chat/tool_loop.py
+++ b/brain/chat/tool_loop.py
@@ -345,8 +345,8 @@ def run_tool_loop(
     -------
     (final_response, invocations)
       - final_response: ChatResponse with content set (tool_calls may be empty)
-      - invocations: list of dicts. Two shapes land in this list, and only one
-        of them carries `outcome`:
+      - invocations: list of dicts. Two shapes land in this list; both now
+        carry `outcome` (#96/#102):
         - in-process dispatch (the `for tc in last_response.tool_calls` loop
           below — the OllamaProvider path):
           {name, arguments, result_summary, outcome, error?}
@@ -356,10 +356,14 @@ def run_tool_loop(
           is set).
         - provider-dispatched invocations (`last_response.dispatched_invocations`
           — the ClaudeCliProvider path, where tools already ran inside the CLI
-          subprocess): built by brain/mcp_server/audit.py::log_invocation as
-          {timestamp, name, audit_level, arguments, result_summary, error}.
-          `outcome` is NOT present on these records — a consumer must not
-          assume it (#102).
+          subprocess): written by brain/mcp_server/tools.py::_call_tool via
+          brain/mcp_server/audit.py::log_invocation (same "ok"/"refused"/"error"
+          classification as the in-process path) and read back by
+          brain/bridge/provider.py::_read_audit_lines_since as
+          {name, arguments, result_summary, error?, outcome?}. A legacy log
+          line written before this fix simply omits the `outcome` key rather
+          than carrying it as null — a consumer should check for the key's
+          presence, not assume every record has one.
     """
     invocations: list[dict[str, Any]] = []
     last_response = ChatResponse(content="", tool_calls=(), raw=None)

--- a/brain/chat/tool_loop.py
+++ b/brain/chat/tool_loop.py
@@ -345,11 +345,21 @@ def run_tool_loop(
     -------
     (final_response, invocations)
       - final_response: ChatResponse with content set (tool_calls may be empty)
-      - invocations: list of dicts, each:
-        {name, arguments, result_summary, outcome, error?}
-        outcome is one of "ok" (dispatched and returned normally), "refused"
-        (returned an {"error": ...} result — e.g. a write_guard denial — rather
-        than raising), or "error" (dispatch raised; record["error"] is set).
+      - invocations: list of dicts. Two shapes land in this list, and only one
+        of them carries `outcome`:
+        - in-process dispatch (the `for tc in last_response.tool_calls` loop
+          below — the OllamaProvider path):
+          {name, arguments, result_summary, outcome, error?}
+          outcome is one of "ok" (dispatched and returned normally), "refused"
+          (returned an {"error": ...} result — e.g. a write_guard denial —
+          rather than raising), or "error" (dispatch raised; record["error"]
+          is set).
+        - provider-dispatched invocations (`last_response.dispatched_invocations`
+          — the ClaudeCliProvider path, where tools already ran inside the CLI
+          subprocess): built by brain/mcp_server/audit.py::log_invocation as
+          {timestamp, name, audit_level, arguments, result_summary, error}.
+          `outcome` is NOT present on these records — a consumer must not
+          assume it (#102).
     """
     invocations: list[dict[str, Any]] = []
     last_response = ChatResponse(content="", tool_calls=(), raw=None)

--- a/brain/felt_time/prompt.py
+++ b/brain/felt_time/prompt.py
@@ -1,8 +1,8 @@
 """prompt.py — render felt-time as a compact ambient context block.
 
 Spec §4 prompt context render. ≤150-token budget. Honest about cold
-start ("too new to have texture yet"). Anchor labels come from each
-source's existing slug — no LLM call, no generated poetry.
+start ("felt time: no duration tracked yet."). Anchor labels come from
+each source's existing slug — no LLM call, no generated poetry.
 """
 
 from __future__ import annotations
@@ -131,7 +131,7 @@ def _open_arc_lines(arc_anchors: list, *, now: datetime) -> list[str]:
 
 def render_prompt_context(state: FeltTimeState, *, now: datetime | None = None) -> str:
     if not state.anchors and state.lived_age_hours == 0.0:
-        return "felt time: too new to have texture yet."
+        return "felt time: no duration tracked yet."
 
     lines = ["felt time"]
     lived_days = state.lived_age_hours / 24.0

--- a/brain/files/commit.py
+++ b/brain/files/commit.py
@@ -3,6 +3,7 @@ Wires a file_write memory + feed event either way."""
 from __future__ import annotations
 
 import logging
+import os
 from pathlib import Path
 
 from brain.files import pending
@@ -54,7 +55,17 @@ def commit_write(persona_dir: Path, rid: str, *, store) -> dict:
     try:
         g.resolved.parent.mkdir(parents=True, exist_ok=True)
         mode = "w" if op == "create" else "a"
+        # #100: an append must not run together with the block before it.
+        # write_guard already requires the target to exist for append, so the
+        # only run-together case is a non-empty file with no trailing newline.
+        needs_separator = False
+        if mode == "a" and g.resolved.exists() and g.resolved.stat().st_size > 0:
+            with g.resolved.open("rb") as probe:
+                probe.seek(-1, os.SEEK_END)
+                needs_separator = probe.read(1) != b"\n"
         with g.resolved.open(mode, encoding="utf-8") as f:
+            if needs_separator:
+                f.write("\n")
             f.write(content)
     except OSError as exc:
         pending.mark(persona_dir, rid, status="error")

--- a/brain/mcp_server/audit.py
+++ b/brain/mcp_server/audit.py
@@ -101,6 +101,7 @@ def log_invocation(
     arguments: dict[str, Any],
     result_summary: str,
     error: str | None = None,
+    outcome: str | None = None,
     monologue_text: str | None = None,
 ) -> None:
     """Append one invocation record to <persona_dir>/tool_invocations.log.jsonl.
@@ -120,6 +121,11 @@ def log_invocation(
         Compact preview of the result. Truncated to 140 chars + "…" if longer.
     error:
         ``None`` on success; ``str(exc)`` on dispatch failure.
+    outcome:
+        ``"ok"``, ``"refused"``, or ``"error"`` — mirrors tool_loop.py's
+        in-process outcome semantics (#96/#102), so a write_guard denial
+        (returned as ``{"error": ...}`` rather than raised) is distinguishable
+        from a committed write. ``None`` for callers that don't classify it.
     """
     mode = _audit_mode(persona_dir)
     if mode == "off":
@@ -147,6 +153,7 @@ def log_invocation(
         "arguments": safe_arguments,
         "result_summary": truncated,
         "error": error,
+        "outcome": outcome,
     }
     if monologue_text:
         record["monologue_text"] = monologue_text

--- a/brain/mcp_server/tools.py
+++ b/brain/mcp_server/tools.py
@@ -71,11 +71,19 @@ def register_tools(
             monologue_text: str | None = (
                 result.get("monologue_text") if isinstance(result, dict) else None
             )
+            # #96/#102: a tool that RETURNS {"error": ...} is a refusal, not a
+            # success — write_guard denials come back this way rather than
+            # raising, so a refused propose_write was indistinguishable from a
+            # committed one in the invocation record. Mirrors tool_loop.py's
+            # in-process outcome semantics exactly.
+            refusal_error = result.get("error") if isinstance(result, dict) else None
             log_invocation(
                 persona_dir,
                 name=name,
                 arguments=arguments,
                 result_summary=_summarize(payload),
+                error=refusal_error,
+                outcome="refused" if refusal_error else "ok",
                 monologue_text=monologue_text,
             )
             return [TextContent(type="text", text=payload)]
@@ -87,6 +95,7 @@ def register_tools(
                 arguments=arguments,
                 result_summary=f"error: {exc}",
                 error=str(exc),
+                outcome="error",
             )
             return [TextContent(type="text", text=err_payload)]
 

--- a/brain/narrative_memory/prompt.py
+++ b/brain/narrative_memory/prompt.py
@@ -18,13 +18,13 @@ _ALSO_OPEN_CAP = 2
 
 
 def render_current_arc_block(persona_dir: Path) -> str:
-    """Returns the arcs block, or 'arcs: still forming …' on cold start.
+    """Returns the arcs block, or 'arcs: none open' on cold start.
 
     No-cost read of arcs_state.json; never falls through to log replay.
     """
     state = load_or_recover(persona_dir)
     if not state.open:
-        return "arcs\n  still forming — no anchors have seeded threads yet"
+        return "arcs\n  none open"
 
     sorted_arcs = sorted(
         state.open.values(),

--- a/brain/self_model/reconcile.py
+++ b/brain/self_model/reconcile.py
@@ -96,17 +96,23 @@ def _write_self_authored_delta(persona_dir: Path, channel: str, delta: float) ->
 
     Mirrors brain/chat/extractor.py::_apply_emotion_delta: the delta is routed
     through ``_filter_to_registered`` (off-vocab channel → dropped) and clamped
-    to [-1, 1]; importance is abs(delta) * 10 on the 0..10 MemoryStore scale.
+    to [-1, 1]; importance is abs(delta) * 10 on the 0..10 MemoryStore scale,
+    then capped at ``extractor._MAX_DELTA_INTENSITY`` — one reconcile can't peg
+    a channel to the full clamp any more than one chat-turn extraction can.
 
     Returns True if a memory was written, False if the channel was off-vocab or
     the delta was effectively zero (nothing to write).
     """
-    from brain.chat.extractor import _filter_to_registered
+    from brain.chat.extractor import _MAX_DELTA_INTENSITY, _filter_to_registered
     from brain.memory.store import Memory, MemoryStore
 
     clamped = _clamp_delta(delta)
     registered = _filter_to_registered({channel: clamped})
-    emotions = {ch: abs(v) * 10.0 for ch, v in registered.items() if abs(v) > 1e-9}
+    emotions = {
+        ch: min(abs(v) * 10.0, _MAX_DELTA_INTENSITY)
+        for ch, v in registered.items()
+        if abs(v) > 1e-9
+    }
     if not emotions:
         return False
 

--- a/tests/felt_time/test_prompt.py
+++ b/tests/felt_time/test_prompt.py
@@ -9,7 +9,7 @@ from brain.felt_time.state import Anchor, FeltTimeState, HorizonBucket, Pressure
 def test_render_prompt_context_cold_start():
     s = FeltTimeState.cold_start()
     blob = render_prompt_context(s)
-    assert "too new" in blob.lower()
+    assert "no duration tracked" in blob.lower()
     assert blob.count("\n") < 5
 
 

--- a/tests/narrative_memory/test_prompt.py
+++ b/tests/narrative_memory/test_prompt.py
@@ -44,7 +44,7 @@ def _arc(
 def test_render_cold_start_no_arcs(tmp_path: Path):
     save_state(tmp_path, ArcsState())
     out = render_current_arc_block(tmp_path)
-    assert "still forming" in out
+    assert "none open" in out
     assert out.startswith("arcs")
 
 
@@ -110,4 +110,4 @@ def test_render_more_than_two_arcs_caps_with_plus_n_more(tmp_path: Path):
 
 def test_render_missing_state_file_returns_cold_start(tmp_path: Path):
     out = render_current_arc_block(tmp_path)
-    assert "still forming" in out
+    assert "none open" in out

--- a/tests/unit/brain/bridge/test_provider_chat.py
+++ b/tests/unit/brain/bridge/test_provider_chat.py
@@ -946,6 +946,37 @@ def test_read_audit_lines_since_logs_malformed_lines(tmp_path: Path, caplog) -> 
     assert "malformed" in caplog.text
 
 
+def test_read_audit_lines_since_surfaces_outcome_and_omits_when_absent(tmp_path: Path) -> None:
+    """#96/#102: outcome must ride along when the MCP audit log carries it, and
+    a legacy line written before the field existed must not gain a fabricated
+    key (the caller distinguishes "no outcome recorded" from "outcome=None")."""
+    from brain.bridge.provider import _read_audit_lines_since
+
+    audit_path = tmp_path / "tool_invocations.log.jsonl"
+    audit_path.write_text(
+        "\n".join(
+            [
+                json.dumps(
+                    {
+                        "name": "propose_write",
+                        "arguments": {},
+                        "result_summary": "error: denied",
+                        "outcome": "refused",
+                    }
+                ),
+                json.dumps({"name": "legacy_tool", "arguments": {}, "result_summary": "ok"}),
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    records = _read_audit_lines_since(audit_path, 0)
+
+    assert records[0]["outcome"] == "refused"
+    assert "outcome" not in records[1]
+
+
 def test_chat_with_tools_keeps_existing_flags(persona_dir: Path) -> None:
     """The other flags (-p, --output-format, --model, --system-prompt-file)
     must remain — only --json-schema is replaced. system_prompt now travels

--- a/tests/unit/brain/chat/test_cold_start_strings.py
+++ b/tests/unit/brain/chat/test_cold_start_strings.py
@@ -1,0 +1,30 @@
+"""#98 — cold-start strings must describe their own subsystem, not the
+relationship. A persona with a long history can legitimately have zero arcs or
+zero lived-age; the string must not then assert that the relationship is new.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from brain.felt_time.prompt import render_prompt_context
+from brain.felt_time.state import FeltTimeState
+from brain.narrative_memory.prompt import render_current_arc_block
+
+# Phrasings retired by #98. A future edit must not reintroduce them.
+_RETIRED = ("too new", "still forming", "no anchors have seeded")
+
+
+def test_felt_time_cold_start_does_not_claim_novelty():
+    block = render_prompt_context(FeltTimeState())
+    lowered = block.lower()
+    for phrase in _RETIRED:
+        assert phrase not in lowered, f"retired phrasing reintroduced: {phrase!r} in {block!r}"
+    assert "felt time" in lowered
+
+
+def test_arcs_cold_start_does_not_claim_novelty(tmp_path: Path):
+    block = render_current_arc_block(tmp_path)
+    lowered = block.lower()
+    for phrase in _RETIRED:
+        assert phrase not in lowered, f"retired phrasing reintroduced: {phrase!r} in {block!r}"
+    assert "arcs" in lowered

--- a/tests/unit/brain/chat/test_extractor_apply.py
+++ b/tests/unit/brain/chat/test_extractor_apply.py
@@ -464,6 +464,66 @@ def test_crystallisation_within_batch_dedup_same_theme(persona_dir: Path):
     )
 
 
+def test_emotion_delta_is_capped_at_max_intensity(
+    persona_dir: Path, registered_test_emotion: str
+):
+    """#94: a maximal delta is a strong nudge, not a peak. One extraction must
+    not be able to peg a channel to the full 10.0 clamp."""
+    from brain.chat.extractor import _MAX_DELTA_INTENSITY
+    from brain.memory.store import MemoryStore
+
+    # Pin the constant meaningfully below the uncapped 10.0 clamp — otherwise
+    # a regression that reset _MAX_DELTA_INTENSITY back to 10.0 would still
+    # satisfy the equality assertion below by coincidence, and this canary
+    # could never fail.
+    assert _MAX_DELTA_INTENSITY < 10.0
+
+    out = ExtractorOutput(emotion_delta={registered_test_emotion: 1.0})
+    apply_side_effects(out, persona_dir=persona_dir)
+
+    store = MemoryStore(persona_dir / "memories.db")
+    try:
+        mems = [
+            m for m in store.list_active()
+            if m.emotions.get(registered_test_emotion, 0.0) > 0
+        ]
+        assert len(mems) == 1, f"expected exactly one emotion memory, got {len(mems)}"
+        m = mems[0]
+        assert m.emotions[registered_test_emotion] == _MAX_DELTA_INTENSITY, (
+            f"delta 1.0 must mint {_MAX_DELTA_INTENSITY}, got "
+            f"{m.emotions[registered_test_emotion]}"
+        )
+        # The coupling is deliberate: importance is derived from the vector and
+        # must stay consistent with it. Asserted so a later edit can't decouple.
+        assert m.importance == _MAX_DELTA_INTENSITY, (
+            f"importance must track the capped vector, got {m.importance}"
+        )
+    finally:
+        store.close()
+
+
+def test_emotion_delta_below_cap_is_unchanged(
+    persona_dir: Path, registered_test_emotion: str
+):
+    """The x10 mapping is preserved for the whole range under the ceiling —
+    the documented '0.15 nudge becomes 1.5' behaviour must not move."""
+    from brain.memory.store import MemoryStore
+
+    out = ExtractorOutput(emotion_delta={registered_test_emotion: 0.15})
+    apply_side_effects(out, persona_dir=persona_dir)
+
+    store = MemoryStore(persona_dir / "memories.db")
+    try:
+        mems = [
+            m for m in store.list_active()
+            if m.emotions.get(registered_test_emotion, 0.0) > 0
+        ]
+        assert len(mems) == 1
+        assert abs(mems[0].emotions[registered_test_emotion] - 1.5) < 0.001
+    finally:
+        store.close()
+
+
 def test_crystallisation_rejected_theme_does_not_block_requeue(persona_dir: Path):
     """A candidate whose theme matches a *rejected* record must still be queued.
 

--- a/tests/unit/brain/chat/test_extractor_apply.py
+++ b/tests/unit/brain/chat/test_extractor_apply.py
@@ -524,6 +524,73 @@ def test_emotion_delta_below_cap_is_unchanged(
         store.close()
 
 
+def test_emotion_delta_aggregate_is_capped_at_max_intensity(
+    persona_dir: Path, registered_test_emotion: str
+):
+    """#94: the defect was that one extraction's minted emotion won
+    aggregate_state's max-pool outright — assert the AGGREGATE, not just the
+    minted memory's own vector."""
+    from brain.chat.extractor import _MAX_DELTA_INTENSITY
+    from brain.emotion.aggregate import aggregate_state
+    from brain.memory.store import MemoryStore
+
+    out = ExtractorOutput(emotion_delta={registered_test_emotion: 1.0})
+    apply_side_effects(out, persona_dir=persona_dir)
+
+    store = MemoryStore(persona_dir / "memories.db")
+    try:
+        state = aggregate_state(store.list_active())
+    finally:
+        store.close()
+
+    intensity = state.emotions.get(registered_test_emotion, 0.0)
+    assert intensity <= _MAX_DELTA_INTENSITY, (
+        f"aggregated {registered_test_emotion} intensity {intensity} exceeds "
+        f"_MAX_DELTA_INTENSITY={_MAX_DELTA_INTENSITY}"
+    )
+    assert intensity < 10.0, (
+        f"aggregated {registered_test_emotion} intensity {intensity} reached "
+        f"the uncapped 10.0 clamp — one extraction won the aggregate outright"
+    )
+
+
+def test_emotion_delta_aggregate_max_pools_not_accumulates(
+    persona_dir: Path, registered_test_emotion: str
+):
+    """Two successive maximal deltas must still max-pool at the aggregate to
+    _MAX_DELTA_INTENSITY, not sum to double it."""
+    from brain.chat.extractor import _MAX_DELTA_INTENSITY
+    from brain.emotion.aggregate import aggregate_state
+    from brain.memory.store import MemoryStore
+
+    apply_side_effects(
+        ExtractorOutput(emotion_delta={registered_test_emotion: 1.0}), persona_dir=persona_dir
+    )
+    apply_side_effects(
+        ExtractorOutput(emotion_delta={registered_test_emotion: 1.0}), persona_dir=persona_dir
+    )
+
+    store = MemoryStore(persona_dir / "memories.db")
+    try:
+        state = aggregate_state(store.list_active())
+    finally:
+        store.close()
+
+    intensity = state.emotions.get(registered_test_emotion, 0.0)
+    assert intensity == _MAX_DELTA_INTENSITY, (
+        f"two successive maximal deltas should max-pool the aggregate to "
+        f"_MAX_DELTA_INTENSITY={_MAX_DELTA_INTENSITY}, got {intensity} "
+        f"(accumulation would reach {2 * _MAX_DELTA_INTENSITY})"
+    )
+    # Same ceiling test_emotion_delta_aggregate_is_capped_at_max_intensity pins
+    # for one delta, restated for two: repetition must not be a back door past
+    # the cap either.
+    assert intensity < 10.0, (
+        f"aggregated {registered_test_emotion} intensity {intensity} reached "
+        f"the uncapped 10.0 clamp after two extractions"
+    )
+
+
 def test_crystallisation_rejected_theme_does_not_block_requeue(persona_dir: Path):
     """A candidate whose theme matches a *rejected* record must still be queued.
 

--- a/tests/unit/brain/chat/test_tool_loop_outcome.py
+++ b/tests/unit/brain/chat/test_tool_loop_outcome.py
@@ -1,0 +1,101 @@
+"""#96 — a refused tool call must be distinguishable from a committed one.
+
+write_guard RETURNS {"error": ...} rather than raising, so a refused
+propose_write reached invocations looking identical to a success.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from brain.bridge.chat import ChatMessage, ChatResponse, ToolCall
+from brain.bridge.provider import LLMProvider
+from brain.chat.tool_loop import build_tools_list, run_tool_loop
+from brain.memory.hebbian import HebbianMatrix
+from brain.memory.store import MemoryStore
+
+
+class ScriptedProvider(LLMProvider):
+    def __init__(self, responses: list[ChatResponse]) -> None:
+        self._responses = list(responses)
+        self._idx = 0
+        self.chat_calls: list[dict[str, Any]] = []
+
+    def generate(self, prompt: str, *, system: str | None = None) -> str:
+        return "stub generate"
+
+    def name(self) -> str:
+        return "scripted"
+
+    def chat(self, messages, *, tools=None, options=None) -> ChatResponse:
+        self.chat_calls.append({"messages": list(messages), "tools": tools})
+        if self._idx < len(self._responses):
+            resp = self._responses[self._idx]
+            self._idx += 1
+            return resp
+        return ChatResponse(content="fallback", tool_calls=(), raw=None)
+
+
+def _run(provider, tmp_path):
+    return run_tool_loop(
+        [ChatMessage(role="user", content="write that down")],
+        provider=provider,
+        tools=build_tools_list("Nell"),
+        store=MemoryStore(":memory:"),
+        hebbian=HebbianMatrix(":memory:"),
+        persona_dir=tmp_path,
+        companion_name="Nell",
+    )
+
+
+def test_guard_refused_write_is_marked_refused(tmp_path: Path):
+    """A propose_write the guard denies must carry outcome='refused'."""
+    denied = ToolCall(
+        id="c1",
+        name="propose_write",
+        arguments={"path": "/etc/passwd", "content": "x", "op": "append"},
+    )
+    provider = ScriptedProvider([
+        ChatResponse(content="", tool_calls=(denied,), raw=None),
+        ChatResponse(content="done", tool_calls=(), raw=None),
+    ])
+    _resp, invocations = _run(provider, tmp_path)
+
+    write_invs = [i for i in invocations if i.get("name") == "propose_write"]
+    assert len(write_invs) == 1, f"expected one propose_write record, got {invocations}"
+    assert write_invs[0].get("outcome") == "refused", (
+        f"guard-refused write must be marked refused, got {write_invs[0]}"
+    )
+
+
+def test_successful_call_is_marked_ok(tmp_path: Path):
+    """A tool that returns normally carries outcome='ok'."""
+    call = ToolCall(
+        id="c1",
+        name="record_monologue",
+        arguments={"monologue": "a thought", "feed_digest": "she thought"},
+    )
+    provider = ScriptedProvider([
+        ChatResponse(content="", tool_calls=(call,), raw=None),
+        ChatResponse(content="done", tool_calls=(), raw=None),
+    ])
+    _resp, invocations = _run(provider, tmp_path)
+
+    mono = [i for i in invocations if i.get("name") == "record_monologue"]
+    assert len(mono) == 1
+    assert mono[0].get("outcome") == "ok", f"expected ok, got {mono[0]}"
+
+
+def test_unknown_tool_is_marked_error(tmp_path: Path):
+    """A dispatch that raises carries outcome='error' and keeps record['error']."""
+    call = ToolCall(id="c1", name="no_such_tool_at_all", arguments={})
+    provider = ScriptedProvider([
+        ChatResponse(content="", tool_calls=(call,), raw=None),
+        ChatResponse(content="done", tool_calls=(), raw=None),
+    ])
+    _resp, invocations = _run(provider, tmp_path)
+
+    rec = [i for i in invocations if i.get("name") == "no_such_tool_at_all"]
+    assert len(rec) == 1
+    assert rec[0].get("outcome") == "error", f"expected error, got {rec[0]}"
+    assert rec[0].get("error"), "the pre-existing error field must still be set"

--- a/tests/unit/brain/chat/test_tool_loop_recruit.py
+++ b/tests/unit/brain/chat/test_tool_loop_recruit.py
@@ -103,10 +103,13 @@ def test_recruit_on_reach_expands_and_reruns(tmp_path: Path) -> None:
     # not the full suite — T5 (E) scopes reach re-invoke to the faculty.
     from brain.chat.tool_recruit import tools_for_capability
     second_tool_names = {t["function"]["name"] for t in (provider.chat_calls[1]["tools"] or [])}
-    expected_tools = set(tools_for_capability("memory"))
+    # reach_for_capability fired on pass 1 and is deliberately not re-offered (#93) —
+    # the rerun prompt already tells her not to reach again.
+    expected_tools = set(tools_for_capability("memory")) - {"reach_for_capability"}
     assert expected_tools.issubset(second_tool_names), (
         f"2nd call tools missing: {expected_tools - second_tool_names}"
     )
+    assert "reach_for_capability" not in second_tool_names
     # Heavy tools NOT in the memory faculty must be absent (scoped, not full suite)
     assert "crystallize_soul" not in second_tool_names
 
@@ -342,3 +345,94 @@ def test_full_toolset_turn_does_not_suppress_streaming(tmp_path: Path) -> None:
     )
     assert not provider.options_seen[0].get("suppress_stream")
     assert provider.emit_text_calls == []
+
+
+def test_rerun_excludes_tools_that_already_fired(tmp_path: Path) -> None:
+    """#93: the re-invoke must not re-offer a tool that already ran this turn.
+
+    record_monologue is in REFLEXIVE_CORE, so it lands in every expanded set —
+    which let one turn record two monologues and let a file-capability reach
+    issue a second propose_write against identical context.
+    """
+    store = MemoryStore(":memory:")
+    hebbian = HebbianMatrix(":memory:")
+    slim_allowed = ["record_monologue", "reach_for_capability"]
+
+    response_1 = ChatResponse(
+        content="I need more tools",
+        tool_calls=(),
+        dispatched_invocations=(
+            {"name": "record_monologue", "arguments": {"monologue": "a thought"}},
+            {"name": "reach_for_capability", "arguments": {"capability": "files"}},
+        ),
+        raw=None,
+    )
+    response_2 = ChatResponse(content="done", tool_calls=(), dispatched_invocations=(), raw=None)
+
+    provider = ScriptedProvider([response_1, response_2])
+    run_tool_loop(
+        [ChatMessage(role="user", content="help")],
+        provider=provider,
+        tools=build_tools_list("Nell", allowed=slim_allowed),
+        store=store,
+        hebbian=hebbian,
+        persona_dir=tmp_path,
+        companion_name="Nell",
+        recruited_allowed=slim_allowed,
+    )
+
+    assert len(provider.chat_calls) == 2
+    second = {t["function"]["name"] for t in (provider.chat_calls[1]["tools"] or [])}
+    assert "record_monologue" not in second, (
+        "record_monologue already fired on pass 1 and must not be re-offered"
+    )
+    assert "reach_for_capability" not in second, (
+        "the rerun prompt tells her not to reach again — the toolset must agree"
+    )
+    # The faculty she actually reached for is still available.
+    assert "propose_write" in second
+
+
+def test_rerun_still_offers_read_only_tool_that_already_fired(tmp_path: Path) -> None:
+    """#93 (narrowed): only _NEVER_REOFFER tools are excluded from the rerun.
+
+    search_memories is in REFLEXIVE_CORE and in tools_for_capability("memory"),
+    and the rerun prompt itself names it as an example tool to call — excluding
+    it after it already fired once would collide with both. Read-only tools are
+    safe to call again with different arguments and must stay available.
+    """
+    store = MemoryStore(":memory:")
+    hebbian = HebbianMatrix(":memory:")
+    slim_allowed = ["search_memories", "reach_for_capability"]
+
+    response_1 = ChatResponse(
+        content="let me check",
+        tool_calls=(),
+        dispatched_invocations=(
+            {"name": "search_memories", "arguments": {"query": "something"}},
+            {"name": "reach_for_capability", "arguments": {"capability": "memory"}},
+        ),
+        raw=None,
+    )
+    response_2 = ChatResponse(content="done", tool_calls=(), dispatched_invocations=(), raw=None)
+
+    provider = ScriptedProvider([response_1, response_2])
+    run_tool_loop(
+        [ChatMessage(role="user", content="help")],
+        provider=provider,
+        tools=build_tools_list("Nell", allowed=slim_allowed),
+        store=store,
+        hebbian=hebbian,
+        persona_dir=tmp_path,
+        companion_name="Nell",
+        recruited_allowed=slim_allowed,
+    )
+
+    assert len(provider.chat_calls) == 2
+    second = {t["function"]["name"] for t in (provider.chat_calls[1]["tools"] or [])}
+    assert "search_memories" in second, (
+        "a read-only tool that already fired must still be offered on the rerun"
+    )
+    assert "reach_for_capability" not in second, (
+        "reach_for_capability must never be re-offered — the rerun prompt says not to reach again"
+    )

--- a/tests/unit/brain/files/test_commit.py
+++ b/tests/unit/brain/files/test_commit.py
@@ -123,3 +123,61 @@ def test_committed_write_surfaces_in_feed(tmp_path, monkeypatch):
     assert entries[0].type == "file_write"
     assert entries[0].opener == "I wrote to a file —"
     assert str(target.resolve()) in entries[0].body
+
+
+def test_append_inserts_separator_when_file_lacks_trailing_newline(tmp_path, monkeypatch):
+    """#100: two appended blocks must not run together into one line."""
+    monkeypatch.setattr(Path, "home", lambda: tmp_path / "home")
+    persona = _persona(tmp_path)
+    target = tmp_path / "home" / "out" / "n.md"
+    target.parent.mkdir(parents=True)
+    target.write_text("first block")  # no trailing newline
+    rid = pending.create(
+        persona,
+        op="append",
+        resolved_path=str(target.resolve()),
+        content="second block",
+        now=datetime.now(UTC),
+    )
+    store = _store(persona)
+    assert commit_write(persona, rid, store=store)["ok"]
+    assert target.read_text() == "first block\nsecond block"
+
+
+def test_append_does_not_double_newline(tmp_path, monkeypatch):
+    """A file already ending in a newline gets no extra one."""
+    monkeypatch.setattr(Path, "home", lambda: tmp_path / "home")
+    persona = _persona(tmp_path)
+    target = tmp_path / "home" / "out" / "n.md"
+    target.parent.mkdir(parents=True)
+    target.write_text("first block\n")
+    rid = pending.create(
+        persona,
+        op="append",
+        resolved_path=str(target.resolve()),
+        content="second block",
+        now=datetime.now(UTC),
+    )
+    store = _store(persona)
+    assert commit_write(persona, rid, store=store)["ok"]
+    assert target.read_text() == "first block\nsecond block"
+
+
+def test_append_to_empty_file_adds_no_leading_newline(tmp_path, monkeypatch):
+    """A zero-byte existing file is the only reachable empty case — the guard
+    refuses append to a non-existent path before commit_write ever runs."""
+    monkeypatch.setattr(Path, "home", lambda: tmp_path / "home")
+    persona = _persona(tmp_path)
+    target = tmp_path / "home" / "out" / "n.md"
+    target.parent.mkdir(parents=True)
+    target.write_text("")
+    rid = pending.create(
+        persona,
+        op="append",
+        resolved_path=str(target.resolve()),
+        content="body",
+        now=datetime.now(UTC),
+    )
+    store = _store(persona)
+    assert commit_write(persona, rid, store=store)["ok"]
+    assert target.read_text() == "body"

--- a/tests/unit/brain/mcp_server/test_tools.py
+++ b/tests/unit/brain/mcp_server/test_tools.py
@@ -77,6 +77,8 @@ def test_register_tools_dispatches_and_logs_success(persona_dir: Path, fake_stor
     # Audit 2026-05-07 P3-3: 'query' is now redacted in default mode.
     assert rec["arguments"] == {"query": "[REDACTED]"}
     assert rec["error"] is None
+    # #96/#102: a normal return is outcome="ok".
+    assert rec["outcome"] == "ok"
 
 
 def test_register_tools_dispatches_and_logs_error(persona_dir: Path, fake_stores) -> None:
@@ -100,6 +102,8 @@ def test_register_tools_dispatches_and_logs_error(persona_dir: Path, fake_stores
     rec = json.loads((persona_dir / "tool_invocations.log.jsonl").read_text(encoding="utf-8"))
     assert rec["name"] == "search_memories"
     assert rec["error"] == "boom"
+    # #96/#102: a raised exception is outcome="error".
+    assert rec["outcome"] == "error"
 
 
 def test_register_tools_unknown_tool_returns_error(persona_dir: Path, fake_stores) -> None:
@@ -141,6 +145,42 @@ def test_register_tools_summary_truncated(persona_dir: Path, fake_stores) -> Non
 
     rec = json.loads((persona_dir / "tool_invocations.log.jsonl").read_text(encoding="utf-8"))
     assert len(rec["result_summary"]) <= 141  # 140 + "…"
+
+
+def test_register_tools_logs_refused_outcome_for_guard_denial(
+    persona_dir: Path, fake_stores
+) -> None:
+    """#96/#102: write_guard denials RETURN {"error": ...} rather than raising,
+    so a refused propose_write was indistinguishable from a committed one in
+    the invocation record. Goes through the real dispatch/propose_write/
+    write_guard chain (not mocked) — a guard-denied path is a realistic case.
+    """
+    from mcp.server import Server
+
+    from brain.mcp_server.tools import register_tools
+
+    store, hebbian = fake_stores
+    server = Server("brain-tools")
+    register_tools(server, persona_dir=persona_dir, store=store, hebbian=hebbian)
+    call_handler = _get_call_handler(server)
+
+    result = asyncio.run(
+        call_handler(
+            _call_request(
+                "propose_write",
+                {"path": "/etc/passwd", "op": "create", "content": "x"},
+            )
+        )
+    )
+
+    text = result.root.content[0].text
+    payload = json.loads(text)
+    assert "error" in payload  # write_guard denial, returned not raised
+
+    rec = json.loads((persona_dir / "tool_invocations.log.jsonl").read_text(encoding="utf-8"))
+    assert rec["name"] == "propose_write"
+    assert rec["outcome"] == "refused"
+    assert rec["error"]  # non-null/non-empty — the record must not drop it
 
 
 # ── helpers ───────────────────────────────────────────────────────────────────

--- a/tests/unit/brain/self_model/test_reconcile.py
+++ b/tests/unit/brain/self_model/test_reconcile.py
@@ -41,10 +41,12 @@ def test_accept_marks_gap_acknowledged_and_sets_cooldown(tmp_path: Path) -> None
 
 
 def test_revise_writes_clamped_registered_emotion_memory(tmp_path: Path) -> None:
+    from brain.chat.extractor import _MAX_DELTA_INTENSITY
     from brain.memory.store import MemoryStore
 
     _seed_open_gap(tmp_path)
-    # delta over the [-1, 1] bound — must be clamped to 1.0 → importance 10.
+    # delta over the [-1, 1] bound — must be clamped to 1.0 → abs(1.0)*10 = 10.0,
+    # then capped at _MAX_DELTA_INTENSITY (F1/#94 twin of the extractor ceiling).
     result = reconcile_self_read(
         persona_dir=tmp_path, action="revise", channel="grief", delta=5.0
     )
@@ -57,8 +59,34 @@ def test_revise_writes_clamped_registered_emotion_memory(tmp_path: Path) -> None
     finally:
         store.close()
     assert len(mems) == 1
-    # clamped to 1.0 → abs(1.0)*10 = 10.0 intensity on the grief channel
-    assert mems[0].emotions.get("grief") == 10.0
+    assert mems[0].emotions.get("grief") == _MAX_DELTA_INTENSITY
+
+
+def test_revise_delta_is_capped_at_max_delta_intensity(tmp_path: Path) -> None:
+    """F1/#94 twin: brain/chat/extractor.py::_apply_emotion_delta caps a minted
+    vector at _MAX_DELTA_INTENSITY so one extraction can't peg a channel to the
+    full 10.0 clamp. This self-authored path must be capped the same way — a
+    delta well inside the [-1, 1] bound (not touched by _clamp_delta) whose x10
+    mapping would exceed the ceiling must still be capped."""
+    from brain.chat.extractor import _MAX_DELTA_INTENSITY
+    from brain.memory.store import MemoryStore
+
+    _seed_open_gap(tmp_path)
+    # 0.5 is within the [-1, 1] delta bound — abs(0.5) * 10 = 5.0, which must
+    # be capped down to _MAX_DELTA_INTENSITY (3.0).
+    result = reconcile_self_read(
+        persona_dir=tmp_path, action="revise", channel="grief", delta=0.5
+    )
+    assert result.get("ok") is True
+    assert result.get("delta_written") is True
+
+    store = MemoryStore(tmp_path / "memories.db")
+    try:
+        mems = [m for m in store.list_active() if m.memory_type == "self_model_reconcile"]
+    finally:
+        store.close()
+    assert len(mems) == 1
+    assert mems[0].emotions.get("grief") == _MAX_DELTA_INTENSITY
 
 
 def test_revise_off_vocab_channel_is_dropped(tmp_path: Path) -> None:


### PR DESCRIPTION
Tier A of the aberrant-behaviour triage — four defects with roots located in code, plus the follow-ups the review surfaced.

Triage that produced this batch: every open issue not assigned to @ThinkerOfThoughts, verified against `main` @ `ce1c997`. Findings went out as per-issue comments; five of those told us something filed was already fixed, not ours, or working as designed.

## What lands

| Issue | Fix | Status |
|---|---|---|
| #100 | `propose_write` append ran blocks together — probe the last byte, insert one `\n` | complete |
| #94 | `emotion_delta` validated as a delta then written as an absolute via ×10, so a valid `1.0` minted the full `10.0` clamp and won `aggregate_state`'s max-pool outright | complete — **both** writers |
| #98 | Two cold-start strings described their own subsystem's emptiness in language the model read as "this relationship is new" | complete |
| #96 | A tool that RETURNS `{"error": …}` — how `write_guard` denials come back — was indistinguishable from a success in the invocation record | complete, **both provider paths** |
| #93 | Rerun re-fired side-effecting tools | **partial — do not let this auto-close** |

## Three things worth a reviewer's attention

**#94's cap has consequences beyond felt state.** `_apply_emotion_delta` sets
`importance=max(emotions.values())`, so capping the vector caps importance too. That flows into
recall ranking (sorted by importance descending) and forgetting salience — `_emotion_input` is
`max(emotions.values())/10.0`, so a maximal-delta memory drops from `1.0` to `0.3`, a 70% fall.
It fades materially sooner.

Directionally that aligns with PR #58's ROOT 2 (generated self-content saturating the
importance-ranked recall channel), and `monologue_emotion` is generated self-content. But it is
a retention change inside @ThinkerOfThoughts' footprint, so it wants his eyes. No code in
`brain/forgetting/` or the recall path changed. Full reasoning in the spec's §2 Wiring.

**#93 is inert on the reference companion and must not be closed by this PR.** The commit
message says `Fixes #93`; that is wrong and was caught too late to reword without a history
rewrite. **Please reopen #93 after merge.**

The narrowed toolset never reaches the Claude CLI: `chat()` uses `tools` only as `if tools:`,
`_chat_with_mcp_tools` takes no tool list and rebuilds the permission list from the full suite
every call, `_list_tools` exposes everything, and `--allowedTools` is permissive rather than
exclusive (capability ledger, spiked 2026-07-14). The fix is live only on `OllamaProvider`.

Consequence already handled: the Tier A spec claimed this gives a causal toggle for #101's
on-disk doublings. It cannot move either way on the CLI path, so running that experiment would
have produced a false refutation. Retracted in `173f671`.

**#93 is re-specced rather than abandoned.** `2026-08-07-write-idempotency-design.md` moves it
to content-hash dedupe in `pending.create` — provider-independent, needs no turn concept, and
unlike the retracted toggle it is a genuine discriminator for #101.

## Verification

Full `uv run pytest` green, `uv run ruff check .` clean. One pre-existing failure throughout:
`tests/harness/examples/test_generic_run.py::test_generic_live_run`, a live-provider test that
cannot authenticate in an agent shell — confirmed failing identically at clean `HEAD`.

Every new test was confirmed genuinely RED, not assumed: the source files were reverted with the
tests kept, all failed, restored, all passed.

Two pre-existing test files had assertions updated (`felt_time`, `narrative_memory` cold-start
strings; the recruit toolset assertion). Each was reviewed as an assertion following a
deliberate behaviour change rather than a test bent to fit — both were net-strengthened.

## Related

- #102 — the provider-layer gap, now closed by this PR
- #101 — the ~299 on-disk doublings; still open, re-approached by the idempotency spec
- #55 — parked pending PR #58's ROOT 1; tuning now would calibrate against a load about to change

🤖 Generated with [Claude Code](https://claude.com/claude-code)
