### PR TITLE
Dedupe identical pending writes by content hash (#93/#101 partial)

### DIFF
--- a/brain/files/pending.py
+++ b/brain/files/pending.py
@@ -75,6 +75,26 @@ def list_pending(persona_dir: Path, *, now: datetime) -> list[dict]:
     return sorted(fresh, key=lambda r: r["proposed_at"], reverse=True)
 
 
+def find_duplicate(persona_dir: Path, *, op: str, resolved_path: str,
+                   content_sha: str, now: datetime) -> str | None:
+    """Id of a fresh pending record proposing this exact write, or None.
+
+    The record id is not a dedupe key — _new_id mixes in `now`, so two
+    identical proposals moments apart mint different ids and both persist
+    (#93/#101). The dedupe key is (op, resolved_path, content_sha).
+
+    Matches against list_pending, which already filters to status="pending"
+    AND within _TTL_HOURS: a record still marked pending but past the TTL has
+    merely not been swept yet, and must not suppress a legitimate proposal.
+    """
+    for r in list_pending(persona_dir, now=now):
+        if (r.get("op") == op
+                and r.get("resolved_path") == resolved_path
+                and r.get("content_sha") == content_sha):
+            return r["id"]
+    return None
+
+
 def mark(persona_dir: Path, rid: str, *, status: str) -> None:
     rec = get(persona_dir, rid)
     if rec is None:

--- a/brain/tools/impls/propose_write.py
+++ b/brain/tools/impls/propose_write.py
@@ -85,12 +85,27 @@ def propose_write(path: str, content: str | None = None, *, op: str,
         return {"error": res.get("error", "write failed")}
 
     now = datetime.now(UTC)
+    content_sha = hashlib.sha256(content.encode()).hexdigest()
+
+    # #93/#101: the same write proposed twice in one turn must not stage two
+    # cards. The record id can't carry this — _new_id mixes in `now` — so match
+    # on (op, resolved_path, content_sha) against the fresh pending set.
+    existing = pending.find_duplicate(persona_dir, op=op,
+                                      resolved_path=str(g.resolved),
+                                      content_sha=content_sha, now=now)
+    if existing is not None:
+        audit(persona_dir, event="propose_deduped", id=existing, op=op,
+              path=str(g.resolved), content_sha=content_sha)
+        return {"status": "already_proposed", "id": existing, "deduped": True,
+                "note": f"this exact {op} of {g.resolved} is already staged and "
+                        "awaiting your confirmation — no second card was created"}
+
     if pending.count_pending(persona_dir, now=now) >= pending._MAX_PENDING:
         return {"error": "too many writes awaiting your review — resolve some first"}
 
     rid = pending.create(persona_dir, op=op, resolved_path=str(g.resolved), content=content,
                          now=now, making_id=making_id)
     audit(persona_dir, event="propose", id=rid, op=op, path=str(g.resolved),
-          content_sha=hashlib.sha256(content.encode()).hexdigest())
+          content_sha=content_sha)
     return {"status": "proposed", "id": rid,
             "note": f"proposed {op} of {g.resolved} — awaiting your confirmation in NellFace"}

--- a/tests/unit/brain/files/test_pending.py
+++ b/tests/unit/brain/files/test_pending.py
@@ -1,7 +1,16 @@
 # tests/unit/brain/files/test_pending.py
+import hashlib
 from datetime import UTC, datetime, timedelta
 
-from brain.files.pending import create, get, list_pending, mark, sweep_expired
+from brain.files.pending import (
+    _TTL_HOURS,
+    create,
+    find_duplicate,
+    get,
+    list_pending,
+    mark,
+    sweep_expired,
+)
 
 
 def test_create_list_get(tmp_path):
@@ -26,3 +35,53 @@ def test_mark_committed(tmp_path):
                  now=datetime(2026, 6, 14, tzinfo=UTC))
     mark(tmp_path, rid, status="committed")
     assert get(tmp_path, rid)["status"] == "committed"
+
+
+def test_find_duplicate_matches_identical_pending_record(tmp_path):
+    now = datetime.now(UTC)
+    sha = hashlib.sha256(b"body").hexdigest()
+    rid = create(tmp_path, op="append", resolved_path="/x/n.md",
+                 content="body", now=now)
+    found = find_duplicate(tmp_path, op="append", resolved_path="/x/n.md",
+                            content_sha=sha, now=now)
+    assert found == rid
+
+
+def test_find_duplicate_ignores_different_content(tmp_path):
+    now = datetime.now(UTC)
+    create(tmp_path, op="append", resolved_path="/x/n.md", content="body", now=now)
+    other = hashlib.sha256(b"different").hexdigest()
+    assert find_duplicate(tmp_path, op="append", resolved_path="/x/n.md",
+                           content_sha=other, now=now) is None
+
+
+def test_find_duplicate_ignores_different_path_and_op(tmp_path):
+    now = datetime.now(UTC)
+    sha = hashlib.sha256(b"body").hexdigest()
+    create(tmp_path, op="append", resolved_path="/x/n.md", content="body", now=now)
+    assert find_duplicate(tmp_path, op="append", resolved_path="/x/OTHER.md",
+                           content_sha=sha, now=now) is None
+    assert find_duplicate(tmp_path, op="create", resolved_path="/x/n.md",
+                           content_sha=sha, now=now) is None
+
+
+def test_find_duplicate_ignores_resolved_records(tmp_path):
+    """Once the user acts, an identical later proposal is legitimately new."""
+    now = datetime.now(UTC)
+    sha = hashlib.sha256(b"body").hexdigest()
+    rid = create(tmp_path, op="append", resolved_path="/x/n.md",
+                 content="body", now=now)
+    for status in ("committed", "declined", "refused", "expired"):
+        mark(tmp_path, rid, status=status)
+        assert find_duplicate(tmp_path, op="append", resolved_path="/x/n.md",
+                               content_sha=sha, now=now) is None, status
+
+
+def test_find_duplicate_ignores_stale_pending_past_ttl(tmp_path):
+    """A record still marked pending but past the TTL has just not been swept —
+    it must not suppress a legitimate new proposal."""
+    old = datetime.now(UTC) - timedelta(hours=_TTL_HOURS + 1)
+    sha = hashlib.sha256(b"body").hexdigest()
+    create(tmp_path, op="append", resolved_path="/x/n.md", content="body", now=old)
+    assert find_duplicate(tmp_path, op="append", resolved_path="/x/n.md",
+                           content_sha=sha, now=datetime.now(UTC)) is None

--- a/tests/unit/brain/files/test_propose_write.py
+++ b/tests/unit/brain/files/test_propose_write.py
@@ -96,3 +96,43 @@ def test_propose_over_queue_cap_refused(tmp_path, monkeypatch):
     out = propose_write(path=str(tmp_path / "home" / "f11.md"), content="x", op="create",
                         persona_dir=_persona(tmp_path))
     assert "error" in out and "awaiting" in out["error"].lower()
+
+
+def test_second_identical_proposal_is_deduped(tmp_path, monkeypatch):
+    """#93/#101: one turn must not stage the same write twice."""
+    from datetime import UTC, datetime
+
+    from brain.files.pending import list_pending
+
+    monkeypatch.setattr(Path, "home", lambda: tmp_path / "home")
+    target = tmp_path / "home" / "Documents" / "note.md"
+
+    first = propose_write(path=str(target), content="block", op="create",
+                          persona_dir=_persona(tmp_path))
+    second = propose_write(path=str(target), content="block", op="create",
+                           persona_dir=_persona(tmp_path))
+
+    assert first["status"] == "proposed"
+    assert second["status"] == "already_proposed"
+    assert second["deduped"] is True
+    assert second["id"] == first["id"]
+    # The canary: ONE card, not two.
+    assert len(list_pending(_persona(tmp_path), now=datetime.now(UTC))) == 1
+
+
+def test_different_content_still_creates_a_second_card(tmp_path, monkeypatch):
+    from datetime import UTC, datetime
+
+    from brain.files.pending import list_pending
+
+    monkeypatch.setattr(Path, "home", lambda: tmp_path / "home")
+    target = tmp_path / "home" / "Documents" / "note.md"
+
+    propose_write(path=str(target), content="block one", op="create",
+                  persona_dir=_persona(tmp_path))
+    second = propose_write(path=str(target), content="block two", op="create",
+                           persona_dir=_persona(tmp_path))
+
+    assert second["status"] == "proposed"
+    assert "deduped" not in second
+    assert len(list_pending(_persona(tmp_path), now=datetime.now(UTC))) == 2


### PR DESCRIPTION
Makes file-write proposals idempotent by content: the same `propose_write` issued twice stages **one** card, and on approval the block lands on disk **once**.

Root: `commit_write` is already idempotent per pending record, so a doubling requires two *distinct* pending records with identical content. The record id cannot dedupe — `_new_id` mixes in `now`, so identical proposals moments apart mint different ids.

Fix: `pending.find_duplicate` keyed on `(op, resolved_path, content_sha)`, matched against `list_pending` (which already filters status **and** TTL freshness, so a stale-but-unswept record cannot suppress a legitimate proposal). A hit returns `{status: already_proposed, deduped: true}` — carried on the `note` field the model already reads, so it has a consumer on day one.

Verified end-to-end, not just unit-tested: two identical proposals → 1 card, second returns the same id, second commit refused, block appears **once** on disk.

## Deliberately not closing #93 or #101

- **#93's malformed `tools[]` record is unchanged on the Claude CLI path.** The rerun still fires both calls and both are logged; the `e8c0d14` toolset narrowing only bites on `OllamaProvider` (`--allowedTools` is permissive, and the tool list never reaches the CLI).
- **#105** — the authorised-notes auto-commit branch still doubles on disk. Filed during review of this change. It creates a record and immediately commits it, so `find_duplicate` never sees it. Worse there than on the card path: no consent gate.

**#101 measurement warning:** a notes-enabled user can still produce doublings after this lands. Segment by notes-folder target before reading the rate as evidence for or against the content-hash hypothesis.

Full suite 4245 passed, ruff clean. One pre-existing failure throughout (`test_generic_live_run`, live-provider auth in an agent shell).

🤖 Generated with [Claude Code](https://claude.com/claude-code)