### PR TITLE
Stop CLI error frames being delivered as the companion's reply (#92)

### DIFF
--- a/brain/bridge/provider.py
+++ b/brain/bridge/provider.py
@@ -435,6 +435,29 @@ def _system_prompt_tempfile(text: str | None) -> Iterator[str | None]:
             pass
 
 
+def _cli_error_detail(payload: dict) -> str | None:
+    """Detail for a result frame that reports failure, or None if it is fine.
+
+    The CLI can exit 0 and report the failure *inside* the frame (#92) — e.g.
+    ``{"is_error": true, "result": "Not logged in · Please run /login"}``. The
+    non-zero-exit guard never sees those, so without this check the error
+    string was assigned straight to ChatResponse.content and the user read a
+    system error as something their companion said.
+
+    The over-budget frame is excluded deliberately: it also carries
+    ``is_error`` but holds partial work worth keeping, and has its own
+    graceful path at each call site.
+    """
+    if not payload.get("is_error"):
+        return None
+    if payload.get("subtype") == "error_max_budget_usd" or any(
+        "maximum budget" in str(e).lower() for e in (payload.get("errors") or [])
+    ):
+        return None
+    detail = str(payload.get("result") or "").strip()
+    return detail[:200] if detail else f"is_error with no result text: {payload!r}"[:200]
+
+
 def _claude_failure_detail(result: subprocess.CompletedProcess[str]) -> str:
     """Return a useful error detail for failed Claude CLI subprocesses.
 
@@ -717,6 +740,9 @@ class ClaudeCliProvider(LLMProvider):
                     f"{partial}\n\n{_BUDGET_EXCEEDED_MSG}" if partial else _BUDGET_EXCEEDED_MSG
                 )
                 return ChatResponse(content=text, tool_calls=(), raw=payload)
+            cli_err = _cli_error_detail(payload)
+            if cli_err is not None:
+                raise ProviderError("claude_cli_error", cli_err)
             content = str(payload["result"])
         except (json.JSONDecodeError, KeyError, TypeError) as exc:
             raise ProviderError(
@@ -1023,7 +1049,14 @@ class ClaudeCliProvider(LLMProvider):
                             )
                             yield StreamDone(content=cutoff, metadata=metadata)
                         else:
-                            yield StreamDone(content=result_text, metadata=metadata)
+                            # #92: an exit-0 frame can still report a failure —
+                            # surface it as an error rather than streaming the
+                            # CLI's error text as her reply.
+                            cli_err = _cli_error_detail(obj)
+                            if cli_err is not None:
+                                yield StreamError(stage="claude_cli_error", detail=cli_err)
+                            else:
+                                yield StreamDone(content=result_text, metadata=metadata)
                         done_emitted = True
                         # The result frame is terminal — stop here. Looping back
                         # to q.get would re-arm the idle-timeout watchdog and, if
@@ -1387,6 +1420,9 @@ class ClaudeCliProvider(LLMProvider):
                         f"{partial}\n\n{_BUDGET_EXCEEDED_MSG}" if partial else _BUDGET_EXCEEDED_MSG
                     )
                     return ChatResponse(content=text, tool_calls=(), raw=payload)
+                cli_err = _cli_error_detail(payload)
+                if cli_err is not None:
+                    raise ProviderError("claude_cli_error", cli_err)
                 content = str(payload["result"])
             except (json.JSONDecodeError, KeyError, TypeError) as exc:
                 raise ProviderError(

--- a/tests/bridge/test_provider_cli_error.py
+++ b/tests/bridge/test_provider_cli_error.py
@@ -1,0 +1,86 @@
+"""CLI error frames must not be delivered as the companion's reply (#92).
+
+The Claude CLI can exit 0 and report a failure inside the result frame —
+``{"is_error": true, "result": "Not logged in · Please run /login"}``.
+The non-zero-exit guard never sees those, so before this fix the error string
+became ``ChatResponse.content`` and the user read a system error as something
+their companion said.
+
+The over-budget frame is the one deliberate exception: it carries partial work
+worth keeping and is handled separately (see test_provider_budget.py).
+
+Tests added one at a time per the tdd-guard rule.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+
+import pytest
+
+from brain.bridge.chat import ChatMessage
+from brain.bridge.provider import ClaudeCliProvider, ProviderError
+
+_AUTH_FRAME = {
+    "type": "result",
+    "is_error": True,
+    "result": "Not logged in · Please run /login",
+}
+
+
+def test_mcp_tools_path_raises_on_cli_error_frame(tmp_path, monkeypatch):
+    """_chat_with_mcp_tools must raise, not hand the error text back as a reply."""
+
+    def fake_run(cmd, *a, **k):
+        return subprocess.CompletedProcess(cmd, 0, stdout=json.dumps(_AUTH_FRAME), stderr="")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    monkeypatch.setitem(__import__("sys").modules, "mcp", __import__("types").ModuleType("mcp"))
+
+    persona = tmp_path / "persona"
+    persona.mkdir()
+    p = ClaudeCliProvider(model="claude-sonnet-4-6")
+
+    with pytest.raises(ProviderError) as exc:
+        p.chat(
+            [ChatMessage(role="user", content="hi")],
+            tools=[{"name": "noop"}],
+            options={"persona_dir": str(persona)},
+        )
+    # The raw CLI text belongs in the log, not in her mouth — but it must be
+    # in the error detail so the failure is diagnosable.
+    assert "Not logged in" in str(exc.value)
+
+
+def test_chat_stream_yields_error_not_done_on_cli_error_frame(monkeypatch):
+    """chat_stream: an exit-0 error frame must yield StreamError, not StreamDone.
+
+    Same defect as the non-streaming paths, one layer out — the WS path would
+    otherwise stream the CLI's error text to the user as her reply.
+    """
+    from unittest.mock import MagicMock, patch
+
+    from brain.bridge.chat import StreamDone, StreamError
+
+    proc = MagicMock()
+    proc.stdout = iter([json.dumps({"type": "result", **_AUTH_FRAME}) + "\n"])
+    proc.stdin = MagicMock()
+    proc.poll.return_value = 0
+    proc.wait.return_value = 0
+    proc.returncode = 0
+    proc.stderr = MagicMock()
+    proc.stderr.read.return_value = ""
+
+    provider = ClaudeCliProvider(model="claude-sonnet-4-6")
+    with patch("brain.bridge.provider.subprocess.Popen", return_value=proc):
+        events = list(provider.chat_stream([ChatMessage(role="user", content="hi")]))
+
+    errors = [e for e in events if isinstance(e, StreamError)]
+    dones = [e for e in events if isinstance(e, StreamDone)]
+    assert errors, f"expected a StreamError, got {events!r}"
+    assert errors[0].stage == "claude_cli_error"
+    assert "Not logged in" in errors[0].detail
+    assert not [d for d in dones if "Not logged in" in (d.content or "")], (
+        "the CLI error text must never be delivered as her reply"
+    )


### PR DESCRIPTION
The Claude CLI can exit 0 and report a failure **inside** the result frame:

```json
{"is_error": true, "result": "Not logged in · Please run /login"}
```

The non-zero-exit guard at `provider.py:700` never sees those, so the error string was assigned straight to `ChatResponse.content` — and the user read a system error as something their companion said.

## Fix

`_cli_error_detail` applied at all three result-frame sites (`chat`, `chat_stream`, `_chat_with_mcp_tools`). Non-streaming paths raise `ProviderError`; the stream yields `StreamError` — each site's existing error channel rather than a new one.

Both already funnel to `provider_failed`, which `friendlyChatError.ts` maps to *"Make sure Claude Code is installed and you're signed in…"*. So an auth failure now tells the user what to do instead of impersonating her. The plumbing existed; the provider just never raised.

## Scope, verified

- **Over-budget frames excluded deliberately** — they also carry `is_error` but hold partial work and keep their graceful path. All 6 existing budget tests pass unchanged.
- **429s unaffected** — they exit non-zero and were already raising at `:700`. Confirmed against `_claude_failure_detail`'s own docstring.
- **The other half of #92 is not a defect.** The "work limit reached" string is our own deliberate `--max-budget-usd` backstop text (`provider.py:82`), not passthrough. Left as is — that one is a product decision, not a bug.

## Verification

Full suite 4247 passed, ruff clean. One pre-existing failure throughout (`test_generic_live_run`, live-provider auth in an agent shell).

Both new tests confirmed genuinely RED: the non-streaming one failed `DID NOT RAISE`; the streaming one was proven by reverting just its hunk and watching it fail, since I wrote that test after the fix rather than before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)