### PR TITLE
Skip a notes append whose block is already in the file (#105)

### DIFF
--- a/brain/tools/impls/propose_write.py
+++ b/brain/tools/impls/propose_write.py
@@ -32,6 +32,21 @@ def _authorised_notes_folder(persona_dir: Path) -> Path | None:
     return None
 
 
+def _block_present(existing: str, content: str) -> bool:
+    """True if `content` appears as a contiguous run of complete lines in `existing`.
+
+    Line-anchored rather than a plain substring test on purpose: a short append
+    ("done") must not be swallowed because it happens to sit inside unrelated
+    text ("well done, truly"). That would silently drop a legitimate note —
+    the same class of harm as the doubling this guards against (#105).
+    """
+    hay = existing.splitlines()
+    needle = content.splitlines()
+    if not needle:
+        return True
+    return any(hay[i:i + len(needle)] == needle for i in range(len(hay) - len(needle) + 1))
+
+
 def propose_write(path: str, content: str | None = None, *, op: str,
                   making_id: str | None = None, persona_dir: Path, **_) -> dict:
     # making_id source (Maker combined-build integration; Task 16b of the maker plan)
@@ -70,6 +85,25 @@ def propose_write(path: str, content: str | None = None, *, op: str,
     if auto is not None and is_within_authorized(g.resolved, auto):
         from brain.files.commit import commit_write
         from brain.memory.store import MemoryStore
+
+        # #105: this branch commits inside the same call, so the pending-record
+        # dedupe (#93) never sees it — an identical block landed on disk twice,
+        # and with no consent card to catch it. Ask the file instead of tracking
+        # recency. `create` cannot double (the guard refuses an existing path),
+        # so only append needs this.
+        # Fail-soft: an unreadable target must never block a legitimate note.
+        if op == "append":
+            try:
+                existing = g.resolved.read_text(encoding="utf-8")
+            except (OSError, ValueError):
+                existing = None
+            if existing is not None and _block_present(existing, content):
+                audit(persona_dir, event="write_skipped_present", id="", op=op,
+                      path=str(g.resolved))
+                return {
+                    "status": "already_present", "path": str(g.resolved), "deduped": True,
+                    "note": f"that block is already in {g.resolved} — nothing written",
+                }
 
         rid = pending.create(persona_dir, op=op, resolved_path=str(g.resolved),
                              content=content, now=datetime.now(UTC), making_id=making_id)

--- a/tests/unit/brain/files/test_propose_write.py
+++ b/tests/unit/brain/files/test_propose_write.py
@@ -136,3 +136,95 @@ def test_different_content_still_creates_a_second_card(tmp_path, monkeypatch):
     assert second["status"] == "proposed"
     assert "deduped" not in second
     assert len(list_pending(_persona(tmp_path), now=datetime.now(UTC))) == 2
+
+
+def _notes_persona(tmp_path, monkeypatch):
+    """Notes enabled on an authorised folder. Returns (persona_dir, notes_dir)."""
+    import json
+
+    h = tmp_path / "home"
+    monkeypatch.setattr(Path, "home", lambda: h)
+    notes = h / "Documents" / "Notes"
+    notes.mkdir(parents=True)
+    persona = _persona(tmp_path)
+    persona.mkdir(parents=True)
+    (persona / "persona_config.json").write_text(
+        json.dumps({"notes_enabled": True, "notes_folder": str(notes)}), encoding="utf-8"
+    )
+    return persona, notes
+
+
+def test_notes_append_skips_a_block_already_present(tmp_path, monkeypatch):
+    """#105: the autonomous notes branch must not write a block the file already has.
+
+    It commits inside the same call, so the pending-record dedupe (#93) never
+    sees it — before this fix two identical calls produced 'seed\\nBLOCK\\nBLOCK'.
+    """
+    persona, notes = _notes_persona(tmp_path, monkeypatch)
+    target = notes / "note.md"
+    target.write_text("seed\n", encoding="utf-8")
+
+    first = propose_write(path=str(target), content="- a line", op="append", persona_dir=persona)
+    after_first = target.read_text(encoding="utf-8")
+    second = propose_write(path=str(target), content="- a line", op="append", persona_dir=persona)
+
+    assert first.get("status") == "written", first
+    assert second.get("status") == "already_present", second
+    assert second.get("deduped") is True
+    assert target.read_text(encoding="utf-8") == after_first, "the second call must write nothing"
+    assert after_first.count("- a line") == 1
+
+
+def test_notes_append_writes_short_content_that_is_only_an_incidental_substring(
+    tmp_path, monkeypatch
+):
+    """The containment check is line-anchored, not a substring test (#105).
+
+    "done" sitting inside "well done, truly" must NOT count as already present —
+    silently dropping a legitimate short note is the same class of harm as the
+    doubling this guards against.
+    """
+    persona, notes = _notes_persona(tmp_path, monkeypatch)
+    target = notes / "note.md"
+    target.write_text("well done, truly\n", encoding="utf-8")
+
+    out = propose_write(path=str(target), content="done", op="append", persona_dir=persona)
+
+    assert out.get("status") == "written", out
+    assert target.read_text(encoding="utf-8") == "well done, truly\ndone"
+
+
+def test_consent_path_still_commits_content_already_in_the_file(tmp_path, monkeypatch):
+    """CANARY for #105's placement decision — do NOT move the check into commit_write.
+
+    commit_write has two callers: the autonomous notes branch, and the
+    /persona/writes/{rid}/approve consent gate. A containment check inside
+    commit_write would silently refuse a write the USER HAD JUST APPROVED.
+    This asserts the consented path is untouched; it fails if the check ever
+    slides down a layer.
+    """
+    from datetime import UTC, datetime
+
+    from brain.files import pending
+    from brain.files.commit import commit_write
+    from brain.memory.store import MemoryStore
+
+    h = tmp_path / "home"
+    monkeypatch.setattr(Path, "home", lambda: h)
+    (h / "Documents").mkdir(parents=True)
+    persona = _persona(tmp_path)
+    target = h / "Documents" / "doc.md"
+    target.write_text("- a line\n", encoding="utf-8")  # content ALREADY present
+
+    rid = pending.create(persona, op="append", resolved_path=str(target.resolve()),
+                         content="- a line", now=datetime.now(UTC))
+    store = MemoryStore(persona / "memories.db")
+    try:
+        res = commit_write(persona, rid, store=store)
+    finally:
+        store.close()
+
+    assert res.get("ok") is True, res
+    assert target.read_text(encoding="utf-8").count("- a line") == 2, (
+        "an approved write must commit even when the content is already present"
+    )


### PR DESCRIPTION
Closes the half of the write-doubling that #93's fix could not reach.

The authorised-notes branch of `propose_write` creates a pending record and commits it **inside the same call**, so the pending-record dedupe never sees it. Verified before the fix — two identical calls produced:

```
on disk -> 'seed\nBLOCK\nBLOCK'   BLOCK count = 2
```

and after:

```
call 2 -> already_present  deduped=True
on disk -> 'seed\nBLOCK'   BLOCK count = 1
```

This was the worse half: it is the one write path with **no consent card**, so the duplicate landed unreviewable.

## Why ask the file instead of tracking recency

A window over recently-committed records needs a constant, and every value is wrong somewhere — too short for a slow rerun, too long to permit a legitimate repeat. That constant would be a guess. "Is this block already in the note?" needs no window, no new state, and no concept of a turn.

## Three narrowings, each verified rather than assumed

- **Append only.** `check_write_target` already refuses `create` on an existing path, so a doubled `create` was never reachable.
- **Not in `commit_write`.** It has exactly two callers: this branch, and `POST /persona/writes/{rid}/approve`. A check down there would silently refuse a write **the user had just approved**. A canary test pins that decision.
- **Not the daily notes.** `brain/notes/write.py::commit_note` is a separate path that writes a new dated file per note via `create`. It never touches this code. (My first draft of the spec got this wrong and said otherwise.)

## Line-anchored, not substring

`"done"` must not be swallowed by `"well done, truly"` — silently dropping a legitimate short note is the same class of harm as the doubling. The check matches a contiguous run of complete lines; verified across seven cases.

## The trade-off

She cannot append a genuinely-identical block to the same note twice while it remains in the file. Softened by two structural facts rather than optimism: the refusal is **visible** (she gets `already_present` and can say so), and it is **not permanent** (remove the line and she can add it again). The real invariant is *the file cannot contain the same block twice*.

No length floor — that would be the same guessed constant I rejected the window for. The marker makes a wrong refusal observable, so a floor can later be picked from evidence.

## Verification

Full suite 4267 passed, ruff clean. One pre-existing failure throughout (`test_generic_live_run`, live-provider auth in an agent shell). New test confirmed RED before the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)