### PR TITLE
Record content_sha on the notes skip event (#101 analysis prerequisite)

### DIFF
--- a/brain/tools/impls/propose_write.py
+++ b/brain/tools/impls/propose_write.py
@@ -76,6 +76,8 @@ def propose_write(path: str, content: str | None = None, *, op: str,
         audit(persona_dir, event="propose_refused", id="", op=op, path=str(g.resolved), error=s.error)
         return {"error": s.error}
 
+    content_sha = hashlib.sha256(content.encode()).hexdigest()
+
     # Auto-commit into the user-authorised notes folder (no confirmation card):
     # the user enabled "let her leave me notes" for this exact folder, so a tool
     # write whose target resolves inside it is committed directly. It still passes
@@ -99,7 +101,7 @@ def propose_write(path: str, content: str | None = None, *, op: str,
                 existing = None
             if existing is not None and _block_present(existing, content):
                 audit(persona_dir, event="write_skipped_present", id="", op=op,
-                      path=str(g.resolved))
+                      path=str(g.resolved), content_sha=content_sha)
                 return {
                     "status": "already_present", "path": str(g.resolved), "deduped": True,
                     "note": f"that block is already in {g.resolved} — nothing written",
@@ -119,7 +121,6 @@ def propose_write(path: str, content: str | None = None, *, op: str,
         return {"error": res.get("error", "write failed")}
 
     now = datetime.now(UTC)
-    content_sha = hashlib.sha256(content.encode()).hexdigest()
 
     # #93/#101: the same write proposed twice in one turn must not stage two
     # cards. The record id can't carry this — _new_id mixes in `now` — so match

--- a/tests/unit/brain/files/test_propose_write.py
+++ b/tests/unit/brain/files/test_propose_write.py
@@ -228,3 +228,29 @@ def test_consent_path_still_commits_content_already_in_the_file(tmp_path, monkey
     assert target.read_text(encoding="utf-8").count("- a line") == 2, (
         "an approved write must commit even when the content is already present"
     )
+
+
+def test_notes_skip_event_records_the_content_sha(tmp_path, monkeypatch):
+    """write_audit.jsonl must correlate a skip to its block (#101 analysis).
+
+    Without content_sha a `write_skipped_present` row cannot be tied to a
+    specific block, so the audit trail can't distinguish which write was
+    suppressed — the exact question the #101 discriminating test asks.
+    """
+    import hashlib
+    import json
+
+    persona, notes = _notes_persona(tmp_path, monkeypatch)
+    target = notes / "note.md"
+    target.write_text("- a line\n", encoding="utf-8")
+
+    propose_write(path=str(target), content="- a line", op="append", persona_dir=persona)
+
+    rows = [
+        json.loads(ln)
+        for ln in (persona / "write_audit.jsonl").read_text(encoding="utf-8").splitlines()
+        if ln.strip()
+    ]
+    skips = [r for r in rows if r["event"] == "write_skipped_present"]
+    assert len(skips) == 1, rows
+    assert skips[0]["content_sha"] == hashlib.sha256(b"- a line").hexdigest()


### PR DESCRIPTION
`write_audit.jsonl` is the only artefact that can say **which** write was suppressed and why. `write_skipped_present` — the event added with the #105 fix — was the single event on the write path emitting no `content_sha`, so a skip could not be correlated to a block.

That correlation is precisely what the #101 discriminating test needs: for a given `(path, content_sha)`, the event sequence tells you whether a doubling came from concurrent proposals, from propose→approve→propose, or from inside the write path itself.

Found while specifying that test, not by review.

Also hoists the single `content_sha` computation above the notes branch so both paths share one value rather than the notes path computing none.

Full suite 4268 passed, ruff clean. Test confirmed RED first.

Bears on #101.

🤖 Generated with [Claude Code](https://claude.com/claude-code)