### PR TITLE
Claim the pending record before writing it (#101 root cause)

### DIFF
--- a/brain/files/commit.py
+++ b/brain/files/commit.py
@@ -52,6 +52,16 @@ def commit_write(persona_dir: Path, rid: str, *, store) -> dict:
             error=err,
         )
         return {"ok": False, "error": err}
+    # #101: claim the record BEFORE writing. The write used to land first and
+    # the status was set after — but pending.mark is silently fallible, so a
+    # failed mark left the record 'pending' with the content already on disk,
+    # and the status guard above stopped blocking a retry. Claiming first means
+    # a retry can only re-enter if nothing was written.
+    if not pending.mark(persona_dir, rid, status="committing"):
+        audit(persona_dir, event="claim_failed", id=rid, op=op, path=rec["resolved_path"],
+              error="could not record the committing status")
+        return {"ok": False, "error": "could not claim the write for commit"}
+
     try:
         g.resolved.parent.mkdir(parents=True, exist_ok=True)
         mode = "w" if op == "create" else "a"

--- a/brain/files/pending.py
+++ b/brain/files/pending.py
@@ -95,15 +95,24 @@ def find_duplicate(persona_dir: Path, *, op: str, resolved_path: str,
     return None
 
 
-def mark(persona_dir: Path, rid: str, *, status: str) -> None:
+def mark(persona_dir: Path, rid: str, *, status: str) -> bool:
+    """Set the record's status. Returns True if it took, False if it did not.
+
+    Returning a bool rather than failing mutely is load-bearing (#101): get()
+    swallows OSError/ValueError, so a transient read failure made this a silent
+    no-op. commit_write then wrote the file while the record stayed 'pending',
+    and its status guard — the thing making the commit idempotent — stopped
+    guarding, so a retry appended the block a second time.
+    """
     rec = get(persona_dir, rid)
     if rec is None:
-        return
+        return False
     rec["status"] = status
     p = _dir(persona_dir) / f"{rid}.json"
     tmp = p.with_suffix(".tmp")
     tmp.write_text(json.dumps(rec), encoding="utf-8")
     tmp.replace(p)
+    return True
 
 
 def sweep_expired(persona_dir: Path, *, now: datetime) -> int:

--- a/tests/unit/brain/files/test_commit.py
+++ b/tests/unit/brain/files/test_commit.py
@@ -181,3 +181,36 @@ def test_append_to_empty_file_adds_no_leading_newline(tmp_path, monkeypatch):
     store = _store(persona)
     assert commit_write(persona, rid, store=store)["ok"]
     assert target.read_text() == "body"
+
+
+def test_commit_refuses_when_it_cannot_claim_the_record(tmp_path, monkeypatch):
+    """#101/Type 22 root: the write must not land if the status can't be recorded.
+
+    commit_write used to write the file and THEN mark the record. pending.mark
+    is silently fallible — get() swallows OSError/ValueError and returns None,
+    so mark returns without marking. The write landed, the record stayed
+    'pending', and the status guard that makes commit_write idempotent stopped
+    guarding: any retry appended the block again. That is the catalogue's
+    Type 22 (one proposal-log entry, doubled block) plus Type 24 (status never
+    leaves 'pending' while the content is present).
+    """
+    from brain.files import commit as commit_mod
+
+    monkeypatch.setattr(Path, "home", lambda: tmp_path / "home")
+    persona = _persona(tmp_path)
+    target = tmp_path / "home" / "out" / "n.md"
+    target.parent.mkdir(parents=True)
+    target.write_text("seed\n", encoding="utf-8")
+    rid = pending.create(persona, op="append", resolved_path=str(target.resolve()),
+                         content="BLOCK", now=datetime.now(UTC))
+
+    # Reproduce mark()'s real failure mode: it silently does nothing.
+    monkeypatch.setattr(commit_mod.pending, "mark", lambda *a, **k: None)
+
+    store = _store(persona)
+    res = commit_write(persona, rid, store=store)
+
+    assert res.get("ok") is False, "a write whose status cannot be recorded must not commit"
+    assert target.read_text(encoding="utf-8") == "seed\n", (
+        "nothing may be written when the claim fails — otherwise a retry doubles the block"
+    )


### PR DESCRIPTION
Root cause of the ~299 doubled blocks (catalogue Type 22) — and it is **neither** of the two duplicate-proposal paths already fixed.

## The catalogue already said so

- **Type 22:** "a committed block appears twice … while `s1b_proposals.jsonl` records only **a single entry** for it"
- **Type 24:** "Status never transitions from 'pending'" — 7 arms — while the content is physically present

One proposal, status stuck, content twice. That was never two proposals, so neither `fe65018` (#93) nor `33abc6e` (#105) could touch it.

## Mechanism

`commit_write` wrote the file and marked the record **afterwards** (`commit.py:66-74`). And `pending.mark` was silently fallible — `get()` swallows `OSError`/`ValueError` and returns `None`, so `mark` returned without marking (`pending.py:99-101`).

The write landed, the record stayed `pending`, and the `status != "pending"` guard that makes `commit_write` idempotent stopped guarding. **Any retry appended the block again.**

And because `list_pending` filters on `"pending"`, the NellFace card never disappeared either — so the write sat there to be approved again. That is how one proposal reached dozens of copies.

## Reproduced, then fixed

```
before:  attempt 1 (mark no-ops) -> 1 block, status 'pending'
         attempt 2 (retry)       -> 2 blocks   '…notify\n- rollback notify'

after:   attempt 1 (mark no-ops) -> ok=False, 0 blocks, status 'pending'
         attempt 2 (retry)       -> ok=True,  1 block
```

No lost write: a failed claim leaves the record `pending`, so the card stays approvable and the retry succeeds exactly once.

## Changes

- `pending.mark` returns whether it took, instead of failing mutely.
- `commit_write` claims the record (`committing`) **before** writing, and refuses outright if the claim cannot be recorded.

`list_pending` and `sweep_expired` both filter on `"pending"`, so a `committing` record is inert to the card list and the sweeper — no re-approve loop.

Full suite 4280 passed, ruff clean. Test confirmed RED first.

Fixes #101

🤖 Generated with [Claude Code](https://claude.com/claude-code)