### PR TITLE
Fix the Windows CI cascade — leaked supervisor thread poisoned a later test (#110)

### DIFF
--- a/tests/unit/brain/bridge/test_supervisor.py
+++ b/tests/unit/brain/bridge/test_supervisor.py
@@ -9,6 +9,8 @@ from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from brain.bridge import persisted_cadence
 from brain.bridge.events import EventBus
 from brain.bridge.provider import FakeProvider
@@ -21,6 +23,33 @@ from brain.bridge.supervisor import (
     run_folded,
 )
 from brain.engines import interest_sweep
+
+
+@pytest.fixture(autouse=True)
+def _no_leaked_supervisor_threads():
+    """Fail the test that leaks a live thread, not the innocent one downstream.
+
+    17 tests in this file start a supervisor thread and none used try/finally.
+    An assertion between `t.start()` and `stop.set()` therefore leaves a daemon
+    thread running for the whole session; the heartbeat-failure test's thread
+    logs ERROR every tick, which is how it broke an unrelated maker test on
+    Windows CI (#110). This turns that silent cross-test poisoning into a local
+    failure at the point of the leak.
+    """
+    before = {t.ident for t in threading.enumerate()}
+    yield
+    deadline = time.monotonic() + 5.0
+    while time.monotonic() < deadline:
+        leaked = [t for t in threading.enumerate()
+                  if t.ident not in before and t.is_alive()]
+        if not leaked:
+            return
+        time.sleep(0.05)
+    assert not leaked, (
+        f"test leaked {len(leaked)} live thread(s): {[t.name for t in leaked]} — "
+        "stop the supervisor thread in a finally so a failed assertion cannot "
+        "leave it running and logging into later tests"
+    )
 
 
 def _wait_until(pred, *, timeout: float = 30.0, interval: float = 0.02) -> bool:
@@ -188,9 +217,18 @@ def test_heartbeat_failure_does_not_break_supervisor_loop(tmp_path: Path) -> Non
 
     t = threading.Thread(target=runner, daemon=True)
     t.start()
-    assert second_attempt.wait(timeout=30.0), "loop did not survive first heartbeat exception"
-    stop.set()
-    t.join(timeout=5.0)
+    try:
+        # #110: this assertion sits between start and stop. Without the finally,
+        # a failure here skips stop.set() and the daemon thread runs for the rest
+        # of the session — raising every tick and logging ERROR into whatever
+        # test is running later. That is what failed an unrelated maker test
+        # eight minutes downstream on Windows CI.
+        assert second_attempt.wait(timeout=30.0), (
+            "loop did not survive first heartbeat exception"
+        )
+    finally:
+        stop.set()
+        t.join(timeout=30.0)
     assert not t.is_alive()
 
 

--- a/tests/unit/brain/bridge/test_supervisor.py
+++ b/tests/unit/brain/bridge/test_supervisor.py
@@ -23,6 +23,24 @@ from brain.bridge.supervisor import (
 from brain.engines import interest_sweep
 
 
+def _wait_until(pred, *, timeout: float = 30.0, interval: float = 0.02) -> bool:
+    """Poll until `pred()` holds or the deadline passes; return the final value.
+
+    Replaces fixed `time.sleep(N)` windows before an assertion (#110). A
+    constant sleep encodes an assumption about how fast the runner is: the
+    Windows CI box is routinely ~25% slower than a local machine, and these
+    supervisor loops then had not finished a pass when the assertion ran.
+    Polling is also FASTER on a quick runner — it stops as soon as the
+    condition holds instead of always burning the full window.
+    """
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if pred():
+            return True
+        time.sleep(interval)
+    return bool(pred())
+
+
 def test_audit_logs_registered_for_rotation() -> None:
     """The append-only audit logs must be bounded by a rolling policy, not unbounded."""
     registered = {name for name, _ in _ROLLING_LOG_POLICIES}
@@ -170,7 +188,7 @@ def test_heartbeat_failure_does_not_break_supervisor_loop(tmp_path: Path) -> Non
 
     t = threading.Thread(target=runner, daemon=True)
     t.start()
-    assert second_attempt.wait(timeout=5.0), "loop did not survive first heartbeat exception"
+    assert second_attempt.wait(timeout=30.0), "loop did not survive first heartbeat exception"
     stop.set()
     t.join(timeout=5.0)
     assert not t.is_alive()
@@ -244,9 +262,9 @@ def test_supervisor_snapshot_sweep_keeps_session_alive(tmp_path: Path) -> None:
         },
     )
     t.start()
-    time.sleep(0.5)
+    _wait_until(lambda: "session_snapshot" in [e.get("type") for e in bus.events])
     stop.set()
-    t.join(timeout=2.0)
+    t.join(timeout=30.0)
 
     buf = persona_dir / "active_conversations" / f"{sid}.jsonl"
     assert buf.exists(), "snapshot sweep must NOT delete the buffer"
@@ -291,11 +309,11 @@ def test_supervisor_finalize_cadence_drops_old_sessions(tmp_path: Path) -> None:
         },
     )
     t.start()
-    time.sleep(0.5)
-    stop.set()
-    t.join(timeout=2.0)
-
     buf = persona_dir / "active_conversations" / f"{sid}.jsonl"
+    _wait_until(lambda: not buf.exists())
+    stop.set()
+    t.join(timeout=30.0)
+
     assert not buf.exists(), "finalize must delete the buffer"
     assert get_session(sid) is None, "finalize must remove from _SESSIONS"
     types = [e.get("type") for e in bus.events]
@@ -541,9 +559,9 @@ def test_run_folded_skips_self_model_when_disabled(tmp_path: Path) -> None:
 
     t = threading.Thread(target=runner, daemon=True)
     t.start()
-    time.sleep(0.3)
+    time.sleep(0.3)  # a window in which it COULD misbehave — not pollable
     stop.set()
-    t.join(timeout=5.0)
+    t.join(timeout=30.0)
     assert not t.is_alive()
     assert fired == [], "self-model tick fired even though disabled"
 


### PR DESCRIPTION
Five Windows CI tests failed then passed on a re-run of the identical commit (#110). **All five are one root**, and it is not what the first pass assumed.

## Recovering the evidence

I had re-run the job, which replaced the logs. The original attempt's job is still retained, so I pulled it back:

`gh api repos/…/actions/jobs/93084824980/logs`

That gave the fifth failure's actual assertion, which I had been unable to see:

```
tests/unit/brain/maker/test_tick.py:106
    assert not any(r.levelno >= logging.ERROR for r in caplog.records)
E   assert not True
------------------------------ Captured log call ------------------------------
ERROR brain.bridge.supervisor:supervisor.py:816 supervisor heartbeat tick raised
  File "tests/unit/brain/bridge/test_supervisor.py", line 158, in boom
```

An ERROR from **a different test file's thread**, landing in the maker test's `caplog` eight minutes later.

## The cascade

`test_heartbeat_failure_does_not_break_supervisor_loop` asserts **between** `t.start()` and `stop.set()`. On the slow runner (8m1s vs the re-run's 6m31s) the assertion failed — so `stop.set()` never executed, and the daemon thread ran for the rest of the session, raising and logging every tick into whatever test came next.

**17 tests in this file start a supervisor thread. None used `try/finally`.** Any of them could leak the same way.

## Changes

1. **The proven source stops its thread in a `finally`** — a failed assertion can no longer leave it running.
2. **An autouse canary fails the test that leaks a live thread**, turning silent cross-test poisoning into a local failure at the point of the leak.
3. The timing work from the first pass stands: `_wait_until` polling replaces fixed sleeps where a condition is pollable (also *faster* on a quick runner), and the join/wait deadlines are widened.

## The canary was verified to fire

Not just asserted — with the `finally` removed and the assertion forced to fail, it catches the leak. With the fix in place, 29 pass.

Full suite 4279 passed, ruff clean. Supervisor file run 5× consecutively, 29 each time.

Fixes #110

🤖 Generated with [Claude Code](https://claude.com/claude-code)