### PR TITLE
Capture an immediately-repeated monologue once (#93)

### DIFF
--- a/brain/chat/monologue_capture.py
+++ b/brain/chat/monologue_capture.py
@@ -16,7 +16,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 
 from brain.memory.store import MemoryStore
-from brain.monologue.trace import write_trace_memory
+from brain.monologue.trace import MONOLOGUE_TRACE_TYPE, write_trace_memory
 
 logger = logging.getLogger(__name__)
 
@@ -64,6 +64,26 @@ def capture_monologue(
         raise CaptureRejected(f"monologue exceeds {MAX_MONOLOGUE_LEN} chars")
     if len(feed_digest) > MAX_FEED_DIGEST_LEN:
         raise CaptureRejected(f"feed_digest exceeds {MAX_FEED_DIGEST_LEN} chars")
+
+    # #93: the recruit-on-reach rerun can call record_monologue twice in one
+    # turn. The narrowed toolset meant to prevent that is inert on
+    # ClaudeCliProvider — the tools argument is a boolean there and
+    # --allowedTools is permissive — so on the real path both calls land and
+    # this ran twice, persisting two identical traces and two digest lines.
+    #
+    # Guard the artefact rather than the timing (same shape as #101/#105): the
+    # duplicate is always immediately adjacent, so comparing against the newest
+    # trace is sufficient, needs no window constant, and leaves her free to
+    # think the same thought again another day.
+    #
+    # Fail-soft: if the lookup raises, capture anyway — never lose her thought
+    # to a dedupe check.
+    try:
+        recent = store.list_by_type(MONOLOGUE_TRACE_TYPE, active_only=True, limit=1)
+        if recent and recent[0].content == monologue:
+            return monologue
+    except Exception:  # noqa: BLE001
+        logger.debug("monologue dedupe lookup failed; capturing anyway", exc_info=True)
 
     # Tier 2 — persist the verbatim trace FIRST (most important; never lose her
     # thought). Best-effort: a failure logs but does not block the reply.

--- a/tests/unit/brain/chat/test_monologue_capture.py
+++ b/tests/unit/brain/chat/test_monologue_capture.py
@@ -96,3 +96,52 @@ def test_capture_write_failure_logged_to_extractor_errors(tmp_path: Path):
     assert error_log.exists()
     entry = json.loads(error_log.read_text().splitlines()[0])
     assert entry["step"] == "monologue_digest_write"
+
+
+def test_identical_monologue_in_one_turn_is_captured_once(tmp_path: Path):
+    """#93: the recruit-on-reach rerun can call record_monologue twice in a turn.
+
+    The narrowed toolset that was meant to stop it is inert on ClaudeCliProvider
+    (the tools argument is a boolean there and --allowedTools is permissive), so
+    on the real path both calls land and capture_monologue runs twice —
+    persisting two identical trace memories AND two identical digest lines.
+
+    Same shape as #101/#105: ask the artefact instead of tracking timing. The
+    duplicate is always immediately adjacent, so comparing against the newest
+    trace is enough — and it leaves her free to think the same thought again
+    another day.
+    """
+    from brain.chat.monologue_capture import capture_monologue
+    from brain.monologue.trace import MONOLOGUE_TRACE_TYPE
+
+    store = _store(tmp_path)
+    thought = "A name I could not place, and it bothered me."
+    digest = "she paused on a name she could not place"
+
+    for _ in range(2):
+        capture_monologue(
+            persona_dir=tmp_path,
+            store=store,
+            monologue=thought,
+            feed_digest=digest,
+        )
+
+    traces = store.list_by_type(MONOLOGUE_TRACE_TYPE, active_only=True)
+    assert len(traces) == 1, f"one thought, one trace — got {len(traces)}"
+
+    lines = (tmp_path / "monologue_digest.jsonl").read_text(encoding="utf-8").splitlines()
+    assert len([ln for ln in lines if ln.strip()]) == 1, "one thought, one digest line"
+
+
+def test_a_different_monologue_still_captures(tmp_path: Path):
+    """The dedupe must only collapse an identical repeat, never a real thought."""
+    from brain.chat.monologue_capture import capture_monologue
+    from brain.monologue.trace import MONOLOGUE_TRACE_TYPE
+
+    store = _store(tmp_path)
+    capture_monologue(persona_dir=tmp_path, store=store,
+                      monologue="First thought.", feed_digest="d1")
+    capture_monologue(persona_dir=tmp_path, store=store,
+                      monologue="Second, different thought.", feed_digest="d2")
+
+    assert len(store.list_by_type(MONOLOGUE_TRACE_TYPE, active_only=True)) == 2


### PR DESCRIPTION
#93 was filed as a **malformed** per-turn `tools[]` set. It is not malformed — tracing it changed the diagnosis.

## What is actually happening

On `ClaudeCliProvider` the recruit-on-reach rerun genuinely calls `record_monologue` twice. The narrowed toolset meant to prevent that (`e8c0d14`) is **inert on that provider** — the `tools` argument is a boolean there and `--allowedTools` is permissive — so both calls land.

So the record showing two entries is **truthful**. She really did call it twice.

The real defect is the issue's other half — *"can double-apply side effects"*. Each call runs `capture_monologue`, which persists a trace memory **and** a digest line. Two calls → a duplicate interior thought and a duplicate feed entry.

## Fix

Third instance of the pattern behind #101 and #105, fixed the same way: **guard the artefact, not the timing.**

The duplicate is always immediately adjacent, so comparing against the newest trace is sufficient. No window constant — the same objection that ruled one out for #105 applies here. She stays free to think the same thought again another day.

Fail-soft: a failed lookup captures anyway rather than losing her thought to a dedupe check.

## Not defects, deliberately left alone

- The `tools[]` record itself — it accurately reports two real calls.
- `reach_for_capability` appearing as a "non-standard singleton tool" — that is the agency safety-valve working.

## Verification

Both tests confirmed RED first (two traces, two digest lines from one thought). A second test pins that a genuinely different thought still captures — the dedupe must only ever collapse an identical repeat.

Full suite 4282 passed, ruff clean.

Fixes #93

🤖 Generated with [Claude Code](https://claude.com/claude-code)