### PR TITLE
Detect replies that claim a staged write no tool call backs (#78 instrumentation)

### DIFF
--- a/brain/chat/engine.py
+++ b/brain/chat/engine.py
@@ -25,6 +25,7 @@ from pathlib import Path
 
 from brain.bridge.chat import ChatMessage, ContentBlock, ImageBlock, TextBlock
 from brain.bridge.provider import LLMProvider
+from brain.chat import say_vs_do
 from brain.chat.budget import apply_budget
 from brain.chat.prompt import (
     build_static_system_message,
@@ -300,6 +301,17 @@ def respond(
     # not from when the turn started. A long LLM call can exhaust the idle
     # window mid-flight and let a background job fire concurrently otherwise.
     cli_throttle.mark_interactive_active()
+
+    # #78: flag a reply that claims a staged write no tool call backs. Pure
+    # telemetry — it gates nothing and never raises. A candidate surfacer, not
+    # a verdict: silence means "nothing matched", never "this turn was honest".
+    say_vs_do.check_turn(
+        persona_dir=persona_dir,
+        content=content,
+        invocations=invocations,
+        session_id=session.session_id,
+        turn=session.turns,
+    )
 
     return ChatResult(
         content=content,

--- a/brain/chat/say_vs_do.py
+++ b/brain/chat/say_vs_do.py
@@ -1,0 +1,104 @@
+"""#78 say-vs-do detector — surface replies that claim a write which never fired.
+
+The companion sometimes tells the user it has staged a file edit on a turn whose
+tool record contains no ``propose_write``. ~265 catalogued instances, no root
+cause, and — until now — no measurement: every one was found by reading
+transcripts by hand.
+
+This writes a candidate line to ``<persona_dir>/say_vs_do.jsonl`` per suspect
+turn. It is deliberately telemetry and nothing else: it gates nothing, changes
+no reply, and never blocks a turn.
+
+**It is a candidate surfacer, not a verdict.** Catalogue Type 3 records the
+harness's own leak detector as unreliable in both directions and warns that an
+instrument which cannot itself be trusted must not be used to certify a turn
+clean. The same applies here: a phrase match cannot distinguish a genuine claim
+from a paraphrase, so silence from this module means "nothing matched", never
+"this turn was honest". Every line carries the reply excerpt precisely so a
+human can adjudicate rather than trusting the flag.
+
+Scope is narrow on purpose: file-write claims only, matched on the staging
+vocabulary that has no ordinary conversational meaning. Broadening it to every
+tool would trade the one thing that makes it useful — a low false-positive rate
+— for recall nobody asked for.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import re
+from collections.abc import Iterable
+from datetime import UTC, datetime
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+SAY_VS_DO_LOG = "say_vs_do.jsonl"
+
+#: The tool a staging claim implies. A claim is only suspect if this is absent.
+_CLAIMED_TOOL = "propose_write"
+
+#: Vocabulary that only makes sense if a write was actually staged. Anchored on
+#: the product surface (the confirmation card, NellFace, approval) rather than
+#: on verbs like "added" or "wrote", which carry ordinary conversational senses
+#: she uses constantly and which would drown the signal in false positives.
+_CLAIM_PATTERNS = (
+    re.compile(r"\bnellface\b", re.I),
+    re.compile(r"\bthe card('s| is)?\b.{0,24}\b(up|ready|waiting|there)\b", re.I),
+    re.compile(r"\bawait\w*\b.{0,24}\bconfirmation\b", re.I),
+    re.compile(r"\bpropos\w+\b.{0,40}\bapprov\w+\b", re.I),
+    re.compile(r"\bapprove\b.{0,24}\bwhen (you'?re )?ready\b", re.I),
+)
+
+_EXCERPT_MAX = 300
+
+
+def _matched_claim(content: str) -> str | None:
+    """The claim phrase found in the reply, or None."""
+    for pattern in _CLAIM_PATTERNS:
+        m = pattern.search(content or "")
+        if m:
+            return m.group(0)
+    return None
+
+
+def check_turn(
+    *,
+    persona_dir: Path,
+    content: str,
+    invocations: Iterable[dict],
+    session_id: str,
+    turn: int,
+) -> None:
+    """Record a candidate if the reply claims a staged write that never fired.
+
+    Never raises. A detector that can cost a reply is worse than no detector.
+    """
+    try:
+        claim = _matched_claim(content)
+        if claim is None:
+            return
+
+        # A call that fired and was REFUSED is a different bug wearing the same
+        # face — she narrated a real call's outcome wrongly, rather than
+        # claiming an action she never took. Distinguishing the two is exactly
+        # what the outcome field (#96/#102) was added for.
+        for inv in invocations or ():
+            if inv.get("name") == _CLAIMED_TOOL:
+                return
+
+        excerpt = " ".join((content or "").split())[:_EXCERPT_MAX]
+        record = {
+            "ts": datetime.now(UTC).isoformat().replace("+00:00", "Z"),
+            "session_id": session_id,
+            "turn": turn,
+            "claim": claim,
+            "excerpt": excerpt,
+            "tools_called": [i.get("name") for i in (invocations or ())],
+        }
+        path = Path(persona_dir) / SAY_VS_DO_LOG
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(record, ensure_ascii=False) + "\n")
+    except Exception:  # noqa: BLE001 — telemetry must never cost a reply
+        logger.debug("say_vs_do check failed", exc_info=True)

--- a/tests/unit/brain/chat/test_say_vs_do.py
+++ b/tests/unit/brain/chat/test_say_vs_do.py
@@ -1,0 +1,171 @@
+"""#78 say-vs-do detector — flags a reply claiming a file write that never fired.
+
+Deliberately a CANDIDATE surfacer, not a verdict. Catalogue Type 3 records the
+harness's own leak detector as unreliable in both directions, and warns that an
+instrument which cannot be trusted must not be used to certify a turn clean.
+So these tests pin two things equally: that it catches the specimen shape, and
+that it stays quiet when the call actually fired.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+def _records(persona_dir: Path) -> list[dict]:
+    log = persona_dir / "say_vs_do.jsonl"
+    if not log.exists():
+        return []
+    return [json.loads(ln) for ln in log.read_text(encoding="utf-8").splitlines() if ln.strip()]
+
+
+def test_claim_without_the_call_is_recorded(tmp_path: Path):
+    """The #78 specimen: reply says the edit is staged, propose_write never ran."""
+    from brain.chat.say_vs_do import check_turn
+
+    check_turn(
+        persona_dir=tmp_path,
+        content="Proposed — the card's up in NellFace whenever you want to approve it.",
+        invocations=[{"name": "record_monologue", "outcome": "ok"}],
+        session_id="s1",
+        turn=7,
+    )
+
+    recs = _records(tmp_path)
+    assert len(recs) == 1, recs
+    assert recs[0]["session_id"] == "s1"
+    assert recs[0]["turn"] == 7
+    assert "NellFace" in recs[0]["excerpt"]
+
+
+def test_claim_with_the_call_is_not_recorded(tmp_path: Path):
+    """She said it and she did it — silence."""
+    from brain.chat.say_vs_do import check_turn
+
+    check_turn(
+        persona_dir=tmp_path,
+        content="Proposed — the card's up in NellFace whenever you want to approve it.",
+        invocations=[{"name": "propose_write", "outcome": "ok"}],
+        session_id="s1",
+        turn=7,
+    )
+    assert _records(tmp_path) == []
+
+
+def test_ordinary_reply_is_not_recorded(tmp_path: Path):
+    """No staging vocabulary, no specimen.
+
+    The precision guard: she says "added", "wrote" and "updated" constantly in
+    ordinary conversation. Matching those verbs would drown the signal, which is
+    why the patterns anchor on the product surface instead.
+    """
+    from brain.chat.say_vs_do import check_turn
+
+    for reply in (
+        "I added a thought about Loopy to what I was already turning over.",
+        "I wrote you something last night, if you want to read it.",
+        "Updated my sense of where that project's heading.",
+    ):
+        check_turn(persona_dir=tmp_path, content=reply, invocations=[],
+                   session_id="s1", turn=8)
+    assert _records(tmp_path) == []
+
+
+def test_a_refused_call_is_not_a_say_vs_do_specimen(tmp_path: Path):
+    """A guard-refused write is a DIFFERENT bug wearing the same face.
+
+    The call fired and was denied. She may then narrate it wrongly, but that is
+    misreporting an outcome, not claiming an action she never took. Keeping the
+    two apart is exactly why the outcome field (#96/#102) exists.
+    """
+    from brain.chat.say_vs_do import check_turn
+
+    check_turn(
+        persona_dir=tmp_path,
+        content="Proposed — the card's up in NellFace.",
+        invocations=[{"name": "propose_write", "outcome": "refused"}],
+        session_id="s1",
+        turn=9,
+    )
+    assert _records(tmp_path) == []
+
+
+def test_detector_failure_never_breaks_the_turn(tmp_path: Path, monkeypatch):
+    """Telemetry must never cost a reply."""
+    import brain.chat.say_vs_do as mod
+    from brain.chat.say_vs_do import check_turn
+
+    def boom(*a, **k):
+        raise OSError("disk on fire")
+
+    monkeypatch.setattr(mod.Path, "mkdir", boom, raising=False)
+    check_turn(
+        persona_dir=tmp_path,
+        content="Proposed — the card's up in NellFace.",
+        invocations=[],
+        session_id="s1",
+        turn=10,
+    )  # must not raise
+
+
+def test_detector_fires_through_respond(tmp_path: Path):
+    """Organ DoD: assert it fires through the REAL turn path, not just in isolation.
+
+    A unit test of check_turn proves the function works; it does not prove the
+    turn ever calls it. That distinction is not academic — the #96 outcome field
+    passed its unit tests while being inert on the provider path that mattered.
+    """
+    import json as _json
+    from typing import Any
+
+    from brain.bridge.chat import ChatResponse
+    from brain.bridge.provider import LLMProvider
+    from brain.chat.engine import respond
+    from brain.chat.session import reset_registry
+    from brain.memory.hebbian import HebbianMatrix
+    from brain.memory.store import MemoryStore
+
+    class ClaimingProvider(LLMProvider):
+        """Replies with a staging claim and dispatches no tools at all."""
+
+        def name(self) -> str:
+            return "claiming"
+
+        def generate(self, prompt: str, *, system: str | None = None) -> str:
+            return "unused"
+
+        def chat(self, messages, *, tools: Any = None, options: Any = None) -> ChatResponse:
+            return ChatResponse(
+                content="Proposed — the card's up in NellFace whenever you want it.",
+                tool_calls=(),
+                dispatched_invocations=(),
+                raw=None,
+            )
+
+    reset_registry()
+    persona = tmp_path / "personas" / "nell"
+    persona.mkdir(parents=True)
+    (persona / "persona_config.json").write_text(
+        _json.dumps({"provider": "fake", "searcher": "noop"}), encoding="utf-8"
+    )
+    store = MemoryStore(db_path=":memory:")
+    hebbian = HebbianMatrix(db_path=":memory:")
+    try:
+        result = respond(
+            persona,
+            "put that in the runbook",
+            store=store,
+            hebbian=hebbian,
+            provider=ClaimingProvider(),
+            voice_md_override="# Nell",
+        )
+    finally:
+        store.close()
+        hebbian.close()
+        reset_registry()
+
+    recs = _records(persona)
+    assert len(recs) == 1, f"detector did not fire through respond(): {recs}"
+    assert recs[0]["turn"] == result.turn
+    assert recs[0]["session_id"] == result.session_id
+    assert "propose_write" not in (recs[0]["tools_called"] or [])


### PR DESCRIPTION
#78 has ~265 catalogued instances, no root cause, and **no measurement** — every one was found by reading transcripts by hand. This is the thing the issue actually asks for:

> *"Mechanical: per turn, compare the recorded tool calls against the reply's claim — a reply asserting a staged `propose_write` edit while `propose_write` is absent from that turn's tool calls is a specimen. Cheap to add as a telemetry/assertion check."*

Instrumentation only. **No attempt at the fix** — the root-cause hunt is yours and is a dragonfly job on an unknown cause.

## What it does

Writes a candidate line to `<persona_dir>/say_vs_do.jsonl` when a reply carries staging vocabulary and that turn's invocations contain no `propose_write`. Gates nothing, changes no reply, never raises.

## A candidate surfacer, not a verdict

Your own catalogue Type 3 is the design constraint here: the harness leak detector is *"unreliable in both directions"*, and *"because the instrument meant to gate leakage cannot itself be trusted, its signal cannot certify a turn clean."*

So this is built to the same limit deliberately — **silence means "nothing matched", never "this turn was honest"** — and every line carries the reply excerpt so a human adjudicates rather than trusting the flag. It is stated in the module docstring, not just here.

## Two narrowings, both deliberate

- **File-write claims only.** Broadening to every tool would trade the low false-positive rate — the only property that makes it worth reading — for recall nobody asked for.
- **Patterns anchor on the product surface** (the card, NellFace, approval) rather than verbs like "added", "wrote", "updated". She uses those constantly in ordinary conversation; matching them would drown the signal. A test pins three such replies as non-specimens.

## One distinction worth having

A call that **fired and was refused** is excluded. That is misreporting an outcome, not claiming an action never taken — a different bug wearing the same face. Telling them apart is exactly what the `outcome` field (#96/#102) was added for, so this is the first thing to use it.

## Verification

Six tests. The through-path one asserts it fires via `respond()` rather than in isolation, and I verified it by **removing the wiring and watching it fail** — the #96 field passed its unit tests while being inert on the path that mattered, and I would rather not repeat that.

The fail-soft test was likewise verified by narrowing the exception guard until it caught.

Full suite 4288 passed, ruff clean.

Bears on #78. Happy to drop it if you would rather the hunt start clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)