### PR TITLE
Make the write-only jsonl detector see the whole surface

### DIFF
--- a/scripts/organ_wireback_audit.py
+++ b/scripts/organ_wireback_audit.py
@@ -12,8 +12,12 @@ runnable, deterministic (AST-based) check.
      minted without it is inert to those loops). Caught the W7 ingest gap.
   2. write-only detector — a *.jsonl basename written somewhere under brain/ but
      read nowhere under brain/ (excluding tests). Caught draft_space W1 and the
-     reflex-crystallizer W2. Heuristic (string-literal filenames), so it is
-     ADVISORY: a hit is a prompt to look, not proof of a dead reader.
+     reflex-crystallizer W2. AST + scope-aware: the filename literal and the
+     operation are normally on different lines, and an earlier same-line
+     heuristic therefore saw only 5 of 32 basenames — a 46 MB write-only
+     gate_rejections.jsonl was invisible for months. Still ADVISORY: a hit is a
+     prompt to look, not proof of a dead reader. Anything unclassifiable is
+     REPORTED (3), never silently dropped — that omission was the real defect.
 
 Usage:
   python scripts/organ_wireback_audit.py            # report (exit 0 always)
@@ -63,38 +67,143 @@ def find_emotionless_memory_creates() -> list[tuple[Path, int]]:
     return hits
 
 
-# --- 2. write-only detector (jsonl filename heuristic) ----------------------
-_JSONL_RE = re.compile(r'["\']([A-Za-z0-9_.\-]+\.jsonl)["\']')
+# --- 2. write-only detector (AST, scope-aware) ------------------------------
+_JSONL_RE = re.compile(r"^[A-Za-z0-9_.\-]+\.jsonl$")
+
+_WRITE_ATTRS = {"write", "writelines", "write_text", "writestr"}
+_READ_ATTRS = {"read", "readline", "readlines", "read_text", "iterdir"}
+_WRITE_MODES = {"a", "w", "a+", "w+", "ab", "wb", "at", "wt"}
+_READ_MODES = {"r", "r+", "rb", "rt"}
+_WRITE_NAMES = ("append", "dump", "write", "log_", "_log", "emit", "record")
+_READ_NAMES = ("read", "load", "iter", "scan", "tail", "stream", "parse", "replay")
 
 
-_WRITE_HINTS = ('"a"', "'a'", '"w"', "'w'", "append", "write_text", "dump", ".write(")
-_READ_HINTS = ("read", "load", "iter", "scan", "tail", "stream", '"r"', "'r'")
+def _jsonl_literals(node: ast.AST) -> set[str]:
+    """Every '*.jsonl' string constant appearing anywhere under `node`."""
+    out: set[str] = set()
+    for n in ast.walk(node):
+        if isinstance(n, ast.Constant) and isinstance(n.value, str) and _JSONL_RE.match(n.value):
+            out.add(n.value)
+    return out
 
 
-def find_write_only_jsonl() -> list[str]:
-    """jsonl basenames that appear in brain/ but only ever next to a write
-    operation (never a read). Coarse substring heuristic → ADVISORY: a hit means
-    'look here', not 'proven dead reader'."""
+def _classify_scope(node: ast.AST) -> tuple[bool, bool]:
+    """(writes, reads) — does this scope contain a write / read operation?
+
+    Scope-level rather than line-level on purpose: the filename literal and the
+    operation are normally on different lines, and requiring them to share one
+    is what made 27 of 32 basenames invisible.
+    """
+    writes = reads = False
+    for n in ast.walk(node):
+        if isinstance(n, ast.Call):
+            fn = n.func
+            attr = fn.attr if isinstance(fn, ast.Attribute) else None
+            name = attr or (fn.id if isinstance(fn, ast.Name) else "")
+            low = (name or "").lower()
+            if attr in _WRITE_ATTRS or any(h in low for h in _WRITE_NAMES):
+                writes = True
+            if attr in _READ_ATTRS or any(h in low for h in _READ_NAMES):
+                reads = True
+            if attr == "open":
+                mode = ""
+                for a in n.args:
+                    if isinstance(a, ast.Constant) and isinstance(a.value, str):
+                        mode = a.value
+                        break
+                for kw in n.keywords:
+                    if kw.arg == "mode" and isinstance(kw.value, ast.Constant):
+                        mode = str(kw.value.value)
+                if mode in _WRITE_MODES:
+                    writes = True
+                elif mode in _READ_MODES or not mode:
+                    reads = True
+    return writes, reads
+
+
+def find_write_only_jsonl(root: Path | None = None) -> list[str]:
+    """jsonl basenames written under `root` but never read there.
+
+    ADVISORY — a hit means 'look here', not 'proven dead reader'.
+
+    Resolves module-level constants (LOG = "x.jsonl") so a scope referencing the
+    constant counts as touching the file. Anything it cannot classify is NOT
+    dropped — see find_unclassified_jsonl. Silent omission was the original
+    defect: a 46 MB write-only log went unreported for months because neither
+    flag was ever set on it.
+    """
+    return sorted(n for n, s in _scan_jsonl(root).items() if s["write"] and not s["read"])
+
+
+def find_unclassified_jsonl(root: Path | None = None) -> list[str]:
+    """jsonl basenames the heuristic could not classify either way.
+
+    Reported rather than dropped: 'no evidence' is a prompt to look by hand, and
+    silently discarding it is how the class hid in the first place.
+    """
+    return sorted(n for n, s in _scan_jsonl(root).items() if not s["write"] and not s["read"])
+
+
+def _scan_jsonl(root: Path | None = None) -> dict[str, dict[str, bool]]:
+    files = (
+        [p for p in root.rglob("*.py") if "__pycache__" not in p.parts]
+        if root is not None
+        else _brain_py_files()
+    )
     seen: dict[str, dict[str, bool]] = {}
-    for path in _brain_py_files():
-        for line in path.read_text(encoding="utf-8").splitlines():
-            names = _JSONL_RE.findall(line)
+
+    def bump(name: str, writes: bool, reads: bool) -> None:
+        s = seen.setdefault(name, {"write": False, "read": False})
+        s["write"] = s["write"] or writes
+        s["read"] = s["read"] or reads
+
+    for path in files:
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+        except (SyntaxError, UnicodeDecodeError):
+            continue
+
+        # Module-level constants: LOG = "thing.jsonl" -> {"LOG": "thing.jsonl"}
+        const_names: dict[str, str] = {}
+        for n in tree.body:
+            if isinstance(n, ast.Assign) and isinstance(n.value, ast.Constant):
+                v = n.value.value
+                if isinstance(v, str) and _JSONL_RE.match(v):
+                    for t in n.targets:
+                        if isinstance(t, ast.Name):
+                            const_names[t.id] = v
+
+        # Function bodies are the scopes. The module is NOT one: ast.walk on the
+        # module descends into every function, so treating it as a scope makes a
+        # file's names inherit every operation anywhere in that file — which
+        # marked a genuinely write-only log as read and hid it again.
+        scopes: list[ast.AST] = [
+            n for n in ast.walk(tree)
+            if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef))
+        ]
+        for scope in scopes:
+            names = _jsonl_literals(scope)
+            for ref in ast.walk(scope):
+                if isinstance(ref, ast.Name) and ref.id in const_names:
+                    names.add(const_names[ref.id])
             if not names:
                 continue
-            low = line.lower()
-            wrote = any(h in low for h in _WRITE_HINTS)
-            read = any(h in low for h in _READ_HINTS)
+            writes, reads = _classify_scope(scope)
             for name in names:
-                s = seen.setdefault(name, {"write": False, "read": False})
-                s["write"] = s["write"] or wrote
-                s["read"] = s["read"] or read
-    return sorted(n for n, s in seen.items() if s["write"] and not s["read"])
+                bump(name, writes, reads)
+
+        # A constant declared but never referenced still deserves reporting.
+        for v in const_names.values():
+            bump(v, False, False)
+
+    return seen
 
 
 def main() -> int:
     strict = "--strict" in sys.argv
     emo = find_emotionless_memory_creates()
     woj = find_write_only_jsonl()
+    unc = find_unclassified_jsonl()
 
     print("== organ wire-back audit ==\n")
     print(f"1. Memory.create_new without emotions= : {len(emo)} site(s)")
@@ -103,9 +212,17 @@ def main() -> int:
     print(f"\n2. jsonl written-but-not-read (advisory) : {len(woj)} file(s)")
     for name in woj:
         print(f"     {name}")
+    print(f"\n3. jsonl the heuristic could not classify : {len(unc)} file(s)")
+    for name in unc:
+        print(f"     {name}")
+    if unc:
+        print(
+            "     (reported, not dropped — 'no evidence' still needs a human look. "
+            "Silent omission is why a 46 MB write-only log went unreported.)"
+        )
     print(
-        "\nBoth are seeds for the docs/maturity-manifest.md refresh — review each "
-        "hit: is the memory intentionally inert, is the writer's reader really "
+        "\nAll three are seeds for the docs/maturity-manifest.md refresh — review "
+        "each hit: is the memory intentionally inert, is the writer's reader really "
         "dead, or is a new organ silently half-wired?"
     )
     if strict and (emo or woj):

--- a/tests/unit/scripts/test_organ_wireback_audit.py
+++ b/tests/unit/scripts/test_organ_wireback_audit.py
@@ -1,0 +1,69 @@
+"""The wire-back audit's write-only jsonl detector must not silently drop files.
+
+The detector existed to catch the brain's characteristic failure — a writer whose
+reader is dead. Measured 2026-08-08: it reported 5 write-only jsonl files while
+32 basenames appear under brain/. The other 27 were invisible, including a 46 MB
+`gate_rejections.jsonl` with 221,906 lines and no reader anywhere.
+
+Cause: it required the filename literal and the write operation on the SAME LINE.
+The common — and better — pattern puts them apart:
+
+    path = persona_dir / "gate_rejections.jsonl"   # name here
+    with path.open("a", encoding="utf-8") as f:     # write here
+
+So a file with no same-line hint scored neither write nor read and was excluded
+from the report entirely: it could never be flagged, in either direction. The
+heuristic systematically missed the tidier code.
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+_AUDIT = Path(__file__).resolve().parents[3] / "scripts" / "organ_wireback_audit.py"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("organ_wireback_audit", _AUDIT)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["organ_wireback_audit"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_write_via_a_path_variable_is_detected(tmp_path: Path):
+    """The real-world shape: name on one line, `.open("a")` on another."""
+    mod = _load()
+    (tmp_path / "writer.py").write_text(
+        'def append_row(persona_dir, row):\n'
+        '    path = persona_dir / "gate_rejections.jsonl"\n'
+        '    with path.open("a", encoding="utf-8") as f:\n'
+        '        f.write("x")\n',
+        encoding="utf-8",
+    )
+    assert "gate_rejections.jsonl" in mod.find_write_only_jsonl(root=tmp_path)
+
+
+def test_an_unrelated_read_elsewhere_in_the_file_does_not_mask_a_write_only_log(
+    tmp_path: Path,
+):
+    """Regression on the scope boundary — I got this wrong once while fixing it.
+
+    `ast.walk(module)` descends into every function, so treating the module as a
+    scope makes a file's jsonl names inherit every operation anywhere in it. That
+    marked a genuinely write-only log as read and hid it again. Scopes are
+    function bodies; the module is not one.
+    """
+    mod = _load()
+    (tmp_path / "mixed.py").write_text(
+        'def append_row(persona_dir, row):\n'
+        '    path = persona_dir / "gate_rejections.jsonl"\n'
+        '    with path.open("a", encoding="utf-8") as f:\n'
+        '        f.write("x")\n'
+        '\n'
+        'def load_something_else(persona_dir):\n'
+        '    return (persona_dir / "other.json").read_text()\n',
+        encoding="utf-8",
+    )
+    assert "gate_rejections.jsonl" in mod.find_write_only_jsonl(root=tmp_path)


### PR DESCRIPTION
The wire-back audit exists to catch this repo's characteristic failure — a writer whose reader is dead. It reported **5** write-only jsonl files. **32** basenames appear under `brain/`.

The other 27 were invisible, including `gate_rejections.jsonl`, which on the real persona is **221,906 lines / 46 MB** written since 15 May with no reader anywhere.

## Cause

It required the filename literal and the write operation on the **same line**. The common — and tidier — pattern separates them:

```python
path = persona_dir / "gate_rejections.jsonl"   # name here
with path.open("a", encoding="utf-8") as f:     # write here
```

A file with no same-line hint scored neither write nor read, so it was dropped from the report entirely — it could never be flagged in **either** direction. The heuristic systematically missed the better-written code, and **silent omission, not misclassification, was the real defect.**

## Change

AST + scope-aware. Function bodies are the scopes, module-level constants (`LOG = "x.jsonl"`) are resolved, and `open()` modes classify direction. Detector 1 was already AST, so this matches — and the module docstring's "deterministic (AST-based)" claim is now true of both rather than half.

**Anything still unclassifiable is reported as such, never dropped.** `learned_patterns.jsonl` lands there: it *is* read, via one indirection the heuristic doesn't follow. That is the conservative outcome working — uncertain reports as uncertain instead of as a false write-only.

## Result

```
2. jsonl written-but-not-read : 5 -> 13 file(s)
3. jsonl unclassified         : 2 file(s)   (new bucket)
```

Spot-checked rather than assumed: `reflex_audit.jsonl` is genuinely reader-less (CLAUDE.local.md records the missing dashboard), and `chat_usage.jsonl`'s only other mention is a rotation-policy entry, not a consumer.

## One test exists because I got it wrong

My first version treated the module as a scope. Because `ast.walk` descends into functions, that made every jsonl name inherit every operation in its file — which marked `gate_rejections.jsonl` as read and **re-hid the exact log this fixes.** I only caught it because I had ground truth to check the output against.

That boundary now has its own regression test.

Full suite 4292 passed, ruff clean.

Follow-up, not fixed here: `gate_rejections.jsonl` itself needs a retention policy — it is the deferred JSONL bounded-tail item with a concrete trigger at last.

🤖 Generated with [Claude Code](https://claude.com/claude-code)