### PR TITLE
Stop logging the resonance z-gate's null result

### DIFF
--- a/brain/bridge/supervisor.py
+++ b/brain/bridge/supervisor.py
@@ -1871,7 +1871,15 @@ _ROLLING_LOG_POLICIES: tuple[tuple[str, int], ...] = (
     ("chat_usage.jsonl", 5),
     ("file_access.jsonl", 5),
     ("attunement_errors.jsonl", 5),
+    ("gate_rejections.jsonl", 3),
 )
+# This table is deliberately hand-maintained, NOT derived from the jsonl files
+# present on disk. Several persona jsonl files are stores or queues, not logs —
+# soul_candidates and initiate_candidates are review queues, forgotten_memories
+# is the recovery graveyard, and adaptive-D reads every row of initiate_d_calls
+# with no time filter. Rotating any of those silently destroys live state. Add
+# entries here only after confirming the file has no reader, or a reader with a
+# bounded window shorter than the retained history.
 # Yearly-archive logs are kept forever — reader walks active + every archive
 # so every decision / initiation event stays reachable.
 _YEARLY_ARCHIVE_LOGS: tuple[tuple[str, str], ...] = (

--- a/brain/initiate/resonance.py
+++ b/brain/initiate/resonance.py
@@ -168,6 +168,26 @@ def top_n_most_active_memories(
     return sorted_pairs[:n]
 
 
+# The z-gate exists to catch a rare activation spike, so "below threshold" is
+# the expected outcome for nearly every memory on nearly every tick — it is the
+# detector's null result, not a rejection worth recording. Every other gate tag
+# means the memory DID spike and was then blocked for a second reason, which is
+# a real event. See _should_log_rejection.
+_NULL_RESULT_GATE = "z_threshold"
+
+
+def _should_log_rejection(gate_name: str | None) -> bool:
+    """Whether a blocked candidate is worth a `gate_rejections.jsonl` row.
+
+    Measured on Hana's live persona 2026-08-08: 221,616 of 221,906 rows (48 MB,
+    99.9%) were `z_threshold` from `recall_resonance`, and only 578 distinct
+    memories produced them — one memory logged 2,891 separate times across 71
+    days, each row saying its activation was still unremarkable. The remaining
+    290 rows, from the other gates, are the ones that carry information.
+    """
+    return gate_name != _NULL_RESULT_GATE
+
+
 def gate_recall_resonance(
     persona_dir: Path,
     *,
@@ -183,7 +203,7 @@ def gate_recall_resonance(
     the same memory ID.
     """
     if z_score < thresholds.recall_resonance_z_threshold:
-        return False, "z_threshold"
+        return False, _NULL_RESULT_GATE
     if staleness_days < thresholds.recall_resonance_staleness_min_days:
         return False, "staleness_min"
 
@@ -306,15 +326,16 @@ def run_resonance_tick(
                 now=now,
             )
             if not allowed:
-                write_gate_rejection(
-                    persona_dir,
-                    ts=now,
-                    source="recall_resonance",
-                    source_id=memory_id,
-                    gate_name=reason or "unknown",
-                    threshold_value=thresholds.recall_resonance_z_threshold,
-                    observed_value=z_score,
-                )
+                if _should_log_rejection(reason):
+                    write_gate_rejection(
+                        persona_dir,
+                        ts=now,
+                        source="recall_resonance",
+                        source_id=memory_id,
+                        gate_name=reason or "unknown",
+                        threshold_value=thresholds.recall_resonance_z_threshold,
+                        observed_value=z_score,
+                    )
                 continue
 
             meta_ok, meta_reason = check_shared_meta_gates(

--- a/tests/unit/brain/initiate/test_resonance.py
+++ b/tests/unit/brain/initiate/test_resonance.py
@@ -325,6 +325,109 @@ def test_run_resonance_tick_emits_on_spike(tmp_path):
     assert candidates[0].source_id == "mem_y"
 
 
+def test_a_quiet_memory_does_not_write_a_gate_rejection_row(tmp_path):
+    """The z-gate's null result is not an event, so it must not be logged.
+
+    The gate fires on a rare spike (z > 2.5), so "no spike" is the expected
+    outcome for nearly every memory on every tick. Logging it per-memory
+    per-tick wrote 221,616 rows to Hana's live `gate_rejections.jsonl` in 71
+    days — 48 MB, 99.9% of the file, one memory recorded 2,891 separate times
+    — all saying nothing happened. Rejections from the OTHER gates mean a
+    memory did spike and was blocked for a second reason; those are events
+    and are still written (290 rows over the same 71 days).
+    """
+    from datetime import UTC, datetime, timedelta
+
+    from brain.initiate.resonance import MemoryActivationBaseline, run_resonance_tick
+    from brain.memory.hebbian import HebbianMatrix
+    from brain.memory.store import Memory, MemoryStore
+
+    persona = tmp_path / "p"
+    persona.mkdir()
+    now = datetime(2026, 5, 13, 10, 0, 0, tzinfo=UTC)
+
+    h = HebbianMatrix(persona / "hebbian.db")
+    h.strengthen("mem_q", "n1", delta=0.1)
+    h.close()
+
+    store = MemoryStore(persona / "memories.db")
+    store.create(
+        Memory(
+            id="mem_q",
+            content="q",
+            memory_type="conversation",
+            domain="us",
+            created_at=now - timedelta(days=30),
+        )
+    )
+    store.close()
+
+    # Bootstrap the baseline past the minimum count, then leave activation
+    # flat — no spike, so the z-gate rejects with "z_threshold".
+    with MemoryActivationBaseline(persona / "memory_activation_baseline.db") as b:
+        for _ in range(12):
+            b.update("mem_q", 0.1, alpha=0.08)
+
+    run_resonance_tick(persona, now=now)
+
+    rejections = persona / "gate_rejections.jsonl"
+    assert not rejections.exists() or rejections.read_text(encoding="utf-8") == "", (
+        "a quiet memory logged a gate rejection:\n"
+        + rejections.read_text(encoding="utf-8")
+    )
+
+
+def test_a_spiking_but_blocked_memory_still_writes_a_gate_rejection_row(tmp_path):
+    """The other side of the null-result filter: real rejections still log.
+
+    Silencing `z_threshold` must not silence the log. A memory that DID spike
+    and was blocked by a later gate is the case the file exists to record —
+    290 such rows over the 71 days that produced 221,616 noise rows.
+    """
+    from datetime import UTC, datetime, timedelta
+
+    from brain.initiate.resonance import MemoryActivationBaseline, run_resonance_tick
+    from brain.memory.hebbian import HebbianMatrix
+    from brain.memory.store import Memory, MemoryStore
+
+    persona = tmp_path / "p"
+    persona.mkdir()
+    now = datetime(2026, 5, 13, 10, 0, 0, tzinfo=UTC)
+
+    h = HebbianMatrix(persona / "hebbian.db")
+    h.strengthen("mem_r", "n1", delta=0.1)
+    h.close()
+
+    store = MemoryStore(persona / "memories.db")
+    store.create(
+        Memory(
+            id="mem_r",
+            content="r",
+            memory_type="conversation",
+            domain="us",
+            created_at=now - timedelta(days=30),
+            # Touched today, so staleness_min (7 days) blocks it AFTER the
+            # z-gate passes — the exact shape of a real rejection.
+            last_accessed_at=now,
+        )
+    )
+    store.close()
+
+    with MemoryActivationBaseline(persona / "memory_activation_baseline.db") as b:
+        for _ in range(12):
+            b.update("mem_r", 0.1, alpha=0.08)
+
+    h = HebbianMatrix(persona / "hebbian.db")
+    for i in range(20):
+        h.strengthen("mem_r", f"new_n{i}", delta=0.4)
+    h.close()
+
+    run_resonance_tick(persona, now=now)
+
+    rows = (persona / "gate_rejections.jsonl").read_text(encoding="utf-8").strip()
+    assert "staleness_min" in rows, f"real rejection was not logged: {rows!r}"
+
+
 def test_baseline_db_uses_wal_and_busy_timeout(tmp_path: Path):
     """Match the WAL + busy_timeout discipline of MemoryStore/HebbianMatrix —
     this DB is opened/written every heartbeat tick and can contend with the


### PR DESCRIPTION
`gate_rejections.jsonl` on the live persona is **48,114,942 bytes / 221,906 lines** — **57% of the whole 84 MB persona directory.** It has no reader.

Surfaced by #117, which is what made the orphan visible.

## It isn't a retention problem

Measured over its 71-day span before changing anything:

| | |
|---|---|
| `source=recall_resonance` | 221,851 / 221,906 — **99.98%** |
| `gate_name=z_threshold` | 221,616 / 221,906 — **99.87%** |
| distinct `source_id` | **578** |
| worst single memory | **2,891 rows** |

The z-gate fires on a rare activation spike (z > 2.5), so *no spike* is the expected outcome for nearly every memory on every tick. `run_resonance_tick` scored the pool every 15 minutes and wrote one row per below-threshold memory.

**One memory recorded 2,891 separate times that nothing had happened to it.** A rare-event detector logging the null hypothesis.

The rows that carry information — a memory that *did* spike and was blocked by a later gate — number **290** across the same 71 days. Signal to noise, 290 : 221,616.

## Fix

**Don't write the null result.** Every other gate tag still writes; those are real events.

Two tests, both driven through `run_resonance_tick` rather than the gate function, so they assert the behaviour on the path that actually produced the 48 MB:

- a quiet memory logs nothing (verified RED first, against the exact live row shape)
- a spiking-but-blocked memory still logs — silencing `z_threshold` must not silence the file

Proved both in a single tick: one row out, not two.

**Enrol it in `_ROLLING_LOG_POLICIES`** (keep=3). The rotation machinery already existed with 8 logs in it — this one was simply never added. The live 48 MB file rotates itself on the next hourly tick; no manual cleanup.

## The tempting version of this fix is a data-loss bug

My first instinct was to enrol every unenrolled `.jsonl`. Checking readers first stopped that:

- `soul_candidates.jsonl`, `initiate_candidates.jsonl` — review **queues**
- `forgotten_memories.jsonl` — the recovery **graveyard**
- `initiate_d_calls.jsonl` — `adaptive.py:207` reads **every row, no time filter**

Rotating any of those destroys live state. It would look like housekeeping and behave like data loss. The table stays hand-maintained and now carries that reasoning above it, so the next person doesn't automate it.

## Verification

`4292 passed`, ruff clean. The one failure is the known agent-shell artefact (`test_generic_live_run` — `Not logged in · Please run /login`), present identically on main. No frontend files touched, so `pnpm build` is left to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)