### PR TITLE
harness: seal stored-channel identity de-id (F2 follow-on)

### DIFF
--- a/tests/harness/config.py
+++ b/tests/harness/config.py
@@ -41,6 +41,17 @@ class Timeouts:
 SYNTHETIC_USER = "Bob"
 PERSONA_NAME = "Canary"
 
+# Synthetic identity used to de-identify the `claude` CLI's auto-injected context so it cannot leak the
+# REAL account/project into the companion's STORED channels (memories.db, works/*.md, active-recall) at
+# runtime. Single source of truth for the stored-channel de-id seal in ``sandbox.py`` (the next increment
+# after the F1/F2 input-side $USER/$LOGNAME de-id). NEVER a real name/email/org/repo here.
+SYNTHETIC_DISPLAY_NAME = SYNTHETIC_USER          # the CLI account display name (== "Bob")
+SYNTHETIC_EMAIL = "bob@example.invalid"          # RFC-2606 reserved TLD → unmistakably synthetic
+SYNTHETIC_ORG = "Bob's Test Org"
+SYNTHETIC_PROJECT = "workspace"                  # neutral scratch-dir / project name (carrier A)
+SYNTHETIC_ACCOUNT_UUID = "00000000-0000-4000-8000-000000000001"
+SYNTHETIC_ORG_UUID = "00000000-0000-4000-8000-000000000002"
+
 # Exit-code contract shared by the engine driver + runner (ported from the hunt drivers).
 EXIT_DONE = 0
 EXIT_REVIEW = 10   # a detector trip — pause for adjudication

--- a/tests/harness/sandbox.py
+++ b/tests/harness/sandbox.py
@@ -16,6 +16,16 @@ What it does (see the module ``README.md`` for the guarantees):
    ``CLAUDE.md`` / ``settings*`` / ``skills`` / ``plugins``. On Mac the credential may live in the
    Keychain; a fresh ``CLAUDE_CONFIG_DIR`` still authenticates via Keychain, so the branch is
    recorded, not hard-failed.
+3b. STORED-CHANNEL DE-ID (the next increment after the F1/F2 input-side ``$USER``/``$LOGNAME`` de-id):
+   seal the three RUNTIME carriers by which the ``claude`` CLI's auto-injected context leaks the REAL
+   owner name / project into the companion's STORED channels (``memories.db``, ``works/*.md``,
+   active-recall) — never a visible reply. **A** neutral cwd (``<root>/work``) so the CLI's
+   working-dir/git block and ``.claude.json`` ``projects`` key name nothing real; **B** a synthetic
+   ``oauthAccount`` pre-seeded into ``.claude.json`` (:func:`_seed_scrubbed_config` — TTL-bounded);
+   **C** a synthetic ``HOME`` (``<root>/home``, empty ``.claude/``) so global user-memory resolves to
+   nothing real. A/C install AFTER the "before" fingerprint and tear down symmetrically (real HOME
+   restored before the "after" fingerprint; cwd before ``rmtree``). See
+   ``hunts/symptom-cluster-rootcause/live-run/STORED-IDENTITY-LEAK-DIAGNOSIS.md``.
 4. Fingerprint the real guarded roots (broad, platformdirs-derived) BEFORE the run. For ``~/.claude``
    the orchestrator's own claude-code session-runtime logs are pruned (F4; see
    ``_claude_session_log_excludes``) — the sandboxed subject cannot reach those (its CLI runs under
@@ -28,9 +38,9 @@ What it does (see the module ``README.md`` for the guarantees):
    change also touching a KINDLED/persona/platformdirs/``brain.paths`` root still raises.
 7. Restore env (in a ``finally``, even on ``SandboxLeak``) and ``rmtree`` the root (unless ``keep``).
 
-**Concurrency:** ``sandbox()`` mutates process-global ``os.environ`` — it is NOT thread-safe or
-safely nestable and assumes serial use within a process. pytest-xdist workers are separate
-processes, so parallel CI is fine.
+**Concurrency:** ``sandbox()`` mutates process-global ``os.environ`` **and process cwd** (the carrier-A
+neutral cwd) — it is NOT thread-safe or safely nestable and assumes serial use within a process.
+pytest-xdist workers are separate processes, so parallel CI is fine.
 """
 
 from __future__ import annotations
@@ -47,7 +57,14 @@ from pathlib import Path
 
 from platformdirs import PlatformDirs
 
-from .config import SYNTHETIC_USER
+from .config import (
+    SYNTHETIC_ACCOUNT_UUID,
+    SYNTHETIC_DISPLAY_NAME,
+    SYNTHETIC_EMAIL,
+    SYNTHETIC_ORG,
+    SYNTHETIC_ORG_UUID,
+    SYNTHETIC_USER,
+)
 
 _APP = "companion-emergence"
 
@@ -278,6 +295,61 @@ def _notes_roots() -> list[Path]:
     recursive walk of an iCloud-synced Documents.
     """
     return [_documents_dir()]
+
+
+# Home-relative sensitive dotfiles/dirs the brain file-write guard (brain/files/write_guard.py) denies
+# writes to (login/persistence/credentials: .ssh, .aws, .gnupg, .netrc, shell rc files, ...). We keep
+# our OWN copy in sync by IMPORTING the guard's list when available, so the leak fingerprint below
+# tracks exactly what the guard protects and cannot silently drift from it.
+#
+# WHY THIS EXISTS (stage-6 finding): the carrier-C stored-channel de-id sets a SYNTHETIC ``$HOME`` for
+# the run window. ``write_guard._denied`` computes its deny set from ``Path.home()`` at write time, so
+# under the synthetic HOME it would compute the deny set against the tempdir home and NO LONGER deny a
+# companion write to the REAL ``~/.ssh``/``~/.aws``/... — and ``_guarded_roots`` above never covered
+# those paths. Fingerprinting them here (from the REAL home, computed before the HOME swap) restores the
+# DETECTION layer that the synthetic HOME weakens on write_guard's PREVENTION layer: any write to a real
+# sensitive home path during a run flips this fingerprint and raises :class:`SandboxLeak`.
+_FALLBACK_HOME_DENY = (
+    ".zshrc", ".bashrc", ".bash_profile", ".profile", ".zprofile", ".zshenv", ".zlogin",
+    ".ssh", ".aws", ".gnupg", ".netrc", ".config/gh",
+    "Library/LaunchAgents",
+)
+
+
+def _sensitive_home_rels() -> tuple[str, ...]:
+    """The home-relative sensitive paths, sourced from ``brain.files.write_guard._HOME_DENY`` so the
+    leak fingerprint stays in lockstep with the write-guard's deny set; falls back to a pinned copy if
+    the import ever fails (fail-safe: a stale-but-present list still guards the well-known paths)."""
+    try:
+        from brain.files.write_guard import _HOME_DENY
+
+        return tuple(_HOME_DENY)
+    except Exception:  # noqa: BLE001 — never let an import hiccup drop the guard
+        return _FALLBACK_HOME_DENY
+
+
+def _sensitive_home_roots() -> list[Path]:
+    """Absolute real-home sensitive paths to fingerprint (resolved; computed while HOME is REAL)."""
+    home = Path.home()
+    return [(home / rel).resolve() for rel in _sensitive_home_rels()]
+
+
+def _path_fingerprint(p: Path) -> dict:
+    """Fingerprint a single sensitive path that may be a DIR, a FILE, or ABSENT.
+
+    A dir → recursive content-hashed fingerprint (these are small: ``.ssh``/``.gnupg``/``.aws``). A file
+    → a one-entry ``{name: (size, mtime_ns, sha256)}`` map. Absent → ``{}`` so that CREATING the path
+    (absent → present) is itself detected as a change. Symlink/race errors degrade to ``{}`` (fail-safe:
+    the enclosing before/after compare still fires if the other side saw content)."""
+    try:
+        if p.is_dir():
+            return _fingerprint(p, hash_content=True)
+        if p.is_file():
+            st = p.stat()
+            return {p.name: (st.st_size, st.st_mtime_ns, _content_hash(p))}
+    except OSError:
+        return {}
+    return {}
 
 
 def _content_hash(f: Path) -> str | None:
@@ -564,6 +636,45 @@ def _seed_auth(claude_config_dir: Path) -> str:
     return "unauthenticated"
 
 
+def _seed_scrubbed_config(claude_config_dir: Path) -> None:
+    """Carrier B (stored-channel de-id): pre-seed ``<CLAUDE_CONFIG_DIR>/.claude.json`` with a SYNTHETIC
+    ``oauthAccount`` so the ``claude`` CLI serves a de-identified account identity into its injected
+    context instead of the developer's REAL ``displayName``/email/org.
+
+    The CLI populates ``.claude.json`` under ``CLAUDE_CONFIG_DIR`` (which ``sandbox()`` sets to the
+    tempdir) from the real account, and that identity bleeds into the companion's less-guarded generative
+    channels (interior monologue, memory-generation, ``works/*.md``) — never the visible reply — which is
+    where the stored-channel leak was traced (see
+    ``hunts/symptom-cluster-rootcause/live-run/STORED-IDENTITY-LEAK-DIAGNOSIS.md``).
+
+    **This is a TTL-bounded seal, NOT a hard redirection.** The diagnosis observed the CLI *refetches* the
+    profile once its cache lapses and rewrites the real identity. We write a synthetic ``oauthAccount`` with
+    a FRESH ``profileFetchedAt`` (now) so a SHORT arm stays inside the cache window and never refetches;
+    long runs that outlast the TTL additionally need the existing periodic ``cred_syncer_*`` scrub loop
+    (out of scope here). All values are synthetic constants from :mod:`.config` — never a real name/email.
+    Only ``oauthAccount`` is seeded; the CLI fills the remaining keys (``projects`` — which the neutral-cwd
+    seal keeps de-identified — caches, ``machineID``) itself.
+    """
+    import json
+    import time
+
+    claude_config_dir.mkdir(parents=True, exist_ok=True)
+    now_ms = int(time.time() * 1000)
+    doc = {
+        "oauthAccount": {
+            "displayName": SYNTHETIC_DISPLAY_NAME,
+            "emailAddress": SYNTHETIC_EMAIL,
+            "organizationName": SYNTHETIC_ORG,
+            "accountUuid": SYNTHETIC_ACCOUNT_UUID,
+            "organizationUuid": SYNTHETIC_ORG_UUID,
+            "profileFetchedAt": now_ms,
+        },
+    }
+    (claude_config_dir / ".claude.json").write_text(
+        json.dumps(doc, ensure_ascii=False), encoding="utf-8"
+    )
+
+
 @contextmanager
 def sandbox(
     *,
@@ -610,10 +721,18 @@ def sandbox(
     # Save prior env so we can restore it exactly (including "was unset"). USER/LOGNAME are here so
     # the env-only de-id below (Type-42) is torn down the SAME way as the redirected home vars —
     # never leaking the synthetic value out of the sandbox, and restoring "was unset" to unset.
+    # HOME is here for the stored-channel de-id seal (carrier C, synthetic HOME) — same tear-down
+    # discipline: the synthetic value never survives the sandbox, "was unset" restores to unset.
     _saved: dict[str, str | None] = {
         k: os.environ.get(k)
-        for k in ("KINDLED_HOME", "CLAUDE_CONFIG_DIR", "NELLBRAIN_HOME", "USER", "LOGNAME")
+        for k in ("KINDLED_HOME", "CLAUDE_CONFIG_DIR", "NELLBRAIN_HOME", "USER", "LOGNAME", "HOME")
     }
+    # Stored-channel de-id carrier A (neutral cwd): remember the real cwd so we can restore it before
+    # rmtree. Guarded — getcwd() raises if the cwd was already removed; None ⇒ we never chdir/restore.
+    try:
+        saved_cwd: str | None = os.getcwd()
+    except OSError:
+        saved_cwd = None
 
     def _restore_env() -> None:
         for k, v in _saved.items():
@@ -673,6 +792,15 @@ def sandbox(
             )
 
         auth_source = _seed_auth(claude_config_dir)
+        # Stored-channel de-id carrier B: pre-seed a SYNTHETIC oauthAccount into the CLI's config so it
+        # injects a de-identified account identity, not the real displayName/email/org. (TTL-bounded —
+        # see _seed_scrubbed_config.) Done AFTER _seed_auth (which creates the dir + copies the real
+        # credentials) and BEFORE any fingerprint, so the write lands in the tempdir, not a guarded root.
+        _seed_scrubbed_config(claude_config_dir)
+        # IMPORTANT (ordering): guard_roots / claude_root / notes_roots and every Path.home()-derived
+        # comparison below MUST be computed while HOME is still REAL — the synthetic HOME (carrier C) is
+        # installed only for the yield window, AFTER the "before" fingerprint, and restored BEFORE the
+        # "after" fingerprint. This keeps the leak guard pointed at the REAL ~/.claude / real data roots.
         guard_roots = _guarded_roots(extra_guard_roots)
         claude_root = (Path.home() / ".claude").resolve()
         # INVARIANT (MINOR-1): the `gr == claude_root` gate below identifies the real ~/.claude root
@@ -682,6 +810,10 @@ def sandbox(
         # exclusion would not apply (fail-SAFE: a spurious leak, not a hole) — so we assert it here.
         assert all(gr == gr.resolve() for gr in guard_roots), "guard_roots must be resolved"
         notes_roots = _notes_roots()
+        # Sensitive real-home paths (write_guard's deny set) — computed HERE while HOME is REAL, so the
+        # carrier-C synthetic HOME (installed after the before-snapshot) never repoints them. Restores
+        # the detection layer the synthetic HOME weakens on write_guard's prevention layer (stage-6).
+        sensitive_roots = _sensitive_home_roots()
         # For the real ~/.claude root, prune (a) the sandbox's own claude-config subtree (defensive)
         # AND (b) the orchestrator's own claude-code session-runtime logs (F4). Any OTHER guarded
         # root gets no exclusions.
@@ -713,6 +845,8 @@ def sandbox(
                 snap[f"notes:{nr}"] = _shallow_notes_fingerprint(
                     nr, exclude_names=_editable_notes_names_for(nr) or None
                 )
+            for sp in sensitive_roots:
+                snap[f"sensitive:{sp}"] = _path_fingerprint(sp)
             return snap
 
         # Live-service pre-check (Phase 2). Runs BEFORE the "before" fingerprint and before yield —
@@ -726,9 +860,30 @@ def sandbox(
 
         before = _snapshot()
 
+        # --- Install the stored-channel de-id seals for the SUBPROCESS window (carriers A + C) --------
+        # Both are process-global (cwd, $HOME) and are torn down symmetrically (cwd in the outer finally
+        # before rmtree; HOME via _saved). They go in AFTER the "before" fingerprint so no Path.home()-
+        # derived guard computation above ever sees the synthetic HOME. Same serial-use assumption as the
+        # existing $USER/$LOGNAME de-id (sandbox() is documented not-thread-safe / not-nestable).
+        #
+        # Carrier A — neutral cwd: brain/bridge/provider.py spawns `claude -p` with NO cwd=, so the CLI
+        # inherits the process cwd. Point it at a de-identified scratch dir (a bare child of the tempdir
+        # root — not a git repo, no ancestor CLAUDE.md) so the CLI's working-dir/git block and the
+        # .claude.json `projects` key name nothing real. (Verified: no brain/ code depends on cwd==repo.)
+        work_dir = root / "work"
+        work_dir.mkdir(parents=True, exist_ok=True)
+        # Carrier C — synthetic HOME: an empty ~/.claude (no CLAUDE.md) so the CLI's global user-memory
+        # resolves to nothing real whichever way it keys (HOME vs CLAUDE_CONFIG_DIR). Auth is unaffected:
+        # the credentials live under CLAUDE_CONFIG_DIR (seeded), not HOME.
+        syn_home = root / "home"
+        (syn_home / ".claude").mkdir(parents=True, exist_ok=True)
+        if saved_cwd is not None:
+            os.chdir(work_dir)
+        os.environ["HOME"] = str(syn_home)
+
         handle = SandboxHandle(
             root=root,
-            env=dict(os.environ),
+            env=dict(os.environ),  # captures the synthetic HOME the subprocess will actually see
             claude_config_dir=claude_config_dir,
             auth_source=auth_source,
             guard_roots=guard_roots,
@@ -736,6 +891,14 @@ def sandbox(
         try:
             yield handle
         finally:
+            # Restore the REAL HOME BEFORE the "after" fingerprint so _hash_critical()'s Path.home()
+            # check (and any other Path.home()-derived comparison) matches the "before" snapshot — a
+            # synthetic HOME here would make the ~/.claude root's content-hash asymmetric and trip a
+            # SPURIOUS SandboxLeak. (_restore_env in the outer finally restores HOME again, idempotently.)
+            if _saved["HOME"] is None:
+                os.environ.pop("HOME", None)
+            else:
+                os.environ["HOME"] = _saved["HOME"]
             after = _snapshot()
             changed = [g for g in before if before[g] != after.get(g)]
             if changed:
@@ -762,7 +925,7 @@ def sandbox(
                 # engine's own file mechanisms — `changed` is not [str(claude_root)] alone and we
                 # STILL hard-raise SandboxLeak.
                 #
-                # KNOWN, OWNER-ACCEPTED RISK (Roy, 2026-08-07): unlike the fail-closed session-log
+                # KNOWN, OWNER-ACCEPTED RISK (owner, 2026-08-07): unlike the fail-closed session-log
                 # allowlist above, ~/.claude is NOT a root the subject provably cannot write. The
                 # Canary's `claude` CLI runs the generate()/chat() paths with
                 # `--dangerously-skip-permissions` and NO --disallowedTools (the lean disallow-list
@@ -787,5 +950,12 @@ def sandbox(
     finally:
         _restore_env()
         _restore_emotion_globals()
+        # Restore the real cwd (carrier A) BEFORE rmtree — the cwd must not sit inside the tree being
+        # removed. Guarded: only if we captured one and actually chdir'd; never os.chdir(None).
+        if saved_cwd is not None:
+            try:
+                os.chdir(saved_cwd)
+            except OSError:
+                pass
         if not keep:
             shutil.rmtree(root, ignore_errors=True)

--- a/tests/unit/harness/test_stored_channel_deid.py
+++ b/tests/unit/harness/test_stored_channel_deid.py
@@ -1,0 +1,207 @@
+"""Stored-channel de-identification seals (carriers A/B/C) — token-free.
+
+Covers 1.5-criteria.md for the harness-stored-channel-deid change:
+- C2 (teardown symmetry: HOME/cwd restored), C3 (F1/F2 $USER/$LOGNAME no-regression),
+- C1b on-disk half (carrier B: synthetic oauthAccount pre-seeded into .claude.json),
+- carrier A mechanism (neutral cwd is a de-identified scratch dir, not the repo),
+- C5 (the leak guard still targets the REAL home under the synthetic-HOME seal).
+
+Zero model tokens: real `sandbox()`, no `claude` subprocess. The CLI-overwrite half of carrier B
+(does the CLI refetch and rewrite the real identity) is only testable in the live assembled arm — see
+`changes/harness-stored-channel-deid/8-harness.md`.
+
+NOTE ON THE FIXTURE (P-1, stage-3): the sibling `_seed_fake_cred` helpers patch `Path.home` to a
+*constant* that ignores `$HOME`. That would MASK the carrier-C seal (which sets `os.environ["HOME"]`),
+so the C5 guard-targeting test below uses a **dynamic** `Path.home` that reads `os.environ["HOME"]`,
+letting the seal's HOME swap actually move `Path.home()` — which is exactly what the guard must survive.
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from tests.harness import SandboxLeak, sandbox
+from tests.harness.config import (
+    SYNTHETIC_DISPLAY_NAME,
+    SYNTHETIC_EMAIL,
+    SYNTHETIC_ORG,
+    SYNTHETIC_USER,
+)
+
+sandbox_mod = importlib.import_module("tests.harness.sandbox")
+
+
+def _seed_dynamic_home(monkeypatch: pytest.MonkeyPatch, home: Path) -> Path:
+    """Point HOME at `home` with a fake ~/.claude/.credentials.json, and make `Path.home()` follow
+    `$HOME` DYNAMICALLY (not a constant) so the carrier-C HOME swap is observable. Also pin the
+    Documents resolver so the notes shallow-scan stays inside the fake home."""
+    (home / ".claude").mkdir(parents=True, exist_ok=True)
+    (home / ".claude" / ".credentials.json").write_text('{"fake": true}')
+    (home / "Documents").mkdir(exist_ok=True)
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: Path(os.environ["HOME"])))
+    monkeypatch.setattr(sandbox_mod, "_documents_dir", lambda: Path(os.environ["HOME"]) / "Documents")
+    return home
+
+
+# ─────────────────────────── C3 — F1/F2 $USER/$LOGNAME no-regression ───────────────────────────
+def test_user_logname_synthetic_in_restored_out(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """C3: inside sandbox() $USER == $LOGNAME == SYNTHETIC_USER; after exit both restored, incl.
+    'was unset' → unset (the seal must not regress the input-side de-id)."""
+    _seed_dynamic_home(monkeypatch, tmp_path / "real-home")
+    monkeypatch.setenv("USER", "realuser")
+    monkeypatch.delenv("LOGNAME", raising=False)  # 'was unset' branch
+
+    with sandbox(live_check="off") as sb:
+        assert os.environ["USER"] == SYNTHETIC_USER
+        assert os.environ["LOGNAME"] == SYNTHETIC_USER
+        assert sb is not None
+
+    assert os.environ["USER"] == "realuser"          # restored
+    assert "LOGNAME" not in os.environ               # 'was unset' → unset
+
+
+# ─────────────────────────── C2 — HOME + cwd teardown symmetry ───────────────────────────
+def test_home_and_cwd_synthetic_in_restored_out(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """C2: carrier A (neutral cwd) + carrier C (synthetic HOME) are installed inside the window and
+    restored on exit. cwd is a de-identified scratch dir under the sandbox root (NOT the repo)."""
+    real_home = _seed_dynamic_home(monkeypatch, tmp_path / "real-home")
+    outer_cwd = os.getcwd()
+
+    with sandbox(live_check="off") as sb:
+        # carrier C: HOME points into the sandbox root, with an empty .claude (no CLAUDE.md).
+        seal_home = Path(os.environ["HOME"])
+        assert seal_home == sb.root / "home"
+        assert seal_home != real_home
+        assert (seal_home / ".claude").is_dir()
+        assert not (seal_home / ".claude" / "CLAUDE.md").exists()
+        # carrier A: cwd is the neutral scratch dir under the sandbox root — not the repo, not real home.
+        cwd = Path(os.getcwd()).resolve()
+        assert cwd == (sb.root / "work").resolve()
+        assert sb.root.resolve() in cwd.parents or cwd == (sb.root / "work").resolve()
+
+    assert os.environ["HOME"] == str(real_home)      # restored
+    assert Path(os.getcwd()) == Path(outer_cwd)      # cwd restored (before rmtree)
+    assert not sb.root.exists()                       # rmtree happened, cwd was outside it
+
+
+# ─────────────────────────── carrier B — synthetic oauthAccount pre-seeded ───────────────────────────
+def test_carrier_b_oauthaccount_scrubbed_on_disk(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """C1b (on-disk half): _seed_scrubbed_config pre-seeds a SYNTHETIC oauthAccount into the CLI's
+    <CLAUDE_CONFIG_DIR>/.claude.json — no real displayName/email/org. (The CLI-refetch half is a live
+    arm concern.)"""
+    _seed_dynamic_home(monkeypatch, tmp_path / "real-home")
+
+    with sandbox(live_check="off") as sb:
+        cfg = sb.claude_config_dir / ".claude.json"
+        assert cfg.is_file(), "carrier B must pre-seed .claude.json under CLAUDE_CONFIG_DIR"
+        oa = json.loads(cfg.read_text())["oauthAccount"]
+        assert oa["displayName"] == SYNTHETIC_DISPLAY_NAME == SYNTHETIC_USER
+        assert oa["emailAddress"] == SYNTHETIC_EMAIL
+        assert oa["organizationName"] == SYNTHETIC_ORG
+        # fresh profileFetchedAt (present + plausibly-now) so a short arm stays inside the cache TTL.
+        assert isinstance(oa["profileFetchedAt"], int) and oa["profileFetchedAt"] > 0
+
+
+# ─────────────────────────── C5 — guard still targets the REAL home under synthetic HOME ───────────────────────────
+def test_guard_roots_target_real_home_not_synthetic(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """C5(a): even though the carrier-C seal swaps $HOME to a synthetic dir for the run window, the
+    leak-guard roots point at the REAL ~/.claude (computed before the swap), never the synthetic one.
+    Uses a DYNAMIC Path.home (reads $HOME) so the swap is real — under the constant-patch fixture this
+    assertion would be vacuous (P-1)."""
+    real_home = _seed_dynamic_home(monkeypatch, tmp_path / "real-home")
+    real_claude = (real_home / ".claude").resolve()
+
+    with sandbox(live_check="off") as sb:
+        # The seal DID move Path.home() (proving the swap is genuine under this fixture)...
+        assert Path.home() == sb.root / "home"
+        # ...yet the guard roots still target the REAL ~/.claude, not <synthetic HOME>/.claude.
+        assert real_claude in sb.guard_roots
+        assert (sb.root / "home" / ".claude").resolve() not in sb.guard_roots
+
+
+def test_guard_roots_follow_home_dynamically_oracle_can_fail(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """C5 oracle-can-fail demonstrator: `_guarded_roots()` derives ~/.claude from `Path.home()` →
+    `$HOME`, so IF the seal set the synthetic HOME *before* computing guard roots, the guard would
+    target the synthetic home. This proves the C5 assertion above can actually fail on a mis-ordered
+    build (it is not vacuous). Here we set HOME to two different dirs and show guard roots follow."""
+    home_a = tmp_path / "home-a"
+    home_b = tmp_path / "home-b"
+    for h in (home_a, home_b):
+        (h / ".claude").mkdir(parents=True)
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: Path(os.environ["HOME"])))
+
+    monkeypatch.setenv("HOME", str(home_a))
+    roots_a = sandbox_mod._guarded_roots()
+    monkeypatch.setenv("HOME", str(home_b))
+    roots_b = sandbox_mod._guarded_roots()
+
+    assert (home_a / ".claude").resolve() in roots_a
+    assert (home_a / ".claude").resolve() not in roots_b
+    assert (home_b / ".claude").resolve() in roots_b
+
+
+def test_leak_guard_still_fires_under_seals(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """C5(b): the SandboxLeak negative control still fires while the carrier-A/C seals are active —
+    mutating a fingerprinted extra guard root raises, so the seals did not gut the #1 guarantee."""
+    _seed_dynamic_home(monkeypatch, tmp_path / "real-home")
+    guarded = tmp_path / "guarded-root"
+    guarded.mkdir()
+    (guarded / "before.txt").write_text("x")
+
+    with pytest.raises(SandboxLeak):
+        with sandbox(live_check="off", extra_guard_roots=[guarded]) as sb:
+            assert Path.home() == sb.root / "home"          # seal active
+            (guarded / "leaked.txt").write_text("mutation during the run")
+
+
+def test_clean_run_under_seals_does_not_trip_spurious_leak(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """C5 symmetry: a clean run (no guarded mutation) does NOT raise a spurious SandboxLeak — proving
+    the real-HOME restore before the after-snapshot keeps the ~/.claude content-hash symmetric.
+    (Discrimination note: a broken build that left HOME synthetic during the after-snapshot would flip
+    the real ~/.claude fingerprint but that lone diff DOWNGRADES to a warning, so this test alone does
+    not prove ordering — that is carried by ``test_guard_roots_target_real_home_not_synthetic``.)"""
+    _seed_dynamic_home(monkeypatch, tmp_path / "real-home")
+    with sandbox(live_check="off") as sb:
+        assert sb.root.exists()
+    # no raise == symmetric before/after fingerprint under the HOME swap
+
+
+def test_write_to_real_home_dotfile_trips_leak_under_synthetic_home(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Stage-6 MAJOR fix: carrier C sets a synthetic HOME, which would weaken brain's write_guard
+    (it denies writes under Path.home()/<.ssh,.aws,...> and Path.home() is synthetic during the run).
+    The leak fingerprint now covers those REAL-home sensitive paths (computed before the swap), so a
+    write to the REAL ~/.ssh during a run still trips SandboxLeak — restoring the detection layer.
+
+    Oracle-can-fail: without the sensitive-home fingerprint, this write (to a path not under any other
+    guard root, and — under synthetic HOME — not under write_guard's deny set) would go UNDETECTED."""
+    real_home = _seed_dynamic_home(monkeypatch, tmp_path / "real-home")
+    real_ssh = real_home / ".ssh"
+    real_ssh.mkdir()  # exists before the run, so it is fingerprinted as a dir
+
+    with pytest.raises(SandboxLeak):
+        with sandbox(live_check="off") as sb:
+            assert Path.home() == sb.root / "home"  # synthetic HOME active
+            # A companion write to the REAL ~/.ssh (absolute path — the risk the seal opened).
+            (real_ssh / "authorized_keys").write_text("ssh-ed25519 AAAA... attacker")


### PR DESCRIPTION
## What
The input-side `$USER`/`$LOGNAME` de-id (F1/F2, #99) seals the shell/tool
environment but not the companion's **stored** channels. The `claude` CLI's
auto-injected context still leaks the real account/project into `memories.db`,
active-recall, and `works/*.md` (never into a visible reply). Root cause: the
CLI subprocess inherits `cwd=repo` and a `HOME`-keyed global `CLAUDE.md`.

## Seal (harness-only, in `tests/harness/sandbox.py`)
All three scoped to the sandbox run window and torn down symmetrically:
- **A — neutral cwd**: the subprocess runs in a de-identified scratch dir.
- **C — synthetic `HOME`**: empty `.claude/`, no global `CLAUDE.md`. The
  load-bearing seal.
- **B — synthetic `oauthAccount`**: pre-seeded belt (the CLI refetches it and
  does not inject it into generation, so it seals nothing on its own — kept as
  documented defense-in-depth).

## Security posture (owner-accepted)
Carrier C's process-wide `HOME` makes `brain/files/write_guard.py` compute its
home-dotfile deny set against the tempdir during a run. Prevention is restored
as **detection**: the `SandboxLeak` fingerprint now imports write_guard's exact
deny set (so they can't drift), with a test proving a write to real `~/.ssh`
under synthetic HOME trips `SandboxLeak`. Parallels the accepted risk in #104.

## Validation
A representative in-character arm through the edited harness produced **zero**
real-identity strings across all populated stored channels (oracle shown able
to fail on a known-bad fixture). New `tests/unit/harness/test_stored_channel_deid.py`
(8 tests); ruff clean; harness unit suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
