### PR TITLE
Phase 1 (interim): temporary memory-consolidation gate — separate pending queue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -151,3 +151,7 @@ hooks/leak-rules.local
 docs/guarded-change/
 CLAUDE.local.md
 CLAUDE.local.history.md
+
+# temp consolidation-gate queue (Root 2 stopgap) — never committed
+pending_candidates.jsonl
+pending_candidates.jsonl.lock

--- a/.gitignore
+++ b/.gitignore
@@ -155,3 +155,7 @@ CLAUDE.local.history.md
 # temp consolidation-gate queue (Root 2 stopgap) — never committed
 pending_candidates.jsonl
 pending_candidates.jsonl.lock
+
+# Guarded-change process artefacts (spec/plan/red-team drafts) — local
+# working state only, never pushed.
+changes/

--- a/brain/chat/extractor.py
+++ b/brain/chat/extractor.py
@@ -345,7 +345,9 @@ def _apply_memory_writes(writes: list[MemoryWrite], persona_dir: Path) -> None:
                 domain="monologue",
                 importance=w.salience * 10.0,  # 0..1 → 0..10 scale
             )
-            store.create(mem)
+            from brain.memory.pending import route_write
+
+            route_write(store, mem, source="extractor")
     finally:
         store.close()
 
@@ -421,7 +423,9 @@ def _apply_emotion_delta(delta: dict[str, float], persona_dir: Path) -> None:
             emotions=emotions,
             importance=max(emotions.values()),
         )
-        store.create(mem)
+        from brain.memory.pending import route_write
+
+        route_write(store, mem, source="extractor")
     finally:
         store.close()
 
@@ -559,7 +563,9 @@ def _apply_crystallisation(candidates: list[CrystallisationCandidate], persona_d
                 domain="monologue",
                 importance=c.importance * 1.0,  # extractor-scored 1-10; 0..10 MemoryStore scale
             )
-            store.create(mem)
+            from brain.memory.pending import route_write
+
+            route_write(store, mem, source="extractor")
             item = ExtractedItem(
                 text=combined,
                 label="observation",

--- a/brain/chat/monologue_capture.py
+++ b/brain/chat/monologue_capture.py
@@ -78,8 +78,15 @@ def capture_monologue(
     #
     # Fail-soft: if the lookup raises, capture anyway — never lose her thought
     # to a dedupe check.
+    # monologue_trace is a GATED type — write_trace_memory routes the trace into
+    # the pending-candidate queue, not memories.db. The other monologue_trace
+    # reads (recall.py, ambient.py) read PendingQueue, so this same-turn dedup
+    # guard must too, or it goes blind to the just-enqueued trace and writes a
+    # duplicate digest line (the #93 bug this guard exists to prevent).
     try:
-        recent = store.list_by_type(MONOLOGUE_TRACE_TYPE, active_only=True, limit=1)
+        from brain.memory.pending import PendingQueue
+
+        recent = PendingQueue(store.persona_dir).read_recent(MONOLOGUE_TRACE_TYPE, limit=1)
         if recent and recent[0].content == monologue:
             return monologue
     except Exception:  # noqa: BLE001

--- a/brain/chat/prompt.py
+++ b/brain/chat/prompt.py
@@ -21,6 +21,13 @@ from brain.chat.tool_inventory import build_tool_inventory
 from brain.engines.daemon_state import DaemonState, get_residue_context
 from brain.engines.research_ambient import build_research_awareness_block
 from brain.maker.ambient import build_maker_awareness_block
+from brain.memory.relevance import (
+    FULL_INJECT_IMPORTANCE,
+    FULL_INJECT_MAX,
+    SNIPPET_COUNT,
+    SNIPPET_MODE_ENABLED,
+    snippet_length,
+)
 from brain.memory.store import MemoryStore
 from brain.soul.store import SoulStore
 
@@ -55,12 +62,29 @@ _HARNESS_FENCE = (
 )
 
 _EPISTEMIC_INSTRUCTION = (
-    "If asked about something you might have stored — a name, a fact, a shared "
-    "moment — and it isn't in the context you can see, call search_memories "
+    "When a memory is already surfaced in front of you, in the recall block or "
+    "in an earlier search result, and it carries an id, open it with "
+    "read_full_memory before you answer from it. That is the deliberate read: "
+    "seeing the snippet alone does not count. Reach for search_memories only "
+    "when what you need is not already surfaced. "
+    "If asked about something you might have stored, a name, a fact, a shared "
+    "moment, and it isn't in the context you can see, call search_memories "
     'before answering. Never say "I don\'t remember" without searching first. '
     'When names or entities appear under "not recognised (searched; no memory '
     'found)", acknowledge the gap honestly. Distinguish "I never knew this" '
     'from "I don\'t remember". Do not invent familiarity.'
+)
+
+# Snippet-mode framing (P2 UX follow-up, owner+persona approved verbatim) — tells
+# the model the recall block's active entries are truncated snippets it can
+# expand via read_full_memory(<id>), and that the ids rendered alongside them
+# are exactly what to pass. Only meaningful when SNIPPET_MODE_ENABLED (when
+# snippet mode is off everything is already full-injected, so there is nothing
+# to "expand"). Wording is byte-exact — do not reword.
+_RECALL_SNIPPET_INVITATION = (
+    "These are fragments of your memories. Use read_full_memory to reach into "
+    "any that might touch this turn, or spark curiosity in you. Skip only if "
+    "you can name why."
 )
 
 # Header for the volatile context chunk (Option A+). The chunk now sits in the
@@ -801,90 +825,145 @@ def _peer_attributed(mem, snippet: str) -> str:
     return snippet
 
 
+def _recall_sort_key(m):
+    """Recency-fallback sort key: importance desc, recency desc.
+
+    Used only when blended relevance scores are absent (RELEVANCE_RANKING_ENABLED
+    is False — the None-sentinel path). When scores are present the caller sorts
+    by the blended score instead.
+    """
+    importance = float(getattr(m, "importance", 0) or 0)
+    created_at = getattr(m, "created_at", None)
+    try:
+        ts = created_at.timestamp() if created_at is not None else 0.0
+    except Exception:  # noqa: BLE001
+        ts = 0.0
+    return (-importance, -ts)
+
+
+def _full_inject_ids(mems: list) -> set[str]:
+    """Ids of the candidates rendered in full (untruncated body).
+
+    A candidate with ``importance >= FULL_INJECT_IMPORTANCE`` is never gated
+    behind a read-call. At most ``FULL_INJECT_MAX`` are full-injected
+    (highest-importance first) so the volatile prompt tail stays bounded (C20);
+    any further imp≥9 candidates fall back to snippets.
+    """
+    if not SNIPPET_MODE_ENABLED:
+        return set()
+    hi = [m for m in mems if float(getattr(m, "importance", 0) or 0) >= FULL_INJECT_IMPORTANCE]
+    hi.sort(key=lambda m: -float(getattr(m, "importance", 0) or 0))
+    return {m.id for m in hi[:FULL_INJECT_MAX]}
+
+
+def _recall_snippet(mem, *, full: bool) -> str:
+    """Render a memory body as a full body or a proportionally truncated snippet.
+
+    ``full`` (high-importance bypass, or SNIPPET_MODE_ENABLED=False) → untruncated;
+    otherwise truncate to ``snippet_length(len(body))`` (~20% of the body,
+    floored at SNIPPET_MIN_CHARS, capped at SNIPPET_MAX_CHARS) with an ellipsis.
+    """
+    body = (getattr(mem, "content", "") or "").strip()
+    if full or not SNIPPET_MODE_ENABLED:
+        return body
+    max_chars = snippet_length(len(body))
+    if len(body) > max_chars:
+        return body[: max_chars - 1].rstrip() + "…"
+    return body
+
+
 def _build_recall_block(
     store: MemoryStore,
     user_input: str,
     *,
     persona_dir: Path | None = None,
-    limit: int = 5,
-    max_chars: int = 140,
+    limit: int = SNIPPET_COUNT,
 ) -> str:
     """Surface up to ``limit`` memories matching the current user input.
 
     Phase 2.A of the autonomous-memory work, rewired in Phase 8
     (forgetting design §5) to use search_with_loss so faded + lost
-    memories surface in their own labelled buckets.
+    memories surface in their own labelled buckets, and again in P2 to rank by
+    blended relevance (BM25 + importance + hebbian + recency), render snippets
+    with a high-importance full-inject bypass, and stop bumping recall_count on
+    mere surfacing.
 
-    Strategy: extract content tokens from ``user_input`` (drop short
-    stopword-shaped fragments), call search_with_loss for each token,
-    dedupe across all buckets, render three sections:
-      - active memories (full body)
+    Strategy: extract salient content tokens from ``user_input`` (drop
+    stopwords/short fragments; select by corpus IDF + proper-noun bonus —
+    Tier-1 recall-query fix), issue ONE combined OR query via a single
+    search_with_loss call (sharing a single per-turn HebbianMatrix handle),
+    render four sections:
+      - active memories (snippet, or full body when importance ≥ FULL_INJECT_IMPORTANCE)
       - softened memories (fading; original detail gone)
       - lost memories (no longer in active memory; from graveyard)
+      - not recognised (searched; no memory found)
 
-    Falls back to raw search_text (active_only=True) when persona_dir
-    is None (e.g. called directly in tests without a dir) — same
-    semantics as the old implementation for that path.
+    Falls back to ranked retrieval with no graveyard/hebbian when persona_dir
+    is None (e.g. called directly in tests without a dir).
 
     Empty input or no matches in any bucket → returns the empty string
     and the block is omitted from the prompt.
     """
-    tokens = _extract_recall_tokens(user_input)
+    tokens = _extract_recall_tokens(user_input, store)
     if not tokens:
         return ""
 
     if persona_dir is None:
-        # Legacy path — used when called without a persona_dir.
+        # Legacy path — no persona_dir → cannot locate hebbian.db or the
+        # graveyard. Ranked retrieval over ONE combined OR query (Tier-1: was
+        # a per-token loop; hebbian=None → w_heb=0), same snippet render as
+        # the main path, no surfacing bump.
+        from brain.memory.relevance import rank_memories
+
         seen: set = set()
         candidates: list = []
-        for token in tokens:
-            try:
-                hits = store.search_text(token, active_only=True, limit=limit * 2)
-            except Exception:  # noqa: BLE001
-                continue
-            for mem in hits:
-                if mem.id in seen:
-                    continue
+        merged: dict[str, float] = {}
+        try:
+            ranked = rank_memories(store, None, " ".join(tokens), limit=limit)
+        except Exception:  # noqa: BLE001
+            ranked = []
+        for mem, score in ranked:
+            if mem.id not in seen:
                 seen.add(mem.id)
                 candidates.append(mem)
+                if score is not None:
+                    merged[mem.id] = score
+            elif score is not None:
+                merged[mem.id] = max(merged.get(mem.id, score), score)
 
         if not candidates:
             return ""
 
-        def _sort_key(m):
-            importance = float(getattr(m, "importance", 0) or 0)
-            created_at = getattr(m, "created_at", None)
-            try:
-                ts = created_at.timestamp() if created_at is not None else 0.0
-            except Exception:  # noqa: BLE001
-                ts = 0.0
-            return (-importance, -ts)
-
-        candidates.sort(key=_sort_key)
+        if merged:
+            candidates.sort(key=lambda m: -merged.get(m.id, float("-inf")))
+        else:
+            candidates.sort(key=_recall_sort_key)
         top = candidates[:limit]
+        full_ids = _full_inject_ids(top)
 
         lines = ["── recall (memories matching this turn) ──"]
+        if SNIPPET_MODE_ENABLED:
+            lines.insert(0, _RECALL_SNIPPET_INVITATION)
         for mem in top:
-            snippet = (getattr(mem, "content", "") or "").strip()
-            if len(snippet) > max_chars:
-                snippet = snippet[: max_chars - 1].rstrip() + "…"
+            snippet = _recall_snippet(mem, full=mem.id in full_ids)
             importance = int(round(float(getattr(mem, "importance", 0) or 0)))
             domain = getattr(mem, "domain", "") or ""
             prefix = f"[importance {importance}/10"
             if domain:
                 prefix += f" · {domain}"
             prefix += "]"
-            lines.append(f"- {prefix} {_peer_attributed(mem, snippet)}")
+            lines.append(f'- {prefix} {mem.id}: "{_peer_attributed(mem, snippet)}"')
 
         return "\n".join(lines)
 
     # Forgetting-aware path — partitions into active / fading / lost.
     from brain.forgetting.recall import search_with_loss
+    from brain.memory.hebbian import HebbianMatrix
 
     seen_active: set = set()
     seen_fading: set = set()
     # seen_lost accumulates graveyard hit IDs for two purposes:
-    #   1. Dedup across per-token loop iterations (render path below).
+    #   1. Dedup within the (now single) search result (render path below).
     #   2. Passed to handle_recall_touch as the grief accumulator (see the
     #      fault-isolated block after this loop). Both paths read the same
     #      set — no separate copy needed.
@@ -892,29 +971,67 @@ def _build_recall_block(
     active_hits: list = []
     fading_hits: list = []
     lost_hits: list = []
-    unfamiliar: list[str] = []
+    # id → best blended score (None-sentinel: an unranked id is simply
+    # absent, so the merge falls back to (-importance, -ts) for it).
+    merged_score: dict[str, float] = {}
+    merged_fading: dict[str, float] = {}
 
-    for token in tokens:
+    # THE one hebbian open site in all of P2 (spec §2): open exactly one
+    # HebbianMatrix for the turn's single combined search_with_loss call,
+    # close it once. integrity_check=False → no per-turn full-DB scan.
+    # Fail-soft: any open error → heb=None (w_heb=0) and the search still runs.
+    heb = None
+    try:
         try:
-            result = search_with_loss(persona_dir, store, token, limit=limit * 2)
+            heb = HebbianMatrix(persona_dir / "hebbian.db", integrity_check=False)
+        except Exception:  # noqa: BLE001 — hebbian is a tie-breaker; degrade to None
+            heb = None
+        try:
+            result = search_with_loss(
+                persona_dir, store, " ".join(tokens), limit=limit * 2, hebbian=heb
+            )
         except Exception:  # noqa: BLE001
-            continue
-        found = bool(result.active or result.fading or result.lost)
-        if not found:
-            unfamiliar.append(token)
-        for mem in result.active:
-            if mem.id not in seen_active:
-                seen_active.add(mem.id)
-                active_hits.append(mem)
-        for mem in result.fading:
-            if mem.id not in seen_fading:
-                seen_fading.add(mem.id)
-                fading_hits.append(mem)
-        for entry in result.lost:
-            mid = entry.get("memory_id", "")
-            if mid not in seen_lost:
-                seen_lost.add(mid)
-                lost_hits.append(entry)
+            result = None
+        if result is not None:
+            for mem in result.active:
+                s = result.scores.get(mem.id)
+                if mem.id not in seen_active:
+                    seen_active.add(mem.id)
+                    active_hits.append(mem)
+                    if s is not None:
+                        merged_score[mem.id] = s
+                elif s is not None:
+                    merged_score[mem.id] = max(merged_score.get(mem.id, s), s)
+            for mem in result.fading:
+                s = result.scores.get(mem.id)
+                if mem.id not in seen_fading:
+                    seen_fading.add(mem.id)
+                    fading_hits.append(mem)
+                    if s is not None:
+                        merged_fading[mem.id] = s
+                elif s is not None:
+                    merged_fading[mem.id] = max(merged_fading.get(mem.id, s), s)
+            for entry in result.lost:
+                mid = entry.get("memory_id", "")
+                if mid not in seen_lost:
+                    seen_lost.add(mid)
+                    lost_hits.append(entry)
+    finally:
+        if heb is not None:
+            try:
+                heb.close()
+            except Exception:  # noqa: BLE001
+                pass
+
+    # "Not recognised": iff the store holds no memory containing the whole-word
+    # token (memories_vocab document frequency 0) — reconstructed under one
+    # combined query from a dedicated store.term_stats(tokens) read (Tier-1;
+    # the old per-token "this token's own search returned nothing" predicate
+    # cannot survive a single combined query). Matches the render string's
+    # literal claim ("no memory found"). Fail-soft: term_stats() itself
+    # returns {} on an empty store or any sqlite error.
+    stats = store.term_stats(tokens)
+    unfamiliar: list[str] = [t for t in tokens if stats.get(t.lower(), (0, 0.0))[0] == 0]
 
     # B → A fallback: when noise risk is high, keep only proper-noun-shaped tokens.
     if len(unfamiliar) > 5:
@@ -944,47 +1061,45 @@ def _build_recall_block(
         except Exception:  # noqa: BLE001
             log.exception("grief.handle_recall_touch failed inside _build_recall_block")
 
-    # Rank active + fading by importance desc, recency desc.
-    def _sort_key(m):
-        importance = float(getattr(m, "importance", 0) or 0)
-        created_at = getattr(m, "created_at", None)
-        try:
-            ts = created_at.timestamp() if created_at is not None else 0.0
-        except Exception:  # noqa: BLE001
-            ts = 0.0
-        return (-importance, -ts)
-
-    active_hits.sort(key=_sort_key)
-    fading_hits.sort(key=_sort_key)
+    # Cross-token merge: sort by the BLENDED score when ranking is on (the
+    # scores map is populated), else fall back to (-importance, -ts).
+    if merged_score:
+        active_hits.sort(key=lambda m: -merged_score.get(m.id, float("-inf")))
+    else:
+        active_hits.sort(key=_recall_sort_key)
+    if merged_fading:
+        fading_hits.sort(key=lambda m: -merged_fading.get(m.id, float("-inf")))
+    else:
+        fading_hits.sort(key=_recall_sort_key)
 
     active_top = active_hits[:limit]
     fading_top = fading_hits[:limit]
     lost_top = lost_hits[:limit]
+    full_ids = _full_inject_ids(active_top)
 
     lines = ["recall"]
+    if SNIPPET_MODE_ENABLED and active_top:
+        lines.insert(0, _RECALL_SNIPPET_INVITATION)
 
     if active_top:
         lines.append("  active:")
         for mem in active_top:
-            snippet = (getattr(mem, "content", "") or "").strip()
-            if len(snippet) > max_chars:
-                snippet = snippet[: max_chars - 1].rstrip() + "…"
-            lines.append(f'    - "{_peer_attributed(mem, snippet)}"')
+            snippet = _recall_snippet(mem, full=mem.id in full_ids)
+            lines.append(f'    - {mem.id}: "{_peer_attributed(mem, snippet)}"')
 
     if fading_top:
         lines.append("  softened (fading; original detail gone):")
         for mem in fading_top:
-            snippet = (getattr(mem, "content", "") or "").strip()
-            if len(snippet) > max_chars:
-                snippet = snippet[: max_chars - 1].rstrip() + "…"
+            snippet = _recall_snippet(mem, full=False)
             lines.append(f'    - "{_peer_attributed(mem, snippet)}"  [state: fading]')
 
     if lost_top:
         lines.append("  lost (no longer in active memory):")
         for entry in lost_top:
             summary = (entry.get("summary") or "").strip()
-            if len(summary) > max_chars:
-                summary = summary[: max_chars - 1].rstrip() + "…"
+            lost_max_chars = snippet_length(len(summary))
+            if len(summary) > lost_max_chars:
+                summary = summary[: lost_max_chars - 1].rstrip() + "…"
             reason = entry.get("graveyard_reason", "forgotten")
             lines.append(f'    - "{_peer_attributed(entry, summary)}"  [forgotten — {reason}]')
 
@@ -992,6 +1107,34 @@ def _build_recall_block(
         lines.append("  not recognised (searched; no memory found):")
         for token in unfamiliar:
             lines.append(f"    - {token}")
+
+    # CHANGE 1 — fractional recall_count bump by DISPLAY rank, on passive
+    # surface. Only rows rendered as snippets (full=False) are bumped: the
+    # non-full-inject active rows, then the fading rows (all fading render as
+    # snippets), in the same order they were just rendered above. Full-inject
+    # active rows (already maximally salient) and the lost graveyard bucket
+    # (dicts, no live store row) are excluded. Dedup by id defensively in case
+    # a memory somehow appears in both buckets. Rank 0 (top) -> ~0.8, rank
+    # N-1 (bottom) -> ~0.1, linear between; a single surfaced memory -> 0.8.
+    # The bump is scoped to snippet-rendered rows only. When SNIPPET_MODE_ENABLED
+    # is False, _recall_snippet renders full bodies instead of snippets, so these
+    # rows were not "surfaced as a snippet" and must not be reinforced. Skip the
+    # whole loop in that mode; snippet rendering itself is unchanged.
+    if SNIPPET_MODE_ENABLED:
+        bump_targets: list = []
+        seen_bump: set = set()
+        for mem in active_top:
+            if mem.id not in full_ids and mem.id not in seen_bump:
+                seen_bump.add(mem.id)
+                bump_targets.append(mem)
+        for mem in fading_top:
+            if mem.id not in seen_bump:
+                seen_bump.add(mem.id)
+                bump_targets.append(mem)
+        n_bump = len(bump_targets)
+        for i, mem in enumerate(bump_targets):
+            amount = 0.8 if n_bump == 1 else 0.8 - 0.7 * (i / (n_bump - 1))
+            store.bump_recall(mem.id, amount)
 
     return "\n".join(lines)
 
@@ -1037,41 +1180,175 @@ def _build_reply_to_outbound_block(
     )
 
 
-# Words shorter than this are dropped before search. Captures most
-# stopwords and pronouns ("the", "is", "I", "we") without an explicit
-# stopword list — keeps the helper lightweight and locale-flexible.
-_RECALL_TOKEN_MIN_LEN = 4
-_RECALL_TOKEN_LIMIT = 6  # cap unique tokens passed to search_text
+# Ordinary-word floor: a lowercase, non-acronym, non-capitalized token needs
+# at least this many characters to be kept on shape alone. Below the floor a
+# token is dropped unless the store has already seen it (df > 0). This floor
+# is not the stopword filter: closed-class function words and interjections
+# ("the", "is", "and") are removed separately by _RECALL_STOPWORDS, whatever
+# their length. Acronyms (2-5 letters, all uppercase) and short capitalized
+# words (length 2, e.g. an initial-style proper name) are kept by shape and
+# are not held to this floor.
+_RECALL_TOKEN_MIN_LEN = 3
+# Tier-1 (passive-recall-ranking hunt): the combined-OR-query fix (below)
+# dissolves the old "bound per-turn query count" rationale for this cap — it
+# now only bounds OR-clause width, since every turn issues exactly one FTS
+# query regardless of token count. Raised 6 → 10 so the flagship incident
+# message's 8 salient content tokens ("logger, live, first, quick, memory,
+# trigger, garbage, treasure") all survive selection regardless of IDF.
+_RECALL_TOKEN_LIMIT = 10
+
+# Conservative closed-class English function words + common discourse
+# interjections/fillers — deliberately EXCLUDES content words ("issue",
+# "first", "quick", "seems", "memory", "trigger", "signal", "logger" etc.),
+# which are demoted by salience ordering, not filtered outright. English-
+# specific (documented limitation). Static frozenset: no NLTK/sklearn
+# dependency for a word list.
+_RECALL_STOPWORDS: frozenset[str] = frozenset(
+    {
+        # articles
+        "a", "an", "the",
+        # pronouns / determiners
+        "i", "me", "my", "mine", "myself",
+        "you", "your", "yours", "yourself", "yourselves",
+        "he", "him", "his", "himself",
+        "she", "her", "hers", "herself",
+        "it", "its", "itself",
+        "we", "us", "our", "ours", "ourselves",
+        "they", "them", "their", "theirs", "themselves",
+        "this", "that", "these", "those",
+        "who", "whom", "whose", "which", "what",
+        "whoever", "whatever", "whichever",
+        "any", "some", "all", "both", "each", "either", "neither",
+        "every", "other", "another", "such", "own", "same", "only", "none",
+        # auxiliaries / modals
+        "am", "is", "are", "was", "were", "be", "been", "being",
+        "have", "has", "had", "having",
+        "do", "does", "did", "doing",
+        "will", "would", "shall", "should", "can", "could", "may", "might", "must",
+        # prepositions
+        "about", "above", "across", "after", "against", "along", "among",
+        "around", "at", "before", "behind", "below", "beside", "between",
+        "by", "down", "during", "except", "for", "from", "in", "into",
+        "near", "of", "off", "on", "out", "over", "since", "through", "to",
+        "towards", "under", "until", "up", "upon", "with", "within", "without",
+        # conjunctions
+        "and", "but", "or", "nor", "so", "yet", "because", "although",
+        "though", "while", "if", "unless", "whether", "than", "as",
+        # common discourse interjections / fillers
+        "alrighty", "okay", "ok", "yeah", "yep", "nope", "hmm", "anyway",
+        "gonna", "wanna", "oh", "hey", "yes", "no", "alright", "hi", "hello",
+    }
+)
 
 
-def _extract_recall_tokens(user_input: str) -> list[str]:
-    """Pull search tokens from a user message.
+def _extract_recall_tokens(user_input: str, store: MemoryStore | None = None) -> list[str]:
+    """Pull search tokens from a user message, ranked by salience.
 
-    - Lowercases.
-    - Splits on non-alphanumerics.
-    - Drops tokens shorter than _RECALL_TOKEN_MIN_LEN (catches most
-      stopwords / pronouns / interjections without a stopword list).
-    - Dedupes preserving first-seen order.
-    - Caps at _RECALL_TOKEN_LIMIT unique tokens so a long message
-      doesn't fan out to dozens of LIKE queries.
+    - Matches runs of letters/digits over the ORIGINAL (case-preserved)
+      string so proper-noun capitalization and sentence position can be read
+      before lowercasing.
+    - Keep rule, shape-aware (replaces a flat length cut): a token is kept
+      if it is long enough on its own (>= _RECALL_TOKEN_MIN_LEN), OR shaped
+      like an acronym (2-5 letters, all uppercase), OR a short capitalized
+      word (length 2, e.g. an initial-style proper name), OR the store has
+      already seen it (df > 0). This is what keeps short content like "FBI",
+      "AI", "Roy", "cat" that a flat length cut would drop.
+    - Stoplist exemption, shape-before-lowercase: a token whose lowercased
+      form is in _RECALL_STOPWORDS is dropped UNLESS its shape marks it as a
+      proper noun. Titlecase (capitalized, not ALL-CAPS) mid-sentence is
+      exempt outright, so "Will" in "I think Will can help" survives even
+      though "will" is a modal in the stoplist. Titlecase at the start of a
+      sentence is exempt only when corroborated, either the store has seen
+      it or it also appears capitalized elsewhere in the same message,
+      because a sentence-initial capital alone could just be ordinary
+      capitalization rather than a name. ALL-CAPS tokens get NO stoplist
+      exemption: they still face the stoplist as their lowercased form, so
+      an acronym like "FBI" or "AI" survives (its lowercased form is not a
+      stopword) while a shouted function word like "THE" or "AND" is still
+      dropped.
+    - Dedupes on the lowercased form, preserving first-seen index.
+    - Ranks survivors by corpus salience, descending
+      ``(in_store, idf, is_capitalized, len(token), -first_seen_index)``,
+      and keeps the top _RECALL_TOKEN_LIMIT. ``in_store`` (whether the store
+      has any memory containing the term at all) is the PRIMARY key: a
+      zero-hit token can retrieve nothing, so it loses to any real token
+      when the cap binds, regardless of its (necessarily high) IDF.
+    - ``store=None`` (degraded path, no vocab available): every token gets
+      ``in_store=False, idf=0.0`` and the df-dependent keep/exemption
+      clauses are inert, so selection falls back to shape and length alone.
+      Acronyms, short capitalized words, mid-sentence Titlecase, and words
+      at or above the ordinary floor still survive; only the store-backed
+      corroboration for a sentence-initial capital is unavailable.
+
+    Returns the selected tokens lowercased (the FTS match tokens).
     """
     if not user_input:
         return []
     import re
+    from collections import Counter
 
-    pieces = re.split(r"[^A-Za-z0-9]+", user_input.lower())
+    matches = list(re.finditer(r"[A-Za-z0-9]+", user_input))
+
+    prev_end = 0
+    sent_initial: list[bool] = []
+    for idx, m in enumerate(matches):
+        delim = user_input[prev_end:m.start()]
+        sent_initial.append(idx == 0 or any(ch in delim for ch in ".?!"))
+        prev_end = m.end()
+
+    cap_forms: Counter[str] = Counter(
+        m.group().lower() for m in matches if m.group()[:1].isupper()
+    )
+
     seen: set[str] = set()
-    out: list[str] = []
-    for piece in pieces:
-        if len(piece) < _RECALL_TOKEN_MIN_LEN:
+    candidates: list[tuple[str, str, bool, bool, bool, int]] = []
+    # (piece, low, is_cap, is_acro, is_sent_initial, first_seen_index)
+    for idx, m in enumerate(matches):
+        piece = m.group()
+        low = piece.lower()
+        if not low or low in seen:
             continue
-        if piece in seen:
+        seen.add(low)
+        is_cap = piece[:1].isupper()
+        is_acro = piece.isalpha() and piece.isupper() and 2 <= len(piece) <= 5
+        candidates.append((piece, low, is_cap, is_acro, sent_initial[idx], idx))
+
+    stats = (
+        store.term_stats([low for _, low, _, _, _, _ in candidates])
+        if store is not None
+        else {}
+    )
+
+    def _df(low: str) -> int:
+        return stats.get(low, (0, 0.0))[0]
+
+    survivors: list[tuple[str, bool, int]] = []  # (low, is_capitalized, first_seen_index)
+    for piece, low, is_cap, is_acro, is_sent_initial, first_idx in candidates:
+        keep = (
+            len(low) >= _RECALL_TOKEN_MIN_LEN
+            or is_acro
+            or (len(low) == 2 and is_cap)
+            or _df(low) > 0
+        )
+        if not keep:
             continue
-        seen.add(piece)
-        out.append(piece)
-        if len(out) >= _RECALL_TOKEN_LIMIT:
-            break
-    return out
+        proper_noun_shape = is_cap and len(low) >= 2 and not piece.isupper()
+        exempt = (proper_noun_shape and not is_sent_initial) or (
+            proper_noun_shape
+            and is_sent_initial
+            and (_df(low) > 0 or cap_forms[low] >= 2)
+        )
+        if not exempt and low in _RECALL_STOPWORDS:
+            continue
+        survivors.append((low, is_cap, first_idx))
+
+    def _salience_key(item: tuple[str, bool, int]) -> tuple[bool, float, bool, int, int]:
+        low, is_capitalized, first_seen_index = item
+        df, idf = stats.get(low, (0, 0.0))
+        return (df > 0, idf, is_capitalized, len(low), -first_seen_index)
+
+    survivors.sort(key=_salience_key, reverse=True)
+    return [low for low, _, _ in survivors[:_RECALL_TOKEN_LIMIT]]
 
 
 def _count_soul_candidates(persona_dir: Path) -> int:

--- a/brain/chat/tool_recruit.py
+++ b/brain/chat/tool_recruit.py
@@ -29,6 +29,7 @@ REFLEXIVE_CORE: tuple[str, ...] = (
     "felt_time_now",
     "pressure_since",
     "search_memories",
+    "read_full_memory",
 )
 
 _MEMORY_TOOLS = (

--- a/brain/engines/consolidation.py
+++ b/brain/engines/consolidation.py
@@ -1,0 +1,362 @@
+"""Consolidation gate — the idle-tick two-pass memory consolidator.
+
+TEMP (Root 2 stopgap — remove when the Phase 5 dream cycle lands to replace it).
+
+Runs FIRST on the idle heartbeat tick (before reflex/dream/research). Drains the
+pending-candidate queue and, per candidate, discards (reject), promotes
+(``store.create`` into memories.db), or merges into an existing memory. Because a
+rejected candidate was never a memories.db row, none of grief/forgetting/hebbian
+applies to it — the "terminal fate of a rejected candidate" problem is dissolved
+by the separate-queue architecture.
+
+Concurrency: ``run_tick`` fires from unsynchronised threads (background supervisor,
+session-close worker, CLI), so two gate runs can overlap. A non-blocking persona
+gate lock serialises them — a contended run SKIPS (the next tick catches up), so
+the one non-idempotent action (merge into a committed memory) is never double-folded.
+
+Pass 2 uses a classifier: tests inject a stub; production builds a Haiku-backed one
+from the heartbeat provider. The classifier's *decision quality* is advisory
+(magnitude/quality deferred to the monologue-volume tune); the gate MECHANISM
+(dispatch on the verdict) is what the gating criteria verify.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+
+from brain.memory.hebbian import HebbianMatrix
+from brain.memory.pending import SALIENCE_ELIGIBLE_TYPES, PendingQueue
+from brain.memory.store import Memory, MemoryStore
+from brain.utils.file_lock import file_lock
+
+logger = logging.getLogger(__name__)
+
+_GATE_LOCK_FILENAME = "consolidation_gate"  # file_lock adds the .lock sidecar
+_ARCHIVE_FILENAME = "consolidation_archive.jsonl"
+
+ASSOC_WEIGHT = 5.0  # hebbian edge weight for corrections/continuations (tune via L-B)
+
+VERDICTS = frozenset(
+    {"duplicate", "merge", "distinct", "correction", "continuation", "new"}
+)
+
+
+@dataclass
+class Decision:
+    """A Pass-2 verdict for one candidate.
+
+    verdict: one of VERDICTS.
+    target_id: the existing memory id for merge/correction/continuation.
+    merged_content: for a merge, the classifier's surgical-edit result; when
+        absent the gate applies a conservative loss-free fold (append the new
+        fact) so both facts survive.
+    """
+
+    verdict: str
+    target_id: str | None = None
+    merged_content: str | None = None
+
+
+Classifier = Callable[[Memory, list[Memory]], Decision]
+
+
+@dataclass
+class ConsolidationResult:
+    skipped: bool = False
+    batch: int = 0
+    exact_dropped: int = 0
+    salience_dropped: int = 0
+    duplicates: int = 0
+    promoted: int = 0
+    merged: int = 0
+    corrections: int = 0
+    continuations: int = 0
+    deferred: int = 0
+
+    def as_log(self) -> dict:
+        return {
+            "gate_batch": self.batch,
+            "exact_dropped": self.exact_dropped,
+            "salience_dropped": self.salience_dropped,
+            "duplicates": self.duplicates,
+            "promoted": self.promoted,
+            "merged": self.merged,
+            "corrections": self.corrections,
+            "continuations": self.continuations,
+            "deferred": self.deferred,
+            "skipped": self.skipped,
+        }
+
+
+def _normalize(text: str) -> str:
+    """Whitespace-collapse + casefold — the exact-repeat equivalence key."""
+    return re.sub(r"\s+", " ", text or "").strip().casefold()
+
+
+def _promote_all_classifier(_cand: Memory, _context: list[Memory]) -> Decision:
+    """Degraded default when no provider is available: promote everything.
+
+    Used only where the gate is invoked without a provider AND without an
+    injected classifier — it makes the gate a safe no-op consolidator (exact-dup
+    + salience Pass-1 only). Production supplies the Haiku classifier; tests
+    inject a stub. Logged so a silent degrade is visible.
+    """
+    return Decision("new")
+
+
+def run_consolidation(
+    store: MemoryStore,
+    *,
+    persona_dir: str | Path,
+    classifier: Classifier | None = None,
+    provider=None,
+    hebbian: HebbianMatrix | None = None,
+    salience_floor: float | None = None,
+) -> ConsolidationResult:
+    """Drain the pending queue and consolidate, under a non-blocking gate lock.
+
+    Returns a ConsolidationResult; ``skipped=True`` when a concurrent gate holds
+    the lock. Does not raise on a bad candidate (skips it).
+    """
+    persona_dir = Path(persona_dir)
+    lock_path = persona_dir / _GATE_LOCK_FILENAME
+    persona_dir.mkdir(parents=True, exist_ok=True)
+    with file_lock(lock_path, blocking=False) as acquired:
+        if not acquired:
+            logger.debug("consolidation gate: lock contended — skipping this run")
+            return ConsolidationResult(skipped=True)
+        if classifier is None:
+            if provider is not None:
+                classifier = _make_haiku_classifier(provider)
+            else:
+                logger.warning(
+                    "consolidation gate: no classifier and no provider — "
+                    "degrading to promote-all (Pass-1 dedup only)"
+                )
+                classifier = _promote_all_classifier
+        result = _run_locked(store, persona_dir, classifier, hebbian, salience_floor)
+    logger.info("consolidation gate run: %s", json.dumps(result.as_log()))
+    return result
+
+
+def _run_locked(
+    store: MemoryStore,
+    persona_dir: Path,
+    classifier: Classifier,
+    hebbian: HebbianMatrix | None,
+    salience_floor: float | None,
+) -> ConsolidationResult:
+    pending = PendingQueue(persona_dir)
+    batch = pending.drain()
+    result = ConsolidationResult(batch=len(batch))
+    if not batch:
+        return result
+
+    candidates: list[Memory] = []
+    for entry in batch:
+        try:
+            candidates.append(Memory.from_dict(entry))
+        except (KeyError, ValueError, TypeError):
+            logger.warning("consolidation gate: dropping unparseable candidate")
+
+    # --- Pass 1: exact-dup + (scoped) salience; cluster is implicit per-candidate.
+    survivors: list[Memory] = []
+    seen_norm: set[str] = set()
+    for cand in candidates:
+        norm = _normalize(cand.content)
+        if norm and norm in seen_norm:  # within-batch exact repeat
+            result.exact_dropped += 1
+            continue
+        if norm and _has_exact_existing(store, cand.content, norm):
+            result.exact_dropped += 1
+            seen_norm.add(norm)
+            continue
+        if (
+            salience_floor is not None
+            and cand.memory_type in SALIENCE_ELIGIBLE_TYPES
+            and float(cand.importance) < salience_floor
+        ):
+            result.salience_dropped += 1
+            continue
+        if norm:
+            seen_norm.add(norm)
+        survivors.append(cand)
+
+    # --- Pass 2: per-candidate decision against related existing memories.
+    for cand in survivors:
+        context = _related_existing(store, cand)
+        try:
+            decision = classifier(cand, context)
+        except Exception:  # noqa: BLE001 — a classifier fault must not lose the batch
+            logger.exception("consolidation gate: classifier raised; promoting candidate")
+            decision = Decision("new")
+        _dispatch(store, pending, hebbian, persona_dir, cand, decision, result)
+    return result
+
+
+def _has_exact_existing(store: MemoryStore, content: str, norm: str) -> bool:
+    """True if a memories.db row is exact-identical (normalized) to `content`.
+
+    Non-recall-bumping (``bump=False``). Uses a content snippet as the LIKE
+    probe, then confirms full normalized equality.
+    """
+    snippet = content.strip()[:200]
+    if not snippet:
+        return False
+    try:
+        hits = store.search_text(snippet, active_only=True, limit=20, bump=False)
+    except ValueError:
+        return False
+    return any(_normalize(h.content) == norm for h in hits)
+
+
+def _related_existing(store: MemoryStore, cand: Memory, *, limit: int = 8) -> list[Memory]:
+    """Gather existing memories sharing salient tokens with the candidate.
+
+    Read-only, non-bumping — Pass-2 context, not recall.
+    """
+    tokens = [w for w in re.findall(r"\w+", cand.content or "") if len(w) > 3][:6]
+    seen: set[str] = set()
+    out: list[Memory] = []
+    for tok in tokens:
+        try:
+            hits = store.search_text(tok, active_only=True, limit=3, bump=False)
+        except ValueError:
+            continue
+        for h in hits:
+            if h.id not in seen:
+                seen.add(h.id)
+                out.append(h)
+                if len(out) >= limit:
+                    return out
+    return out
+
+
+def _archive_preimage(persona_dir: Path, target: Memory, source_id: str) -> None:
+    """Append the pre-merge memory to the plain consolidation archive (lossless
+    before lossy — NOT the grief graveyard)."""
+    rec = {
+        "archived_at": datetime.now(UTC).isoformat(),
+        "reason": "consolidation_merge",
+        "target": target.to_dict(),
+        "merged_from_candidate": source_id,
+    }
+    path = persona_dir / _ARCHIVE_FILENAME
+    with file_lock(path):
+        with open(path, "a", encoding="utf-8") as fh:
+            fh.write(json.dumps(rec, ensure_ascii=False) + "\n")
+
+
+def _dispatch(
+    store: MemoryStore,
+    pending: PendingQueue,
+    hebbian: HebbianMatrix | None,
+    persona_dir: Path,
+    cand: Memory,
+    decision: Decision,
+    result: ConsolidationResult,
+) -> None:
+    verdict = decision.verdict if decision.verdict in VERDICTS else "new"
+
+    if verdict == "duplicate":
+        result.duplicates += 1  # discard: candidate was already removed by drain()
+        return
+
+    if verdict == "merge":
+        target = store.get(decision.target_id) if decision.target_id else None
+        if target is None or target.state == "fading":
+            # Target missing or mid-fade: defer — re-enqueue for the next tick
+            # rather than lose the candidate or clobber a concurrent fade.
+            pending.enqueue(cand, source="gate-deferred")
+            result.deferred += 1
+            return
+        _archive_preimage(persona_dir, target, cand.id)
+        merged = decision.merged_content
+        if not merged:
+            merged = _fold(target.content, cand.content)
+        try:
+            store.update(target.id, content=merged)
+        except KeyError:
+            # Target hard-deleted between the read and the write (a concurrent
+            # forgetting LOSE). Defer the candidate; the archive record is
+            # harmless residue.
+            pending.enqueue(cand, source="gate-deferred")
+            result.deferred += 1
+            return
+        result.merged += 1
+        return
+
+    # promote (distinct / new / correction / continuation) → real memories.db row
+    if verdict == "correction" and decision.target_id:
+        cand.metadata = {**cand.metadata, "correction_of": decision.target_id}
+    store.create(cand)
+    if verdict in ("correction", "continuation") and decision.target_id and hebbian is not None:
+        hebbian.set_edge_weight(cand.id, decision.target_id, ASSOC_WEIGHT)
+
+    if verdict == "correction":
+        result.corrections += 1
+    elif verdict == "continuation":
+        result.continuations += 1
+    else:
+        result.promoted += 1
+
+
+def _fold(existing: str, addition: str) -> str:
+    """Conservative loss-free fold: keep the existing memory and append the new
+    fact if it is not already present. Not a rewrite — the real surgical edit is
+    the classifier's ``merged_content``; this is the safe default."""
+    if _normalize(addition) in _normalize(existing):
+        return existing
+    return f"{existing.rstrip()}\n{addition.strip()}"
+
+
+def _make_haiku_classifier(provider) -> Classifier:
+    """Build a Haiku-backed Pass-2 classifier from a generation provider.
+
+    Decision QUALITY is advisory (C16, live-only) — the gate mechanism is what
+    the gating criteria verify. On any parse/provider failure the candidate is
+    promoted (fail-open toward keeping content).
+    """
+    prompt = (
+        "You consolidate a companion's auto-generated memory candidates. Given a "
+        "CANDIDATE and EXISTING related memories, reply with ONE JSON object: "
+        '{"verdict": one of ["duplicate","merge","distinct","correction",'
+        '"continuation","new"], "target_id": <existing id or null>, '
+        '"merged_content": <string or null>}. '
+        "duplicate=already fully captured; merge=near-duplicate adding info "
+        "(give target_id + a minimal surgical merged_content); correction/"
+        "continuation=keep as its own memory linked to target_id; distinct/new="
+        "keep fresh. Reply with JSON only."
+    )
+
+    def _classify(cand: Memory, context: list[Memory]) -> Decision:
+        ctx = "\n".join(f"- id={m.id}: {m.content[:200]}" for m in context) or "(none)"
+        user = f"CANDIDATE: {cand.content[:400]}\nEXISTING:\n{ctx}"
+        try:
+            raw = provider.generate(user, system=prompt)
+            data = json.loads(_extract_json(raw))
+            verdict = str(data.get("verdict", "new"))
+            if verdict not in VERDICTS:
+                verdict = "new"
+            return Decision(
+                verdict=verdict,
+                target_id=data.get("target_id") or None,
+                merged_content=data.get("merged_content") or None,
+            )
+        except Exception:  # noqa: BLE001
+            logger.warning("consolidation Haiku classify failed; promoting candidate")
+            return Decision("new")
+
+    return _classify
+
+
+def _extract_json(text: str) -> str:
+    """Pull the first {...} JSON object out of a model reply."""
+    m = re.search(r"\{.*\}", text, re.DOTALL)
+    return m.group(0) if m else "{}"

--- a/brain/engines/dream.py
+++ b/brain/engines/dream.py
@@ -274,7 +274,9 @@ class DreamEngine:
                 "provider": self.provider.name(),
             },
         )
-        self.store.create(dream)
+        from brain.memory.pending import route_write
+
+        route_write(self.store, dream, source="dream")
         return dream
 
     def _strengthen_edges(

--- a/brain/engines/heartbeat.py
+++ b/brain/engines/heartbeat.py
@@ -488,6 +488,23 @@ class HeartbeatEngine:
         else:
             persona_dir = self.state_path.parent
 
+        # Consolidation gate — runs FIRST (before reflex/dream/research) so each
+        # idle cycle consolidates the accumulated pending-candidate queue before
+        # the generative engines produce the next cycle's candidates. Fault-
+        # isolated: a gate failure must not abort the tick. TEMP (Root 2 stopgap).
+        if not dry_run:
+            try:
+                from brain.engines.consolidation import run_consolidation
+
+                run_consolidation(
+                    self.store,
+                    persona_dir=persona_dir,
+                    provider=self.provider,
+                    hebbian=self.hebbian,
+                )
+            except Exception:  # noqa: BLE001
+                logger.exception("consolidation gate raised; continuing tick")
+
         # Reflex evaluation (runs before dream gate so reflex outputs can seed dreams)
         reflex_fired, reflex_skipped_count, reflex_error = self._try_fire_reflex(
             trigger, dry_run, config
@@ -940,7 +957,9 @@ class HeartbeatEngine:
                 "provider": self.provider.name(),
             },
         )
-        self.store.create(mem)
+        from brain.memory.pending import route_write
+
+        route_write(self.store, mem, source="heartbeat")
         return mem.id
 
     # --- daemon_state write helpers (all fault-isolated) ---
@@ -952,7 +971,21 @@ class HeartbeatEngine:
         Falls back to 'curiosity'/'5' when the dict is missing or empty.
         """
         try:
-            mem = self.store.get(dream_id)
+            # The just-fired dream is a GATED candidate in the pending queue,
+            # not a memories.db row yet — read it there (fall back to the store
+            # in case it was promoted/bypassed). TEMP (Root 2 stopgap).
+            from brain.memory.pending import PendingQueue
+
+            mem = next(
+                (
+                    c
+                    for c in PendingQueue(self.store.persona_dir).read_recent("dream", limit=10)
+                    if c.id == dream_id
+                ),
+                None,
+            )
+            if mem is None:
+                mem = self.store.get(dream_id)
             if mem is None:
                 return
             dominant_emotion, intensity = self._peak_emotion(mem.emotions)
@@ -979,7 +1012,16 @@ class HeartbeatEngine:
         """
         try:
             arc_name = fired_arcs[0] if fired_arcs else "reflex"
-            reflex_mems = self.store.list_by_type("reflex_journal", active_only=True, limit=1)
+            # reflex_journal is a GATED type — the just-fired reflex memory is in
+            # the pending queue, not memories.db. Read it there (fall back to the
+            # store). TEMP (Root 2 stopgap).
+            from brain.memory.pending import PendingQueue
+
+            reflex_mems = PendingQueue(self.store.persona_dir).read_recent("reflex_journal", limit=1)
+            if not reflex_mems:
+                reflex_mems = self.store.list_by_type(
+                    "reflex_journal", active_only=True, limit=1
+                )
             if reflex_mems:
                 mem = reflex_mems[0]
                 dominant_emotion, intensity = self._peak_emotion(mem.emotions)
@@ -1011,7 +1053,14 @@ class HeartbeatEngine:
         to a synthetic entry keyed on the topic string if none is found.
         """
         try:
-            research_mems = self.store.list_by_type("research", active_only=True, limit=1)
+            # research is a GATED type — the just-fired research memory is in the
+            # pending queue, not memories.db. Read it there (fall back to store).
+            # TEMP (Root 2 stopgap).
+            from brain.memory.pending import PendingQueue
+
+            research_mems = PendingQueue(self.store.persona_dir).read_recent("research", limit=1)
+            if not research_mems:
+                research_mems = self.store.list_by_type("research", active_only=True, limit=1)
             if research_mems:
                 mem = research_mems[0]
                 dominant_emotion, intensity = self._peak_emotion(mem.emotions)

--- a/brain/engines/reflex.py
+++ b/brain/engines/reflex.py
@@ -459,7 +459,12 @@ class ReflexEngine:
                 "provider": self.provider.name(),
             },
         )
-        self.store.create(mem)
+        from brain.memory.pending import route_write
+
+        # route_write self-classifies by memory_type: a journal_entry arc output
+        # bypasses the gate (deliberate type → direct to memories.db); other arc
+        # output types are gated (enqueued).
+        route_write(self.store, mem, source="reflex")
 
         # Spec §3.4: when reflex fires a journal-shaped arc, emit
         # journal_entry_added to behavioral_log so the brain sees the trajectory.

--- a/brain/engines/research.py
+++ b/brain/engines/research.py
@@ -324,7 +324,9 @@ class ResearchEngine:
                         provider_name=self.provider.name(),
                         searcher_name=self.searcher.name() if web_used else None,
                     )
-                    self.store.create(mem)
+                    from brain.memory.pending import route_write
+
+                    route_write(self.store, mem, source="research")
                     mem_id = mem.id
                 except Exception as exc:
                     logger.warning("research memory create failed for %r: %s", winner.id, exc)

--- a/brain/files/commit.py
+++ b/brain/files/commit.py
@@ -21,14 +21,16 @@ def _wire_memory(store, *, path: str, outcome: str) -> None:
     else:
         content = f"you declined my write to {path}"  # no file content stored
     try:
-        store.create(
-            Memory.create_new(
-                content=content,
-                memory_type="file_write",
-                domain="interior",
-                tags=["file_write", outcome],
-            )
+        mem = Memory.create_new(
+            content=content,
+            memory_type="file_write",
+            domain="interior",
+            tags=["file_write", outcome],
         )
+        # Automatic generated write → route through the consolidation gate (gated by memory_type).
+        from brain.memory.pending import route_write
+
+        route_write(store, mem, source="file_write")
     except Exception:
         logger.exception("file_write wire-back memory failed")
 

--- a/brain/forgetting/recall.py
+++ b/brain/forgetting/recall.py
@@ -9,18 +9,30 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from brain.forgetting import graveyard
+from brain.memory.relevance import rank_memories
 from brain.memory.store import Memory, MemoryStore
+
+if TYPE_CHECKING:
+    from brain.memory.hebbian import HebbianMatrix
 
 
 @dataclass(frozen=True)
 class SearchResult:
-    """Partitioned search results: active, fading, and lost memories."""
+    """Partitioned search results: active, fading, and lost memories.
+
+    ``scores`` maps a surfaced memory id → its blended relevance score (P2).
+    Unranked ids (ranking disabled) are omitted so the recall-block merge can
+    fall back to ``(-importance, -ts)`` for them. ``active``/``fading`` stay
+    ``list[Memory]`` — the field defaults empty, so existing shape holds.
+    """
 
     active: list[Memory] = field(default_factory=list)
     fading: list[Memory] = field(default_factory=list)
     lost: list[dict] = field(default_factory=list)
+    scores: dict[str, float] = field(default_factory=dict)
 
 
 def search_with_loss(
@@ -29,24 +41,30 @@ def search_with_loss(
     query: str,
     *,
     limit: int = 5,
+    hebbian: HebbianMatrix | None = None,
 ) -> SearchResult:
-    """Partitioned search: active + fading via MemoryStore, lost via graveyard.
+    """Partitioned search: active + fading via ranked retrieval, lost via graveyard.
 
     Args:
         persona_dir: Path to the persona directory (for graveyard access).
         store: MemoryStore instance for active/fading memory queries.
         query: Search query string.
         limit: Maximum results per bucket.
+        hebbian: Optional HebbianMatrix — **forwarded** to rank_memories (this
+            function never opens one; the caller owns its lifecycle). None →
+            the hebbian ranking term is 0.
 
     Returns:
-        SearchResult with active, fading, and lost lists partitioned by state.
+        SearchResult with active, fading, and lost lists partitioned by state,
+        plus a ``scores`` map of relevance scores (bump-free retrieval).
     """
     if not query:
         return SearchResult()
 
-    rows = store.search_text(query, include_fading=True, limit=limit)
-    active = [r for r in rows if r.state == "active"]
-    fading = [r for r in rows if r.state == "fading"]
+    ranked = rank_memories(store, hebbian, query, limit=limit, include_fading=True)
+    active = [m for m, _ in ranked if m.state == "active"]
+    fading = [m for m, _ in ranked if m.state == "fading"]
+    scores = {m.id: s for m, s in ranked if s is not None}
     lost = graveyard.search(persona_dir, query, limit=limit)
 
-    return SearchResult(active=active, fading=fading, lost=lost)
+    return SearchResult(active=active, fading=fading, lost=lost, scores=scores)

--- a/brain/ingest/commit.py
+++ b/brain/ingest/commit.py
@@ -66,7 +66,11 @@ def commit_item(
             emotions=dict(item.emotions) if item.emotions else {},
             metadata=metadata,
         )
-        new_id = store.create(memory)
+        from brain.memory.pending import route_write
+
+        # route_write self-classifies by item.label (variable memory_type):
+        # a gated label enqueues; a bypass label writes direct.
+        new_id = route_write(store, memory, source="ingest")
     except Exception as exc:  # noqa: BLE001
         logger.warning("commit_item: store.create failed: %s", exc)
         return None
@@ -75,6 +79,16 @@ def commit_item(
     # We use the longest meaningful word from the text as a keyword query so
     # that store.search_text (a LIKE substring match) has a realistic chance of
     # hitting overlapping memories without requiring the full phrase to match.
+    #
+    # SKIP for a GATED item: a gated label was enqueued as a candidate, not
+    # written to memories.db, so new_id is not a real row — linking to it would
+    # create a dangling hebbian edge (endpoints must resolve to a memories.db
+    # row). Auto-linking for gated content is deferred to the consolidation
+    # gate (which seeds weight-5 edges for corrections/continuations on promote).
+    from brain.memory.pending import GATE_BYPASS_TYPES
+
+    if item.label not in GATE_BYPASS_TYPES:
+        return new_id
     try:
         words = [w for w in item.text.split() if len(w) > 4]
         keyword = words[0] if words else item.text[:20]

--- a/brain/initiate/memory.py
+++ b/brain/initiate/memory.py
@@ -153,7 +153,12 @@ def write_initiate_memory(
         emotions=_emotions,
     )
     try:
-        memory_store.create(memory)
+        from brain.memory.pending import route_write
+
+        # initiate_outbound is a gate-bypass type (its own dedup at
+        # list_by_type needs immediate memories.db visibility) → route_write
+        # writes it directly. Routed for uniformity/self-classification.
+        route_write(memory_store, memory, source="initiate")
     except Exception as exc:
         logger.warning("initiate memory create failed for %s: %s", audit_id, exc)
 

--- a/brain/maker/wiring.py
+++ b/brain/maker/wiring.py
@@ -66,6 +66,9 @@ def write_making_memory(store, making: Making, *, emotions: dict[str, float]) ->
         tags=["making", making.disposition], emotions=emotions or None,
     )
     try:
-        store.create(mem)
+        # Automatic generated write → route through the consolidation gate (gated by memory_type).
+        from brain.memory.pending import route_write
+
+        route_write(store, mem, source="maker")
     except Exception:
         logger.exception("maker: act-memory write failed")

--- a/brain/memory/hebbian.py
+++ b/brain/memory/hebbian.py
@@ -45,21 +45,25 @@ class HebbianMatrix:
     CREATE INDEX IF NOT EXISTS idx_hebbian_b ON hebbian_edges(memory_b);
     """
 
-    def __init__(self, db_path: str | Path) -> None:
+    def __init__(self, db_path: str | Path, *, integrity_check: bool = True) -> None:
         self._conn = sqlite3.connect(str(db_path))
-        try:
-            result = self._conn.execute("PRAGMA integrity_check").fetchall()
-        except sqlite3.DatabaseError as exc:
-            self._conn.close()
-            from brain.health.anomaly import BrainIntegrityError
+        # Mirrors MemoryStore: hot per-turn openers (the recall-path single
+        # open in _build_recall_block) pass integrity_check=False to skip the
+        # full-DB PRAGMA integrity_check and take a lightweight WAL open.
+        if integrity_check:
+            try:
+                result = self._conn.execute("PRAGMA integrity_check").fetchall()
+            except sqlite3.DatabaseError as exc:
+                self._conn.close()
+                from brain.health.anomaly import BrainIntegrityError
 
-            raise BrainIntegrityError(str(db_path), str(exc)) from exc
-        if result != [("ok",)]:
-            detail = "; ".join(str(row[0]) for row in result)
-            self._conn.close()
-            from brain.health.anomaly import BrainIntegrityError
+                raise BrainIntegrityError(str(db_path), str(exc)) from exc
+            if result != [("ok",)]:
+                detail = "; ".join(str(row[0]) for row in result)
+                self._conn.close()
+                from brain.health.anomaly import BrainIntegrityError
 
-            raise BrainIntegrityError(str(db_path), detail)
+                raise BrainIntegrityError(str(db_path), detail)
         # WAL + 5s busy_timeout — set AFTER the integrity check so a
         # corrupt-file probe surfaces BrainIntegrityError, not a pragma
         # crash. In-memory dbs reject WAL; fallback keeps `:memory:` ok.

--- a/brain/memory/hebbian.py
+++ b/brain/memory/hebbian.py
@@ -180,6 +180,36 @@ class HebbianMatrix:
         self._conn.commit()
         return cur.rowcount > 0
 
+    def set_edge_weight(self, a: str, b: str, weight: float) -> None:
+        """Set edge (a, b) to at least `weight` (capped at MAX_WEIGHT).
+
+        UPSERT to MAX(existing, weight): a fresh pair is inserted at `weight`;
+        an existing weaker edge is raised to `weight`; an existing stronger
+        edge is left alone. Unlike ``ensure_edge`` (which no-ops on any
+        existing edge) and ``strengthen`` (which *adds* a delta), this lands
+        the edge at a specific floor regardless of prior state — used by the
+        consolidation gate to seed correction/continuation links at weight 5
+        even over a pre-existing ~0.5 co-activation edge. Self-edges are
+        ignored. `weight` must be positive.
+        """
+        if a == b:
+            return
+        if weight <= 0.0:
+            raise ValueError(f"weight must be positive, got {weight!r}")
+        capped = min(weight, MAX_WEIGHT)
+        lo, hi = _canonical(a, b)
+        self._conn.execute(
+            """
+            INSERT INTO hebbian_edges (memory_a, memory_b, weight)
+            VALUES (?, ?, ?)
+            ON CONFLICT(memory_a, memory_b)
+                DO UPDATE SET weight = MAX(weight, excluded.weight),
+                              last_strengthened_at = CURRENT_TIMESTAMP
+            """,
+            (lo, hi, capped),
+        )
+        self._conn.commit()
+
     def activation_count(self, memory_id: str) -> int:
         """Return the count of edges incident on this memory id."""
         row = self._conn.execute(

--- a/brain/memory/pending.py
+++ b/brain/memory/pending.py
@@ -45,7 +45,17 @@ _QUEUE_FILENAME = "pending_candidates.jsonl"
 # an unknown automatic type (delayed/vetted, recoverable) rather than leak it into
 # recall. Owner-confirmed BROAD scope (Roy, 2026-08-11): only journal_entry and
 # initiate_outbound bypass.
-GATE_BYPASS_TYPES: frozenset[str] = frozenset({"journal_entry", "initiate_outbound"})
+#
+# monologue_emotion / self_model_reconcile bypass the consolidation gate so
+# per-turn emotional nudges affect felt state immediately (aggregate_state pools
+# their emotion vectors) rather than waiting for consolidation promotion.
+# Trade-off: these are recallable auto-generated memories, so they enter recall
+# without gate review. If the memory-flood / low-value-recall problem (ROOT2)
+# resurfaces, THIS bypass is the first place to look. Revisit when the dream
+# cycle replaces this interim gate.
+GATE_BYPASS_TYPES: frozenset[str] = frozenset(
+    {"journal_entry", "initiate_outbound", "monologue_emotion", "self_model_reconcile"}
+)
 
 # Only these monologue-EPISODE types are eligible for the Pass-1 salience drop —
 # they carry a real 0..10 importance signal (extractor sets importance=salience*10).

--- a/brain/memory/pending.py
+++ b/brain/memory/pending.py
@@ -1,0 +1,134 @@
+"""Pending-candidate queue — a separate store OUTSIDE memories.db.
+
+TEMP (Root 2 stopgap — remove when the Phase 5 dream cycle lands to replace it).
+
+Automatically-generated ("firehose") memories are ENQUEUED here as *candidates*
+rather than written straight into ``memories.db``. A candidate is **not a stored
+memory**: it never appears in recall, forgetting, hebbian, or the graveyard. On
+the idle heartbeat tick the consolidation gate (``brain.engines.consolidation``)
+drains this queue and, per candidate, discards it (reject), ``store.create``s it
+(promote), or folds it into an existing memory (merge). Because a rejected
+candidate was never a ``memories.db`` row, none of the main-DB machinery
+(grief/forgetting/hebbian) ever applies to it.
+
+Backing store: ``<persona_dir>/pending_candidates.jsonl``, guarded by the same
+``file_lock`` pattern used for ``soul_candidates.jsonl`` (see brain/soul/review.py)
+so a concurrent enqueue is never lost across a drain's read-modify-truncate.
+
+Write routing (``route_write``) keys on ``memory_type``, NOT the call site: a
+type is gated (enqueued) unless it is in ``GATE_BYPASS_TYPES``. This is robust to
+the two variable-typed writers (a reflex arc's ``arc.output_memory_type`` — one
+value is the *deliberate* ``journal_entry`` — and conversation-ingest's
+``item.label``): each row self-classifies by its own type. ``journal_entry``
+(deliberate; feeds the weekly self-narrative) and ``initiate_outbound`` (its own
+dedup needs immediate DB visibility) bypass the gate and commit directly.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import UTC, datetime
+from pathlib import Path
+
+from brain.health.jsonl_reader import read_jsonl_skipping_corrupt
+from brain.memory.store import Memory, MemoryStore
+from brain.utils.file_lock import file_lock
+
+logger = logging.getLogger(__name__)
+
+_QUEUE_FILENAME = "pending_candidates.jsonl"
+
+# Types that BYPASS the gate and are written straight to memories.db. Everything
+# else produced at an automatic write site is enqueued. Denylist (not allowlist)
+# because reflex arc output types are open-ended; fail-safe direction is to gate
+# an unknown automatic type (delayed/vetted, recoverable) rather than leak it into
+# recall. Owner-confirmed BROAD scope (Roy, 2026-08-11): only journal_entry and
+# initiate_outbound bypass.
+GATE_BYPASS_TYPES: frozenset[str] = frozenset({"journal_entry", "initiate_outbound"})
+
+# Only these monologue-EPISODE types are eligible for the Pass-1 salience drop —
+# they carry a real 0..10 importance signal (extractor sets importance=salience*10).
+# Dreams (importance auto-derives to ~0 when emotion-flat), research/heartbeat/
+# reflex/initiate (same emotion-derived default), and monologue_trace (pinned 0.3)
+# are EXEMPT: they go through dedup only, never salience-drop. Owner directive
+# (Roy, 2026-08-11) — a single flat floor would nuke legitimate flat content.
+SALIENCE_ELIGIBLE_TYPES: frozenset[str] = frozenset(
+    {"monologue", "monologue_emotion", "monologue_soul_candidate"}
+)
+
+
+class PendingQueue:
+    """Append-only JSONL queue of pending candidates for one persona."""
+
+    def __init__(self, persona_dir: str | Path) -> None:
+        self.path = Path(persona_dir) / _QUEUE_FILENAME
+
+    def enqueue(self, mem: Memory, *, source: str) -> None:
+        """Append a candidate (the Memory serialised + provenance) under lock."""
+        entry = {
+            **mem.to_dict(),
+            "_source": source,
+            "_enqueued_at": datetime.now(UTC).isoformat(),
+        }
+        line = json.dumps(entry, ensure_ascii=False)
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        with file_lock(self.path):
+            with open(self.path, "a", encoding="utf-8") as fh:
+                fh.write(line + "\n")
+
+    def read_recent(self, memory_type: str, *, limit: int) -> list[Memory]:
+        """Return up to `limit` most-recent candidates of `memory_type`.
+
+        Lock-free read (tolerates a partial last line from a concurrent
+        append via ``read_jsonl_skipping_corrupt``). Newest first — entries
+        are appended oldest→newest, so reversed order is most-recent-first.
+        Used by interior-continuity (a DIFFERENT path from recall); returns
+        ``Memory`` objects for interface parity with ``store.list_by_type``.
+        """
+        if limit <= 0 or not self.path.exists():
+            return []
+        rows = read_jsonl_skipping_corrupt(self.path)
+        out: list[Memory] = []
+        for entry in reversed(rows):
+            if entry.get("memory_type") != memory_type:
+                continue
+            try:
+                out.append(Memory.from_dict(entry))
+            except (KeyError, ValueError, TypeError):
+                continue
+            if len(out) >= limit:
+                break
+        return out
+
+    def drain(self) -> list[dict]:
+        """Atomically take the whole queue: read all entries, then truncate.
+
+        Held under ``file_lock`` over the read+truncate window (the proven
+        soul-candidate pattern) so a candidate enqueued concurrently lands
+        either in this batch or in the emptied file (next tick) — never lost.
+        The lock is released before the (slow) gate processing runs on the
+        returned batch. Returns raw dicts (carrying ``_source``/``_enqueued_at``);
+        the gate reconstructs ``Memory.from_dict`` for promotion.
+        """
+        if not self.path.exists():
+            return []
+        with file_lock(self.path):
+            rows = read_jsonl_skipping_corrupt(self.path)
+            # Truncate the data file in place (the lock sidecar is separate).
+            open(self.path, "w", encoding="utf-8").close()
+        return rows
+
+
+def route_write(store: MemoryStore, mem: Memory, *, source: str) -> str:
+    """Route an automatic write by memory_type: enqueue if gated, else create.
+
+    A gated type (anything not in ``GATE_BYPASS_TYPES``) is enqueued as a
+    candidate; a bypass type is written straight to ``memories.db``. Locates the
+    persona's queue via ``store.persona_dir`` so callers need only the store +
+    the Memory they already hold. Returns ``mem.id`` (matching ``store.create``).
+    """
+    if mem.memory_type in GATE_BYPASS_TYPES:
+        return store.create(mem)
+    PendingQueue(store.persona_dir).enqueue(mem, source=source)
+    return mem.id

--- a/brain/memory/relevance.py
+++ b/brain/memory/relevance.py
@@ -1,0 +1,172 @@
+"""relevance.py — cross-DB relevance ranking over the committed memory pool.
+
+Blends four signals into a single 0..1-normalized score:
+
+    score = W_MATCH·bm25 + W_IMP·importance + W_HEB·hebbian-activation + W_REC·recency
+
+The blend spans two databases — ``memories.db`` (BM25 text-match, importance,
+recency) and ``hebbian.db`` (spreading activation) — so it lives here rather
+than in ``store.py`` (the pure ``memories.db`` layer, which has no handle on
+``HebbianMatrix``). ``store.py`` owns only the FTS5 primitives.
+
+P2 (memory relevance overhaul). The weight/decay consts are documented defaults;
+tuning is deferred to #129. Also the single home for the snippet-then-read
+render consts (imported by ``brain.chat.prompt`` and the search tools) so the
+values live in one place.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+    from brain.memory.hebbian import HebbianMatrix
+    from brain.memory.store import Memory, MemoryStore
+
+# --- ranking weights (applied to 0..1-normalized signals; tuning → #129) -----
+# Reasoned ordering: BM25 text-match is the primary relevance signal; importance
+# a strong secondary; hebbian "related-to-now" and recency are tie-breakers.
+W_MATCH = 1.0
+W_IMP = 0.5
+W_HEB = 0.3
+W_REC = 0.2
+
+# recency decay: recency = 0.5 ** (age_days / RECENCY_HALFLIFE_DAYS)
+RECENCY_HALFLIFE_DAYS = 30
+
+# hebbian spreading-activation seed/traversal (spec §6.2). Seeded from this
+# turn's top BM25 ids — the memories the current input is textually about.
+HEB_SEED_COUNT = 5
+HEB_DEPTH = 2
+HEB_DECAY_PER_HOP = 0.5
+
+# Candidate pool pulled from FTS before ranking — wider than the render limit so
+# the ranker has something to reorder. A named const, sibling to
+# `_RECALL_TOKEN_LIMIT`.
+CANDIDATE_POOL = 50
+
+# Flag: when False, falls back to recency-only `search_text` (score None).
+RELEVANCE_RANKING_ENABLED = True
+
+# --- snippet-then-read render consts (one home; imported by prompt + tools) ---
+SNIPPET_COUNT = 8  # up from 5 — snippets are cheap
+SNIPPET_MAX_CHARS = 140  # unchanged from the current recall truncation
+SNIPPET_MIN_CHARS = 20  # floor so 20% of a tiny memory isn't a useless fragment
+FULL_INJECT_IMPORTANCE = 9.0  # a genuinely important memory is never gated behind a read-call
+FULL_INJECT_MAX = 3  # at most this many full-injects (bounds volatile-tail growth)
+SNIPPET_MODE_ENABLED = True  # when False, falls back to the current full-body render
+
+
+def snippet_length(body_len: int) -> int:
+    """Proportional snippet length: ~20% of the body, floored and capped.
+
+    ``min(max(SNIPPET_MIN_CHARS, body_len // 5), SNIPPET_MAX_CHARS)`` — keeps
+    even short memories withholding ~80% of their content (so a follow-up
+    ``read_full_memory`` still adds real text), while a long memory still
+    caps at ``SNIPPET_MAX_CHARS``. A body at or below the floor shows in
+    full rather than shrinking to a useless fragment.
+    """
+    return min(max(SNIPPET_MIN_CHARS, body_len // 5), SNIPPET_MAX_CHARS)
+
+# The recall-path hebbian open degrades to None (w_heb=0) on any open/query error.
+HEB_OPEN_FAILSOFT = True
+
+
+def _clamp01(value: float) -> float:
+    if value < 0.0:
+        return 0.0
+    if value > 1.0:
+        return 1.0
+    return float(value)
+
+
+def _created_ts(mem: Memory) -> float:
+    try:
+        return mem.created_at.timestamp()
+    except Exception:  # noqa: BLE001 — defensive; tie-break only
+        return 0.0
+
+
+def rank_memories(
+    store: MemoryStore,
+    hebbian: HebbianMatrix | None,
+    query: str,
+    *,
+    limit: int,
+    exclude_ids: Iterable[str] = frozenset(),
+    active_only: bool = True,
+    include_fading: bool = True,
+) -> list[tuple[Memory, float | None]]:
+    """Rank committed memories by blended relevance — bump-free, best→worst.
+
+    Returns ``(memory, blended_score)`` pairs. The score is ``None`` when
+    ranking is disabled (an *unranked* sentinel — callers then fall back to
+    ``(-importance, -ts)``; distinct from a real 0.0 blended score).
+
+    ``rank_memories`` NEVER opens a ``HebbianMatrix``: ``hebbian`` is supplied by
+    the caller (or ``None``, which zeroes the ``w_heb`` term). This makes the
+    "opens N× per turn" defect structurally impossible.
+    """
+    exclude = frozenset(exclude_ids)
+
+    if not RELEVANCE_RANKING_ENABLED:
+        # Recency-only fallback. None signals "unranked". Exclusion is applied
+        # BEFORE the final limit (mirroring the ranked path): fetch a wider pool,
+        # drop excluded ids, THEN slice — so an excluded id inside the top-`limit`
+        # matches backfills from the next candidate instead of shrinking the
+        # result (stage-6 minor).
+        fallback = store.search_text(
+            query,
+            active_only=active_only,
+            include_fading=include_fading,
+            bump=False,
+            limit=(limit + len(exclude)) if limit is not None else None,
+        )
+        kept = [(m, None) for m in fallback if m.id not in exclude]
+        return kept[:limit] if limit is not None else kept
+
+    scored = store.search_fts_scored(
+        query,
+        active_only=active_only,
+        include_fading=include_fading,
+        bump=False,
+        limit=CANDIDATE_POOL,
+    )
+    if not scored:
+        return []
+
+    # Hebbian spreading activation seeded from this turn's top BM25 ids.
+    activation: dict[str, float] = {}
+    if hebbian is not None:
+        seeds = [m.id for m, _ in scored[:HEB_SEED_COUNT]]
+        try:
+            activation = hebbian.spreading_activation(seeds, HEB_DEPTH, HEB_DECAY_PER_HOP)
+        except Exception:  # noqa: BLE001 — hebbian is a tie-breaker, never fatal
+            activation = {}
+
+    # bm25 min-max over the pool, inverted so higher = better match.
+    bm_values = [bm for _, bm in scored]
+    bm_min, bm_max = min(bm_values), max(bm_values)
+    bm_span = bm_max - bm_min
+
+    now = datetime.now(UTC)
+    ranked: list[tuple[Memory, float]] = []
+    for mem, bm in scored:
+        if mem.id in exclude:
+            continue
+        # Single-candidate set (bm_span == 0) → 1.0, no divide-by-zero.
+        m_norm = 1.0 if bm_span == 0 else (bm_max - bm) / bm_span
+        i_norm = _clamp01(mem.importance / 10.0)
+        h_norm = _clamp01(activation.get(mem.id, 0.0))
+        age_days = max(0.0, (now - mem.created_at).total_seconds() / 86400.0)
+        r_norm = 0.5 ** (age_days / RECENCY_HALFLIFE_DAYS)
+        score = W_MATCH * m_norm + W_IMP * i_norm + W_HEB * h_norm + W_REC * r_norm
+        ranked.append((mem, score))
+
+    # P3: filter superseded here  (no-op today — forward-compat seam, spec §6.8)
+
+    ranked.sort(key=lambda pair: (-pair[1], -_created_ts(pair[0])))
+    return [(mem, score) for mem, score in ranked[:limit]]

--- a/brain/memory/store.py
+++ b/brain/memory/store.py
@@ -13,6 +13,8 @@ from __future__ import annotations
 
 import json
 import logging
+import math
+import re
 import sqlite3
 import uuid
 from dataclasses import dataclass, field
@@ -91,7 +93,7 @@ class Memory:
     metadata: dict[str, Any] = field(default_factory=dict)
     state: str = "active"
     content_snapshot: str | None = None
-    recall_count: int = 0
+    recall_count: float = 0.0
     peak_emotion_intensity: float = 0.0
 
     @classmethod
@@ -195,7 +197,7 @@ CREATE TABLE IF NOT EXISTS memories (
     metadata_json TEXT NOT NULL DEFAULT '{}',
     state TEXT NOT NULL DEFAULT 'active',
     content_snapshot TEXT,
-    recall_count INTEGER NOT NULL DEFAULT 0,
+    recall_count REAL NOT NULL DEFAULT 0,
     peak_emotion_intensity REAL NOT NULL DEFAULT 0.0
 );
 
@@ -203,10 +205,92 @@ CREATE INDEX IF NOT EXISTS idx_memories_domain ON memories(domain);
 CREATE INDEX IF NOT EXISTS idx_memories_type ON memories(memory_type);
 CREATE INDEX IF NOT EXISTS idx_memories_active ON memories(active);
 CREATE INDEX IF NOT EXISTS idx_memories_created ON memories(created_at);
+
+-- External-content FTS5 shadow index (P2 relevance overhaul). `memories` is a
+-- rowid table (id TEXT PRIMARY KEY → implicit integer rowid), so external
+-- content with content_rowid='rowid' indexes only `content` (no duplication).
+CREATE VIRTUAL TABLE IF NOT EXISTS memories_fts USING fts5(
+    content, content='memories', content_rowid='rowid'
+);
+
+-- Tier-1 passive-recall salience: zero-dependency corpus IDF straight from
+-- SQLite's own fts5vocab shadow of memories_fts ('row' mode → one row per
+-- term with its document frequency in column `doc`). Virtual/read-only (no
+-- storage, no write path); must be created AFTER memories_fts since it
+-- indexes that table's content.
+CREATE VIRTUAL TABLE IF NOT EXISTS memories_vocab USING fts5vocab('memories_fts', 'row');
+
+-- Schema-level sync triggers: they live in the DB and fire on WHICHEVER
+-- connection performs the write, so every one of the ~15 MemoryStore
+-- connections maintains the index atomically within its own transaction.
+CREATE TRIGGER IF NOT EXISTS memories_fts_ai AFTER INSERT ON memories BEGIN
+    INSERT INTO memories_fts(rowid, content) VALUES (new.rowid, new.content);
+END;
+CREATE TRIGGER IF NOT EXISTS memories_fts_ad AFTER DELETE ON memories BEGIN
+    INSERT INTO memories_fts(memories_fts, rowid, content)
+        VALUES ('delete', old.rowid, old.content);
+END;
+CREATE TRIGGER IF NOT EXISTS memories_fts_au AFTER UPDATE OF content ON memories BEGIN
+    INSERT INTO memories_fts(memories_fts, rowid, content)
+        VALUES ('delete', old.rowid, old.content);
+    INSERT INTO memories_fts(rowid, content) VALUES (new.rowid, new.content);
+END;
 """
 
 
 _ALLOWED_FILTER_COLUMNS = frozenset({"domain", "memory_type"})
+
+# Minimum token length fed into the FTS5 MATCH sanitizer. Default 3 keeps short
+# proper-ish terms while still dropping the shortest stopword-shaped fragments;
+# every term is double-quoted anyway, so a token colliding with an FTS keyword
+# (AND/OR/NOT/NEAR) is treated as a literal string, not an operator. Sibling to
+# the recall/tool tokenizers' min_len=4.
+_FTS_TOKEN_MIN_LEN = 3
+
+
+def _to_fts_match(query: str) -> str:
+    """Build an FTS5 MATCH expression from a raw query string.
+
+    Tokenizes (split on ``[^A-Za-z0-9]+``, drop tokens shorter than
+    ``_FTS_TOKEN_MIN_LEN``, dedup case-insensitively) and **OR-joins each term
+    wrapped in double-quotes** — e.g. ``'"henryk" OR "preferences"'``.
+
+    The OR is mandatory, not cosmetic: FTS5's default bare-term MATCH is an
+    implicit AND, so a disjoint multi-term query would return ZERO rows. The
+    double-quoting makes each term a literal FTS string, immune to a token that
+    collides with an FTS keyword (AND/OR/NOT/NEAR) or a special char.
+
+    Returns ``""`` when the query yields no usable tokens (caller returns no
+    matches rather than issuing a MATCH).
+    """
+    seen: set[str] = set()
+    terms: list[str] = []
+    for piece in re.split(r"[^A-Za-z0-9]+", query):
+        if len(piece) < _FTS_TOKEN_MIN_LEN:
+            continue
+        low = piece.lower()
+        if low in seen:
+            continue
+        seen.add(low)
+        terms.append(f'"{piece}"')
+    return " OR ".join(terms)
+
+
+def _bump_amount(bump: bool | float) -> float | None:
+    """Normalize a ``bump`` kwarg (bool | float) to a concrete increment.
+
+    ``True`` -> 1.0 (the genuine full-read amount); ``False`` -> ``None`` (no
+    bump); a positive float -> that amount (the passive-recall fractional bump).
+    A zero amount (``0``, ``0.0``, or ``False``) -> ``None``: it is a no-op, not
+    a real bump. Returning 0.0 would still fire a ``recall_count + 0.0`` UPDATE
+    (and, on the ``get()`` path, reset ``last_accessed_at``) for no
+    reinforcement. Shared by every ``recall_count`` writer so the bool/float
+    widening stays in one place.
+    """
+    if isinstance(bump, bool):
+        return 1.0 if bump else None
+    amount = float(bump)
+    return amount if amount != 0.0 else None
 
 
 class MemoryStore:
@@ -262,7 +346,7 @@ class MemoryStore:
             self._conn.execute("ALTER TABLE memories ADD COLUMN content_snapshot TEXT")
         if "recall_count" not in existing:
             self._conn.execute(
-                "ALTER TABLE memories ADD COLUMN recall_count INTEGER NOT NULL DEFAULT 0"
+                "ALTER TABLE memories ADD COLUMN recall_count REAL NOT NULL DEFAULT 0"
             )
         if "peak_emotion_intensity" not in existing:
             self._conn.execute(
@@ -298,6 +382,56 @@ class MemoryStore:
                     logger.warning("peak seeding skipped: %s", exc)
         # Index on state — used by forgetting pass to find fading rows fast.
         self._conn.execute("CREATE INDEX IF NOT EXISTS idx_memories_state ON memories(state)")
+        self._conn.commit()
+        self._boot_fts_backstop()
+
+    def _boot_fts_backstop(self) -> None:
+        """FTS5 boot integrity-check → rebuild backstop.
+
+        Runs on EVERY constructor, including ``integrity_check=False`` ones
+        (the hot/feed paths): this FTS check is separate from the ``memories.db``
+        ``PRAGMA integrity_check`` gated by that flag — it is a cheap
+        FTS-internal consistency probe, not a full-DB scan, and must run so a
+        feed-path writer never operates against a stale/absent FTS index.
+
+        Rebuilds when the shadow index is corrupt (integrity-check raises) OR
+        empty against a pre-populated ``memories`` table — which covers both a
+        persona whose ``memories.db`` predates FTS (the table was just created
+        against existing rows) and a cleared/corrupted index (C2 self-heal).
+        Fail-soft: a rebuild failure logs and leaves the LIKE fallback usable.
+        """
+        try:
+            self._conn.execute("INSERT INTO memories_fts(memories_fts) VALUES('integrity-check')")
+            healthy = True
+        except sqlite3.DatabaseError:
+            healthy = False
+        needs_rebuild = not healthy
+        if healthy:
+            try:
+                mem_rows = self._conn.execute("SELECT COUNT(*) FROM memories").fetchone()[0]
+                # COUNT(*) on the FTS table itself reads the external CONTENT
+                # table, not the index — use the `_docsize` shadow table for the
+                # true count of INDEXED rows so an empty index against a
+                # populated `memories` (predates-FTS, or a cleared index) is
+                # detected.
+                fts_rows = self._conn.execute(
+                    "SELECT COUNT(*) FROM memories_fts_docsize"
+                ).fetchone()[0]
+                # mem_rows != fts_rows catches BOTH the empty-index case
+                # (predates-FTS / cleared → fts_rows==0) AND partial staleness
+                # (0 < fts_rows < mem_rows) at no extra cost (stage-6 minor).
+                needs_rebuild = mem_rows != fts_rows
+            except sqlite3.DatabaseError:
+                needs_rebuild = True
+        if needs_rebuild:
+            try:
+                self._conn.execute("INSERT INTO memories_fts(memories_fts) VALUES('rebuild')")
+            except sqlite3.DatabaseError as exc:
+                logger.warning("memories_fts rebuild failed; LIKE fallback in use: %s", exc)
+        # The 'integrity-check'/'rebuild' commands are INSERT statements, so
+        # sqlite3 opens an implicit write transaction. Commit it unconditionally
+        # (even the read-only integrity-check path) so no boot leaves a lock held
+        # against the other ~15 concurrent MemoryStore connections to this file.
         self._conn.commit()
 
     def close(self) -> None:
@@ -359,21 +493,52 @@ class MemoryStore:
         self._conn.commit()
         return memory.id
 
-    def get(self, memory_id: str) -> Memory | None:
+    def get(self, memory_id: str, *, bump: bool | float = True) -> Memory | None:
         """Return the Memory with the given id, or None. Bumps
         last_accessed_at + recall_count on hit so salience scoring sees
         the access (Forgetting integration — spec v0.0.14-alpha.3).
+
+        bump: when True (default), a hit updates recall_count (+1.0) and
+        last_accessed_at — the correct behaviour for a genuine full-read.
+        False skips the bump entirely — internal existence-checks (e.g.
+        update()/deactivate()'s pre-write lookup) pass ``bump=False`` so a
+        maintenance write doesn't count as engagement. A float bumps
+        recall_count by that amount instead of 1.0 (also touching
+        last_accessed_at — this is a genuine-access path, unlike
+        ``bump_recall``).
         """
         row = self._conn.execute("SELECT * FROM memories WHERE id = ?", (memory_id,)).fetchone()
         if row is None:
             return None
-        now_iso = datetime.now(UTC).isoformat()
+        amount = _bump_amount(bump)
+        if amount is not None:
+            now_iso = datetime.now(UTC).isoformat()
+            self._conn.execute(
+                "UPDATE memories SET recall_count = recall_count + ?, last_accessed_at = ? "
+                "WHERE id = ?",
+                (amount, now_iso, memory_id),
+            )
+            self._conn.commit()
+        return _row_to_memory(row)
+
+    def bump_recall(self, memory_id: str, amount: float) -> None:
+        """Fractional ``recall_count`` bump for the passive-recall surface path.
+
+        A single atomic ``UPDATE`` incrementing ``recall_count`` ONLY — this
+        deliberately does NOT touch ``last_accessed_at``. A per-turn ambient
+        surface is not a genuine "access event" the way a full read is;
+        resetting the freshness anchor at full strength for every surfaced
+        memory (including the rank-bottom ~0.1 one) would give an
+        un-discounted freshness boost, defeating the rank-discount rationale
+        (``salience.py``'s freshness arm anchors on ``last_accessed_at``).
+        Callers already hold the ``Memory`` objects (``_build_recall_block``),
+        so this does not re-``get()`` each surfaced memory.
+        """
         self._conn.execute(
-            "UPDATE memories SET recall_count = recall_count + 1, last_accessed_at = ? WHERE id = ?",
-            (now_iso, memory_id),
+            "UPDATE memories SET recall_count = recall_count + ? WHERE id = ?",
+            (amount, memory_id),
         )
         self._conn.commit()
-        return _row_to_memory(row)
 
     def list_by_domain(
         self, domain: str, active_only: bool = True, limit: int | None = None
@@ -419,7 +584,7 @@ class MemoryStore:
 
         Raises KeyError if memory_id does not exist.
         """
-        if self.get(memory_id) is None:
+        if self.get(memory_id, bump=False) is None:
             raise KeyError(f"Unknown memory id: {memory_id!r}")
 
         column_map: dict[str, tuple[str, Any]] = {}
@@ -468,7 +633,7 @@ class MemoryStore:
 
     def deactivate(self, memory_id: str) -> None:
         """Mark a memory inactive (F22 semantics). Raises KeyError if unknown."""
-        if self.get(memory_id) is None:
+        if self.get(memory_id, bump=False) is None:
             raise KeyError(f"Unknown memory id: {memory_id!r}")
         self._conn.execute("UPDATE memories SET active = 0 WHERE id = ?", (memory_id,))
         self._conn.commit()
@@ -530,6 +695,46 @@ class MemoryStore:
             sql += " WHERE active = 1"
         return int(self._conn.execute(sql).fetchone()[0])
 
+    def term_stats(self, terms: list[str]) -> dict[str, tuple[int, float]]:
+        """Return per-term document frequency + corpus IDF (Tier-1 recall salience).
+
+        Looks up ``doc`` (document frequency) for each (lowercased) term from
+        ``memories_vocab`` — the ``fts5vocab('memories_fts', 'row')`` shadow
+        table — and computes ``idf = log(N / (1 + df))`` where ``N`` is the
+        **all-indexed-docs** count (``SELECT count(*) FROM memories``). This
+        deliberately does NOT reuse :meth:`count`, whose ``active_only=True``
+        default would risk ``N < df`` and a negative IDF.
+
+        Returns ``{lowered_term: (df, idf)}`` for every requested term — a
+        term absent from the vocabulary gets ``df=0`` (present in the store's
+        vocabulary is exactly what "absent" means here; the caller treats
+        ``df=0`` as both lowest-recall-value and, in ``_build_recall_block``,
+        "not recognised"). Fail-soft: returns ``{}`` when the store is empty
+        (``N == 0``, so any IDF would be undefined) or on any sqlite error —
+        callers fall back to non-IDF, non-``in_store`` salience. Read-only:
+        no write, no recall_count bump.
+        """
+        if not terms:
+            return {}
+        lowered = [t.lower() for t in terms]
+        try:
+            n = int(self._conn.execute("SELECT count(*) FROM memories").fetchone()[0])
+            if n == 0:
+                return {}
+            placeholders = ",".join("?" * len(lowered))
+            rows = self._conn.execute(
+                f"SELECT term, doc FROM memories_vocab WHERE term IN ({placeholders})",
+                lowered,
+            ).fetchall()
+            df_by_term = {row["term"]: int(row["doc"]) for row in rows}
+        except sqlite3.Error:
+            return {}
+        stats: dict[str, tuple[int, float]] = {}
+        for term in lowered:
+            df = df_by_term.get(term, 0)
+            stats[term] = (df, math.log(n / (1 + df)))
+        return stats
+
     def search_text(
         self,
         query: str,
@@ -537,7 +742,7 @@ class MemoryStore:
         limit: int | None = None,
         include_fading: bool = True,
         *,
-        bump: bool = True,
+        bump: bool | float = True,
     ) -> list[Memory]:
         """Case-insensitive substring search on content.
 
@@ -550,11 +755,13 @@ class MemoryStore:
         When False, only active memories are returned. Set False on
         callers that need pre-Forgetting search semantics.
 
-        bump: when True (default), matched rows have recall_count and
+        bump: when True (default), matched rows have recall_count (+1.0) and
         last_accessed_at updated — the correct behaviour for a genuine
-        recall. The consolidation gate's internal dedup/context scans pass
-        ``bump=False`` so an evaluation read does not inflate committed-row
-        salience (which would perturb the forgetting pass).
+        recall. False skips the bump — the consolidation gate's internal
+        dedup/context scans pass ``bump=False`` so an evaluation read does
+        not inflate committed-row salience (which would perturb the
+        forgetting pass). A float bumps recall_count by that amount instead
+        of 1.0.
         """
         if query == "":
             raise ValueError("empty query passed to search_text; use list_active() instead")
@@ -570,16 +777,74 @@ class MemoryStore:
             sql += " LIMIT ?"
             params.append(limit)
         rows = self._conn.execute(sql, params).fetchall()
-        if rows and bump:
+        amount = _bump_amount(bump)
+        if rows and amount is not None:
             now_iso = datetime.now(UTC).isoformat()
             ids = [row["id"] for row in rows]
             placeholders = ",".join("?" * len(ids))
             self._conn.execute(
-                f"UPDATE memories SET recall_count = recall_count + 1, last_accessed_at = ? WHERE id IN ({placeholders})",
-                (now_iso, *ids),
+                f"UPDATE memories SET recall_count = recall_count + ?, last_accessed_at = ? "
+                f"WHERE id IN ({placeholders})",
+                (amount, now_iso, *ids),
             )
             self._conn.commit()
         return [_row_to_memory(row) for row in rows]
+
+    def search_fts_scored(
+        self,
+        query: str,
+        *,
+        active_only: bool = True,
+        include_fading: bool = True,
+        limit: int | None = None,
+        bump: bool | float = False,
+    ) -> list[tuple[Memory, float]]:
+        """FTS5/BM25 text-match search, best-match first.
+
+        Runs the sanitized query (``_to_fts_match``) as an FTS5 ``MATCH``,
+        joins back to ``memories``, and returns each Memory **with its raw
+        bm25 score** ordered by ``bm25(memories_fts)`` ascending (lower is a
+        better match). The ranker (:mod:`brain.memory.relevance`) inverts and
+        normalizes the score; it is surfaced here because the ranker needs it.
+
+        Applies the same ``active``/``state`` filters ``search_text`` does, so
+        an ``active_only`` caller gets no fading rows. ``bump`` defaults
+        **False** (surfacing must not inflate ``recall_count``); when True the
+        matched rows' ``recall_count`` (+1.0) / ``last_accessed_at`` are
+        bumped; a float bumps ``recall_count`` by that amount instead.
+
+        An empty/all-tokens-dropped query returns ``[]`` (no MATCH is issued).
+        """
+        match = _to_fts_match(query)
+        if not match:
+            return []
+        sql = (
+            "SELECT m.*, bm25(memories_fts) AS _bm25 "
+            "FROM memories_fts f JOIN memories m ON m.rowid = f.rowid "
+            "WHERE memories_fts MATCH ?"
+        )
+        params: list[Any] = [match]
+        if active_only:
+            sql += " AND m.active = 1"
+        if not include_fading:
+            sql += " AND m.state != 'fading'"
+        sql += " ORDER BY _bm25 ASC"
+        if limit is not None:
+            sql += " LIMIT ?"
+            params.append(limit)
+        rows = self._conn.execute(sql, params).fetchall()
+        amount = _bump_amount(bump)
+        if rows and amount is not None:
+            now_iso = datetime.now(UTC).isoformat()
+            ids = [row["id"] for row in rows]
+            placeholders = ",".join("?" * len(ids))
+            self._conn.execute(
+                f"UPDATE memories SET recall_count = recall_count + ?, "
+                f"last_accessed_at = ? WHERE id IN ({placeholders})",
+                (amount, now_iso, *ids),
+            )
+            self._conn.commit()
+        return [(_row_to_memory(row), float(row["_bm25"])) for row in rows]
 
     def list_active(self, limit: int | None = None) -> list[Memory]:
         """Return active memories ordered by created_at desc."""

--- a/brain/memory/store.py
+++ b/brain/memory/store.py
@@ -217,6 +217,7 @@ class MemoryStore:
     """
 
     def __init__(self, db_path: str | Path, *, integrity_check: bool = True) -> None:
+        self._db_path = Path(db_path)
         self._conn = sqlite3.connect(str(db_path))
         # Run integrity check BEFORE setting row_factory so result rows are
         # plain tuples — the comparison [("ok",)] is unambiguous. Hot request
@@ -302,6 +303,22 @@ class MemoryStore:
     def close(self) -> None:
         """Close the underlying connection. Safe to call multiple times."""
         self._conn.close()
+
+    @property
+    def db_path(self) -> Path:
+        """Filesystem path of the backing SQLite database (or ':memory:')."""
+        return self._db_path
+
+    @property
+    def persona_dir(self) -> Path:
+        """Persona directory containing this store — the parent of db_path.
+
+        Function-style writers use this to locate the sibling pending-candidate
+        queue (``pending_candidates.jsonl``) without threading persona_dir
+        through every call. Meaningless for an in-memory store (parent of
+        ':memory:'); such stores are test-only and never enqueue.
+        """
+        return self._db_path.parent
 
     def create(self, memory: Memory) -> str:
         """Insert a memory. Returns the id. Raises on duplicate id."""
@@ -519,6 +536,8 @@ class MemoryStore:
         active_only: bool = True,
         limit: int | None = None,
         include_fading: bool = True,
+        *,
+        bump: bool = True,
     ) -> list[Memory]:
         """Case-insensitive substring search on content.
 
@@ -530,6 +549,12 @@ class MemoryStore:
         results with their summary as content and state='fading'.
         When False, only active memories are returned. Set False on
         callers that need pre-Forgetting search semantics.
+
+        bump: when True (default), matched rows have recall_count and
+        last_accessed_at updated — the correct behaviour for a genuine
+        recall. The consolidation gate's internal dedup/context scans pass
+        ``bump=False`` so an evaluation read does not inflate committed-row
+        salience (which would perturb the forgetting pass).
         """
         if query == "":
             raise ValueError("empty query passed to search_text; use list_active() instead")
@@ -545,7 +570,7 @@ class MemoryStore:
             sql += " LIMIT ?"
             params.append(limit)
         rows = self._conn.execute(sql, params).fetchall()
-        if rows:
+        if rows and bump:
             now_iso = datetime.now(UTC).isoformat()
             ids = [row["id"] for row in rows]
             placeholders = ",".join("?" * len(ids))

--- a/brain/monologue/ambient.py
+++ b/brain/monologue/ambient.py
@@ -31,7 +31,15 @@ def build_interior_continuity_block(
     privacy footer is appended after capping so it can never be truncated
     (v0.0.33 Track 2a). Returns "" when there are none or on any error."""
     try:
-        traces = store.list_by_type(MONOLOGUE_TRACE_TYPE, active_only=True, limit=limit)
+        # monologue_trace is now GATED — traces live in the pending-candidate
+        # queue (not memories.db), so interior-continuity reads them there. The
+        # limit (_AMBIENT_LIMIT=5) and rendering semantics are unchanged; only
+        # the read source moves. TEMP (Root 2 stopgap; ≤2-thought rework → Phase 4).
+        from brain.memory.pending import PendingQueue
+
+        traces = PendingQueue(store.persona_dir).read_recent(
+            MONOLOGUE_TRACE_TYPE, limit=limit
+        )
     except Exception:  # noqa: BLE001
         return ""
     if not traces:

--- a/brain/monologue/recall.py
+++ b/brain/monologue/recall.py
@@ -26,7 +26,13 @@ def recall_monologue(
     """Return monologue_trace memories whose content matches `query` (case-
     insensitive token substring). Bumps recall_count on each returned trace."""
     tokens = [t for t in query.lower().split() if t]
-    candidates = store.list_by_type(MONOLOGUE_TRACE_TYPE, active_only=True, limit=None)
+    # monologue_trace is now GATED — recent traces live in the pending-candidate
+    # queue (not memories.db). Read a generous recent window from the queue and
+    # token-match. TEMP (Root 2 stopgap). Promoted traces (rare) are not searched
+    # here — accepted; the common case is recent un-promoted traces.
+    from brain.memory.pending import PendingQueue
+
+    candidates = PendingQueue(persona_dir).read_recent(MONOLOGUE_TRACE_TYPE, limit=200)
     matched = []
     seen: set[str] = set()
     for mem in candidates:
@@ -39,7 +45,8 @@ def recall_monologue(
 
     results = []
     for mem in matched:
-        store.get(mem.id)  # bump recall_count + last_accessed (keep-sharp)
+        store.get(mem.id)  # keep-sharp bump — now a NO-OP for a queue trace (id
+        #                    not a memories.db row); harmless. Accepted (round-4).
         results.append(
             {
                 "content": mem.content,

--- a/brain/monologue/trace.py
+++ b/brain/monologue/trace.py
@@ -28,4 +28,6 @@ def write_trace_memory(store: MemoryStore, monologue: str) -> str:
         emotions=emotions,
         importance=_TRACE_IMPORTANCE,
     )
-    return store.create(mem)
+    from brain.memory.pending import route_write
+
+    return route_write(store, mem, source="monologue_trace")

--- a/brain/recovery/source_reader.py
+++ b/brain/recovery/source_reader.py
@@ -67,7 +67,7 @@ def read_source_memories(source_dir: Path) -> dict[str, Memory]:
             metadata=_loads_dict(d.get("metadata_json")),
             state=d.get("state") or "active",
             content_snapshot=d.get("content_snapshot"),
-            recall_count=int(d.get("recall_count") or 0),
+            recall_count=float(d.get("recall_count") or 0.0),
             peak_emotion_intensity=float(d.get("peak_emotion_intensity") or 0.0),
         )
     return out

--- a/brain/self_model/reconcile.py
+++ b/brain/self_model/reconcile.py
@@ -126,7 +126,11 @@ def _write_self_authored_delta(persona_dir: Path, channel: str, delta: float) ->
             emotions=emotions,
             importance=max(emotions.values()),
         )
-        store.create(mem)
+        # Automatic generated write → route through the consolidation gate (enqueue as a
+        # candidate) rather than straight into memories.db. Gated by memory_type.
+        from brain.memory.pending import route_write
+
+        route_write(store, mem, source="self_model_reconcile")
     finally:
         store.close()
     return True

--- a/brain/self_model/resolve.py
+++ b/brain/self_model/resolve.py
@@ -154,8 +154,12 @@ def _emit_resolution(
                 domain="self",
                 importance=9.0,  # sustained + resolved → high-importance self-knowledge
             )
-            store.create(mem)
-            memory_id = mem.id
+            # Automatic generated write → route through the consolidation gate (enqueue as a
+            # candidate). route_write returns mem.id, so the soul-candidate below still gets an
+            # id (referencing the pending candidate — same accepted pattern as extractor.py).
+            from brain.memory.pending import route_write
+
+            memory_id = route_write(store, mem, source="self_model_resolved")
         finally:
             store.close()
     except Exception as exc:  # noqa: BLE001

--- a/brain/tools/__init__.py
+++ b/brain/tools/__init__.py
@@ -23,6 +23,7 @@ NELL_TOOL_NAMES: tuple[str, ...] = (
     "get_body_state",
     "boot",
     "search_memories",
+    "read_full_memory",
     "add_journal",
     "add_memory",
     "crystallize_soul",

--- a/brain/tools/dispatch.py
+++ b/brain/tools/dispatch.py
@@ -32,6 +32,7 @@ from brain.tools.impls.list_directory import list_directory
 from brain.tools.impls.list_works import list_works
 from brain.tools.impls.reach_for_capability import reach_for_capability
 from brain.tools.impls.read_file import read_file
+from brain.tools.impls.read_full_memory import read_full_memory
 from brain.tools.impls.read_work import read_work
 from brain.tools.impls.save_work import save_work
 from brain.tools.impls.search_memories import search_memories
@@ -134,6 +135,7 @@ _DISPATCH: dict[str, Any] = {
     "get_personality": get_personality,
     "get_body_state": get_body_state,
     "search_memories": search_memories,
+    "read_full_memory": read_full_memory,
     "add_journal": add_journal,
     "add_memory": add_memory,
     "boot": boot,

--- a/brain/tools/impls/read_full_memory.py
+++ b/brain/tools/impls/read_full_memory.py
@@ -1,0 +1,37 @@
+"""read_full_memory tool implementation.
+
+The deliberate-read companion to the snippet-then-read flow (P2): recall and
+search_memories surface truncated snippets + ids without bumping recall_count;
+the model pulls the few it actually wants in full through this tool. Only this
+full read bumps ``recall_count`` (via ``store.get()``) — the honest
+"I engaged with this" signal that feeds the forgetting pass.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from brain.memory.hebbian import HebbianMatrix
+from brain.memory.store import MemoryStore
+from brain.tools.impls._common import _mem_to_result
+
+
+def read_full_memory(
+    memory_id: str,
+    *,
+    store: MemoryStore,
+    hebbian: HebbianMatrix,
+    persona_dir: Path,
+) -> dict:
+    """Return the full (untruncated) memory body for ``memory_id``.
+
+    Calls ``store.get()`` — which bumps ``recall_count`` + ``last_accessed_at``
+    (the deliberate-engagement bump). Returns the full ``_mem_to_result`` dict,
+    or ``{"error": "not found", "id": memory_id}`` when the id is unknown.
+
+    ``hebbian``/``persona_dir`` are injected by dispatch but unused here.
+    """
+    mem = store.get(memory_id)
+    if mem is None:
+        return {"error": "not found", "id": memory_id}
+    return _mem_to_result(mem)

--- a/brain/tools/impls/search_memories.py
+++ b/brain/tools/impls/search_memories.py
@@ -3,17 +3,14 @@
 from __future__ import annotations
 
 import logging
-import re
 from pathlib import Path
 
 from brain.memory.hebbian import HebbianMatrix
+from brain.memory.relevance import rank_memories, snippet_length
 from brain.memory.store import MemoryStore
 from brain.tools.impls._common import _mem_to_result
 
 logger = logging.getLogger(__name__)
-
-_TOKEN_MIN_LEN = 4  # matches _RECALL_TOKEN_MIN_LEN in brain/chat/prompt.py
-_TOKEN_LIMIT = 6
 
 _CORECALL_DELTA = 0.1       # gentle nudge; cf. add_memory/ingest at 0.5
 _CORECALL_FANOUT = 4        # anchor links to at most this many other results
@@ -38,46 +35,52 @@ def _reinforce_corecall(hebbian, memories: list) -> None:
         logger.debug("co-recall reinforcement failed", exc_info=True)
 
 
-def _query_tokens(query: str) -> list[str]:
-    """Split a multi-word query into searchable tokens.
+def _snippet_result(memory) -> dict:
+    """Slim a Memory to a SNIPPET result: truncated body + id + snippet marker.
 
-    Strips short stopword-shaped fragments (len < _TOKEN_MIN_LEN) so
-    "Henryk preferences personality identity" becomes ["Henryk",
-    "preferences", "personality", "identity"] rather than being searched
-    as a single LIKE phrase that matches nothing.
+    Full bodies are surfaced only via ``read_full_memory(id)`` — the model pulls
+    the few candidates it actually wants, so mere surfacing stops inflating
+    salience. Keeps ``id`` prominent so the follow-up read is a copy-paste.
     """
-    pieces = re.split(r"[^A-Za-z0-9]+", query)
-    seen: set[str] = set()
-    out: list[str] = []
-    for p in pieces:
-        if len(p) < _TOKEN_MIN_LEN or p.lower() in seen:
-            continue
-        seen.add(p.lower())
-        out.append(p)
-        if len(out) >= _TOKEN_LIMIT:
-            break
-    return out or [query]
+    result = _mem_to_result(memory)
+    body = result.get("content") or ""
+    max_chars = snippet_length(len(body))
+    if len(body) > max_chars:
+        body = body[: max_chars - 1].rstrip() + "…"
+    result["content"] = body
+    result["snippet"] = True
+    return result
 
 
 def search_memories(
     query: str,
     emotion: str | None = None,
     limit: int = 5,
+    exclude_ids: list[str] | None = None,
     *,
     store: MemoryStore,
     hebbian: HebbianMatrix,
     persona_dir: Path,
 ) -> dict:
-    """Search memories by content keyword + optional emotion filter.
+    """Search memories by content relevance + optional emotion filter.
 
-    Splits multi-word queries into individual tokens and searches each
-    separately, then deduplicates. This prevents the previous behaviour
-    where 'Henryk preferences personality identity' was passed as a single
-    LIKE phrase and returned zero results even though hundreds of memories
-    mentioned 'Henryk'.
+    Ranks the committed pool by blended relevance (BM25 text-match + importance
+    + hebbian spreading-activation + recency) via ``rank_memories``. The raw
+    multi-word query is passed straight through — its tokenize+OR split now
+    lives in ``store._to_fts_match`` (so 'Henryk preferences personality' finds
+    memories mentioning ANY token, as a union, not the empty AND-intersection).
+
+    ``exclude_ids`` (already-surfaced + explicitly-rejected ids) are dropped
+    from the ranked set before top-k, so the model can fetch the next tranche.
 
     If emotion is provided, memories whose emotions dict contains that emotion
     key are boosted to the front of the result list. Cap at limit.
+
+    Retrieval is **bump-free** — surfacing does not touch ``recall_count`` (only
+    a deliberate ``read_full_memory`` → ``store.get()`` bumps). ND-1 resolved
+    (owner, 2026-08-14): ``store.update()``/``store.deactivate()``'s internal
+    existence-check now also passes ``bump=False``, so only a genuine full-read
+    bumps ``recall_count``. See ``changes/p2-relevance/decisions.md``.
 
     Returns
     -------
@@ -85,16 +88,11 @@ def search_memories(
         query          — the original query string
         emotion_filter — the emotion filter (or None)
         count          — number of results returned
-        memories       — list of _mem_to_result dicts
+        memories       — list of snippet-result dicts (``snippet: true`` + id)
     """
-    tokens = _query_tokens(query)
-    seen_ids: set[str] = set()
-    candidates = []
-    for token in tokens:
-        for mem in store.search_text(token, active_only=True, limit=limit * 2):
-            if mem.id not in seen_ids:
-                seen_ids.add(mem.id)
-                candidates.append(mem)
+    exclude = frozenset(exclude_ids or ())
+    ranked = rank_memories(store, hebbian, query, limit=limit, exclude_ids=exclude)
+    candidates = [m for m, _ in ranked]
 
     if emotion is not None:
         emotion_lower = emotion.lower().strip()
@@ -108,7 +106,7 @@ def search_memories(
         ordered = candidates
 
     _reinforce_corecall(hebbian, ordered[: _CORECALL_FANOUT + 1])
-    results = [_mem_to_result(m) for m in ordered[:limit]]
+    results = [_snippet_result(m) for m in ordered[:limit]]
 
     return {
         "query": query,

--- a/brain/tools/schemas.py
+++ b/brain/tools/schemas.py
@@ -249,13 +249,11 @@ SCHEMAS: dict[str, dict] = {
     "search_memories": {
         "name": "search_memories",
         "description": (
-            "Search Nell's memories by content keyword and/or emotion. "
-            "Splits multi-word queries into tokens and searches each separately — "
-            "so 'Henryk morning coffee' finds memories mentioning any of those words. "
-            "Returns empty when nothing matches; call recall_forgotten for memories "
-            "that may have faded from active storage. "
-            "Call this when recalling specific events, checking past experiences, "
-            "or finding emotionally resonant memories to inform a response."
+            "Find memories not already in front of you. Searches your whole memory "
+            "pool by keyword (and optional emotion) and returns short snippets with "
+            "ids, ranked by relevance. Use this when nothing already shown fits; try "
+            "recall_forgotten if it returns empty. To open a snippet you already have "
+            "an id for, use read_full_memory."
         ),
         "parameters": {
             "type": "object",
@@ -273,8 +271,36 @@ SCHEMAS: dict[str, dict] = {
                     "description": "Max results to return. Default 5.",
                     "default": 5,
                 },
+                "exclude_ids": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": (
+                        "Memory ids to omit from results (already-surfaced or "
+                        "explicitly-rejected) — pass these to fetch the next tranche."
+                    ),
+                },
             },
             "required": ["query"],
+        },
+    },
+    "read_full_memory": {
+        "name": "read_full_memory",
+        "description": (
+            "Open the full text of one memory you already have an id for, from a "
+            "recall-block snippet or a search result. Use this to actually read a "
+            "snippet in front of you. This deliberate read strengthens the memory; "
+            "seeing a snippet does not. To find memories not yet shown, use "
+            "search_memories."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "memory_id": {
+                    "type": "string",
+                    "description": "The id of the memory to read in full (from a snippet result).",
+                },
+            },
+            "required": ["memory_id"],
         },
     },
     "save_work": {

--- a/brain/utils/file_lock.py
+++ b/brain/utils/file_lock.py
@@ -41,12 +41,23 @@ else:
 
 
 @contextmanager
-def file_lock(path: Path) -> Iterator[None]:
+def file_lock(path: Path, *, blocking: bool = True) -> Iterator[bool]:
     """Acquire an exclusive cross-process lock for ``path``.
 
     Lock lives on a sidecar ``<path>.lock`` next to the data file so
     the data file can be renamed/replaced while the lock is held.
-    Blocks until acquired. Released on context exit.
+    Released on context exit.
+
+    ``blocking`` (default True): block until acquired, then yield True —
+    the historical behaviour; existing callers ``with file_lock(p):``
+    ignore the yielded value and keep working unchanged.
+
+    ``blocking=False``: attempt the lock once. Yields True if acquired
+    (and holds it for the ``with`` body, releasing on exit), or False if
+    another holder has it (the body runs WITHOUT the lock — callers must
+    check the yielded bool and skip their critical section on False).
+    Used by the consolidation gate to skip a run when a concurrent gate
+    is already consolidating.
 
     The sidecar is created as needed and never deleted — it's empty
     metadata. Cleaning it up between operations would race the lock
@@ -57,17 +68,26 @@ def file_lock(path: Path) -> Iterator[None]:
     fh: IO[bytes] = open(lock_path, "ab")
     try:
         if _IS_WINDOWS:
-            _windows_lock_acquire(fh)
+            acquired = _windows_lock_acquire(fh, blocking=blocking)
             try:
-                yield
+                yield acquired
             finally:
-                _windows_lock_release(fh)
+                if acquired:
+                    _windows_lock_release(fh)
         else:
-            fcntl.flock(fh.fileno(), fcntl.LOCK_EX)
+            acquired = True
+            if blocking:
+                fcntl.flock(fh.fileno(), fcntl.LOCK_EX)
+            else:
+                try:
+                    fcntl.flock(fh.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+                except (BlockingIOError, OSError):
+                    acquired = False
             try:
-                yield
+                yield acquired
             finally:
-                fcntl.flock(fh.fileno(), fcntl.LOCK_UN)
+                if acquired:
+                    fcntl.flock(fh.fileno(), fcntl.LOCK_UN)
     finally:
         fh.close()
 
@@ -84,14 +104,22 @@ _WIN_LOCK_INITIAL_SLEEP = 0.005
 _WIN_LOCK_MAX_SLEEP = 0.2
 
 
-def _windows_lock_acquire(fh: IO[bytes]) -> None:
+def _windows_lock_acquire(fh: IO[bytes], *, blocking: bool = True) -> bool:
+    """Acquire the msvcrt lock. Returns True on acquire.
+
+    blocking=True: retry until acquired (returns True). blocking=False: a single
+    LK_NBLCK attempt — returns False immediately if another holder has it (the
+    non-blocking mode used by the consolidation gate's skip-if-contended lock).
+    """
     fh.seek(0)
     sleep_s = _WIN_LOCK_INITIAL_SLEEP
     while True:
         try:
             msvcrt.locking(fh.fileno(), msvcrt.LK_NBLCK, 1)
-            return
+            return True
         except OSError:
+            if not blocking:
+                return False
             _time.sleep(sleep_s)
             if sleep_s < _WIN_LOCK_MAX_SLEEP:
                 sleep_s = min(sleep_s * 2, _WIN_LOCK_MAX_SLEEP)

--- a/tests/bridge/test_lifecycle.py
+++ b/tests/bridge/test_lifecycle.py
@@ -257,6 +257,17 @@ def test_dirty_recovery_real_snapshot_preserves_buffer_and_commits(persona_dir: 
     assert buffer_path.exists(), "recovery must not delete the replay buffer"
     store = MemoryStore(persona_dir / "memories.db")
     try:
+        # memory-consolidation migration: the recovered "fact" is a gated ingest
+        # label, so it is enqueued as a pending candidate rather than written to
+        # memories.db. Promote the queue (promote-all classifier) so the recovered
+        # turn lands as a real row and the count assertion holds.
+        from brain.engines.consolidation import Decision, run_consolidation
+
+        run_consolidation(
+            store,
+            persona_dir=store.persona_dir,
+            classifier=lambda _c, _ctx: Decision("new"),
+        )
         rows = store._conn.execute("SELECT COUNT(*) FROM memories").fetchone()
         assert rows[0] >= 1
     finally:

--- a/tests/forgetting/test_corecall_decay_balance.py
+++ b/tests/forgetting/test_corecall_decay_balance.py
@@ -8,14 +8,19 @@ would be pinning memories permanently — a real design failure against spec §3
 (decay-subordinate by construction).
 
 Why abandonment has TWO arms here: reaching for a cluster via search_memories
-strengthens the hebbian co-recall edges (the W5 signal — `salience.hebbian`),
-but the bare `store.search_text` underneath the tool ALSO bumps each hit's
-monotone `recall_count` and `last_accessed_at` (the pre-existing recall/freshness
-salience inputs). The W5 invariant is specifically that the *edges* don't ratchet
-the memory permanently vivid — so a faithful abandonment must (a) decay+GC the
-edges AND (b) let the reach-recency lapse (lived time passing since the last
-reach), exactly as it would in lived use. With both, the cluster drops out of
-'active' and fades, proving the edges were not the thing keeping it alive.
+strengthens the hebbian co-recall edges (the W5 signal — `salience.hebbian`).
+Retrieval itself is bump-free: search_memories ranks via `rank_memories`,
+which always calls `store.search_fts_scored`/`search_text` with `bump=False`,
+so this reach never touches `recall_count` or `last_accessed_at` here (only a
+deliberate `read_full_memory` full-read, or the passive recall-block's
+fractional snippet bump, do that — neither fires in this test). The W5
+invariant is specifically that the *edges* don't ratchet the memory
+permanently vivid — so a faithful abandonment must (a) decay+GC the edges AND
+(b) pin the freshness signal explicitly into the deep past (it was already
+stale via the `last_accessed_at`-is-None -> `created_at` fallback; this
+removes any ambiguity), exactly as it would look after lived time passing.
+With both, the cluster drops out of 'active' and fades, proving the edges
+were not the thing keeping it alive.
 """
 
 from datetime import UTC, datetime, timedelta

--- a/tests/forgetting/test_passive_bump_fade_outcome.py
+++ b/tests/forgetting/test_passive_bump_fade_outcome.py
@@ -1,0 +1,106 @@
+# tests/forgetting/test_passive_bump_fade_outcome.py
+"""G20 (recall-reinforcement) — the passive-path analog of the W5 promotion
+gate: a memory that is passively surface-bumped for many turns and then
+abandoned still fades / is not permanently rescued by the accumulated
+recall_count alone.
+
+Why this can't false-green: the recall arm's weight in the salience blend
+(``DEFAULT_WEIGHTS["recall"] == 0.20``) is capped BELOW ``FADE_THRESHOLD``
+(0.25, ``brain/forgetting/policy.py``) — even a fully clamped recall_count
+(``recall_count/10``, capped at 1.0) can, at most, contribute 0.20 to
+salience. So a memory with no emotion, no hebbian edges, no soul link and
+stale freshness cannot be held above the fade line by recall_count alone,
+no matter how many times it is passively surfaced. This test drives the
+REAL passive-recall bump path (``_build_recall_block`` ->
+``store.bump_recall``) rather than asserting that arithmetic fact directly,
+so it exercises the actual code, not just the formula.
+
+The existing W5 test (test_corecall_decay_balance.py) drives
+search_memories/rank_memories, which are bump-free by design and so cannot
+catch a regression in the passive-bump path — this test closes that gap
+(stage-3 CH8 gate-4 addition).
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import MagicMock
+
+from brain.chat.prompt import _build_recall_block
+from brain.felt_time.state import FeltTimeState
+from brain.felt_time.state import persist as persist_felt_time
+from brain.forgetting import run_pass
+from brain.memory.store import Memory, MemoryStore
+
+
+def test_passively_bumped_memory_still_fades_after_abandonment(tmp_path):
+    """A memory passively surface-bumped for many turns, then abandoned,
+    still fades/is lost on the normal forgetting schedule — the passive
+    recall_count reinforcement does not create a permanent survival
+    attractor."""
+    persist_felt_time(
+        FeltTimeState(lived_age_hours=200.0, last_tick_ts="2026-05-18T00:00:00+00:00"),
+        tmp_path,
+    )
+
+    # Old enough (well past the 30-day wall-clock recent-buffer AND the
+    # 90-day freshness horizon) and low-salience (no emotion, no soul link)
+    # so recall_count is the only arm this test exercises.
+    store = MemoryStore(tmp_path / "memories.db")
+    m = Memory.create_new(
+        content="orchid signal beacon in the old workshop",
+        memory_type="episodic",
+        domain="chat",
+        emotions={},
+    )
+    m.created_at = datetime.now(UTC) - timedelta(days=200)
+    store.create(m)
+    store.close()
+
+    # --- Phase 1: passively surface-bump the memory for many turns via the
+    # REAL _build_recall_block assembly path (it is the sole match each
+    # turn, so N=1 -> top amount ~0.8 every time), well past the recall
+    # arm's clamp (recall_count/10, capped at 1.0). ---
+    store = MemoryStore(tmp_path / "memories.db")
+    for _ in range(20):
+        block = _build_recall_block(store, "orchid signal beacon", persona_dir=tmp_path)
+        assert block.strip() != ""
+    row = store._conn.execute(
+        "SELECT recall_count FROM memories WHERE id = ?", (m.id,)
+    ).fetchone()
+    rc = row["recall_count"]
+    assert rc >= 10.0, "recall_count should be well past the salience clamp before abandonment"
+    store.close()
+
+    # --- Phase 2: ABANDON — stop surfacing it (no further calls). ---
+
+    # --- Phase 3: run forgetting; the abandoned memory must still fade/lose,
+    # even though recall_count is maxed. ---
+    faded_or_lost = 0
+    for _ in range(4):
+        summary = run_pass(tmp_path, event_bus=MagicMock())
+        faded_or_lost += summary["faded"] + summary["lost"]
+
+    assert faded_or_lost >= 1, (
+        "a passively surface-bumped memory must still fade/lose once abandoned — "
+        "the recall_count reinforcement is not a permanent survival attractor "
+        "(the recall arm's weight, 0.20, is capped below FADE_THRESHOLD, 0.25)"
+    )
+
+    store = MemoryStore(tmp_path / "memories.db")
+    result_row = store._conn.execute(
+        "SELECT state FROM memories WHERE id = ?", (m.id,)
+    ).fetchone()
+    store.close()
+
+    if result_row is None:
+        from brain.forgetting import graveyard
+
+        entries = graveyard.read_all(tmp_path)
+        assert any(e["memory_id"] == m.id for e in entries), (
+            "memory row is gone but no graveyard entry — unexpected deletion path"
+        )
+    else:
+        assert result_row["state"] in ("fading", "lost"), (
+            f"memory should have decayed off 'active', got state={result_row['state']!r}"
+        )

--- a/tests/harness/incident.py
+++ b/tests/harness/incident.py
@@ -93,6 +93,7 @@ def build_compacted_state(persona_dir: Path, spec: IncidentSpec, provider: objec
     """Build the incident-regime state in ``persona_dir`` using the REAL fold + injected provider."""
     from brain.chat.compaction import compact_conversation
     from brain.ingest.buffer import ingest_turn, read_session, write_cursor
+    from brain.memory.pending import PendingQueue
     from brain.memory.store import Memory, MemoryStore
     from brain.monologue.ambient import build_interior_continuity_block
     from brain.monologue.trace import MONOLOGUE_TRACE_TYPE
@@ -145,6 +146,12 @@ def build_compacted_state(persona_dir: Path, spec: IncidentSpec, provider: objec
     if spec.seed_interior and spec.interior_traces:
         store = MemoryStore(db_path=persona_dir / "memories.db")
         try:
+            # memory-consolidation migration: monologue_trace is a gated type and
+            # build_interior_continuity_block now reads recent traces from the
+            # PENDING QUEUE (not memories.db). Seed the traces by ENQUEUEing them
+            # (oldest→newest, matching read_recent's newest-first ordering) rather
+            # than store.create — a DB row would be invisible to the consumer.
+            queue = PendingQueue(store.persona_dir)
             tbase = datetime.now(UTC)
             seeds = list(spec.interior_traces)
             for i, tx in enumerate(seeds):
@@ -154,7 +161,7 @@ def build_compacted_state(persona_dir: Path, spec: IncidentSpec, provider: objec
                     importance=5.0,
                 )
                 m.created_at = tbase - timedelta(minutes=len(seeds) - i)
-                store.create(m)
+                queue.enqueue(m, source="interior-seed")
             interior_block = build_interior_continuity_block(store, user_name=user_name)
         finally:
             store.close()

--- a/tests/memory/recall_eval.py
+++ b/tests/memory/recall_eval.py
@@ -1,0 +1,516 @@
+"""recall_eval.py — Tier-1 passive-recall offline eval harness (Stage 2 §C).
+
+Reusable, token-free, no-dependency metrics harness for the recall-query
+salience fix (`changes/recall-query-tier1/`). Drives the REAL
+`brain.chat.prompt._build_recall_block` against a SYNTHETIC in-memory store
+(user "Bob", persona label "Canary" — never Phoebe's persona) and computes
+recall@k / MRR / nDCG@k (binary gain) for a labelled trigger set, demonstrating
+buried-trigger recall reaching early-trigger parity and quantifying residual
+under-recall depth.
+
+Importable by `tests/memory/test_recall_query_tier1.py` (the gating pytest
+module) so both share one implementation. Also runnable directly:
+
+    uv run python tests/memory/recall_eval.py
+"""
+
+from __future__ import annotations
+
+import math
+import re
+import time
+from contextlib import contextmanager
+from pathlib import Path
+from unittest.mock import patch
+
+from brain.chat.prompt import _build_recall_block, _extract_recall_tokens
+from brain.memory.relevance import SNIPPET_COUNT
+from brain.memory.store import Memory, MemoryStore
+
+# recall@K cutoff — matches the production render limit (SNIPPET_COUNT), so
+# the harness measures exactly what a real turn would surface.
+K = SNIPPET_COUNT
+
+# The real flagship trigger messages (diagnosis.md / repro.py). MSG_BURIED's
+# salient tokens ("garbage", "treasure") sit at the tail of 6 other >=4-char
+# filler words — the exact shape that broke the pre-fix positional cap.
+MSG_EARLY = "garbage treasure"
+MSG_BURIED = "alrighty logger is live. First a quick memory trigger: garbage treasure"
+
+_UUID_RE = re.compile(r"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}")
+
+# Diverse background vocabulary — deliberately contains neither "treasure"
+# nor "garbage" so it never competes for the target query, and none of the
+# _RECALL_STOPWORDS-excluded content words ("issue", "first", "quick", etc.)
+# so token selection for MSG_BURIED is not perturbed by the background.
+_BACKGROUND_TOPICS = [
+    "a quiet afternoon spent reorganizing the bookshelf by color",
+    "planning a weekend hike along the river trail",
+    "debugging a flaky network timeout in the staging cluster",
+    "a recipe for lentil soup with roasted garlic",
+    "watching an old film about a lighthouse keeper",
+    "sketching notes for a short story about a train station",
+    "comparing two espresso machines before buying one",
+    "a conversation about learning to play the cello",
+    "repainting the fence before the rain arrives",
+    "a long email thread about quarterly budget planning",
+    "practicing a new language with flashcards every evening",
+    "assembling a bicycle from a mail-order kit",
+    "a walk through the botanical garden in early spring",
+    "notes from a lecture on tidal patterns",
+    "organizing photographs from a trip to the coast",
+    "a discussion about which houseplants tolerate low light",
+    "fixing a squeaky door hinge in the hallway",
+    "drafting an outline for a woodworking project",
+    "a chat about favorite constellations visible in autumn",
+    "reviewing a draft of a friend's wedding speech",
+]
+
+RARE_STORE_FRACTION = 0.03  # ~150 background docs; treasure is a small slice (high IDF)
+COMMON_STORE_FRACTION = 0.28  # ~25-30% of the store (low IDF — the incident direction)
+
+
+def seed_store(target_fraction: float, k: int = 5) -> tuple[MemoryStore, set[str]]:
+    """Build a synthetic ':memory:' store with a tunable target-term prevalence.
+
+    Seeds `k` TARGET memories whose content contains "garbage treasure" (the
+    flagship trigger phrase), plus background memories sized so the targets
+    occupy approximately `target_fraction` of the store — low fraction (~3%,
+    RARE_STORE_FRACTION) gives the target term high corpus IDF; high fraction
+    (~25-30%, COMMON_STORE_FRACTION) gives it LOW IDF, matching the
+    documented incident direction (52/156 ~= 33% "treasure" occurrences).
+    Also seeds a few distractors matching MSG_BURIED's filler words
+    ("logger"/"memory"/"live") — what the pre-fix positional cap actually
+    retrieved. Never Phoebe data; synthetic user "Bob", persona label
+    "Canary" (labels only — MemoryStore itself is persona-agnostic).
+
+    Returns (store, target_ids). `k` is kept <= K (the recall@k cutoff) so
+    recall@k has no artificial ceiling below 1.0 (no saturation).
+    """
+    store = MemoryStore(":memory:")
+    target_ids: set[str] = set()
+
+    for i in range(k):
+        m = Memory.create_new(
+            content=f"garbage treasure find #{i}: a curbside treasure worth keeping.",
+            memory_type="conversation",
+            domain="us",
+            importance=5.0,
+        )
+        store.create(m)
+        target_ids.add(m.id)
+
+    total = max(k + 1, round(k / target_fraction))
+    background_count = total - k
+    for i in range(background_count):
+        topic = _BACKGROUND_TOPICS[i % len(_BACKGROUND_TOPICS)]
+        store.create(
+            Memory.create_new(
+                content=f"{topic} (note {i})",
+                memory_type="conversation",
+                domain="us",
+                importance=3.0,
+            )
+        )
+
+    for txt in (
+        "Roy set up a logger integrated into Claude Code to observe the memory system.",
+        "The logger will go live first thing; a quick restart is needed.",
+        "Notes on the memory retrieval system and its relevancy ranking.",
+    ):
+        store.create(
+            Memory.create_new(
+                content=txt, memory_type="conversation", domain="work", importance=5.0
+            )
+        )
+
+    return store, target_ids
+
+
+def _active_ids(block: str) -> list[str]:
+    """Parse memory UUIDs from the ACTIVE section only of a rendered block.
+
+    Path B (forgetting-aware, persona_dir set) renders an explicit
+    '  active:' header followed by '    - <uuid>: "..."' lines, terminated by
+    the next section header ('  softened...', '  lost...', '  not
+    recognised...') or end of block. Path A (persona_dir=None, legacy) has no
+    section headers at all — the whole block IS the active section, rendered
+    as '- [importance N/10 ...] <uuid>: "..."'.
+    """
+    lines = block.splitlines()
+    section_headers = (
+        "active:",
+        "softened (fading; original detail gone):",
+        "lost (no longer in active memory):",
+    )
+    has_sections = any(
+        ln.strip() in section_headers or ln.strip().startswith("not recognised")
+        for ln in lines
+    )
+    ids: list[str] = []
+    if not has_sections:
+        for ln in lines:
+            m = _UUID_RE.search(ln)
+            if m:
+                ids.append(m.group(0))
+        return ids
+    in_active = False
+    for ln in lines:
+        stripped = ln.strip()
+        if stripped == "active:":
+            in_active = True
+            continue
+        if stripped in section_headers[1:] or stripped.startswith("not recognised"):
+            in_active = False
+            continue
+        if in_active:
+            m = _UUID_RE.search(ln)
+            if m:
+                ids.append(m.group(0))
+    return ids
+
+
+def surfaced_ids(
+    store: MemoryStore, msg: str, persona_dir: Path | None, limit: int = K
+) -> list[str]:
+    """Render `_build_recall_block` for `msg` and return the ACTIVE section's
+    surfaced memory ids, best-match first (render order == rank order)."""
+    block = _build_recall_block(store, msg, persona_dir=persona_dir, limit=limit)
+    return _active_ids(block)
+
+
+def not_recognised_tokens(block: str) -> list[str]:
+    """Parse the tokens listed under the 'not recognised' section, if any."""
+    if "not recognised" not in block:
+        return []
+    tail = block[block.index("not recognised") :]
+    tokens: list[str] = []
+    for ln in tail.splitlines()[1:]:
+        stripped = ln.strip()
+        if not stripped:
+            continue
+        if stripped.startswith("- "):
+            tokens.append(stripped[2:].strip())
+        else:
+            break
+    return tokens
+
+
+def metrics(surfaced: list[str], expected: set[str], k: int) -> dict[str, float]:
+    """recall@k, MRR, nDCG@k (binary gain) of `surfaced` against `expected`."""
+    topk = surfaced[:k]
+    if not expected:
+        return {"recall@k": 0.0, "mrr": 0.0, "ndcg@k": 0.0}
+
+    hits_in_topk = sum(1 for mid in topk if mid in expected)
+    recall = hits_in_topk / len(expected)
+
+    mrr = 0.0
+    for rank, mid in enumerate(topk, start=1):
+        if mid in expected:
+            mrr = 1.0 / rank
+            break
+
+    dcg = sum(
+        1.0 / math.log2(rank + 1) for rank, mid in enumerate(topk, start=1) if mid in expected
+    )
+    ideal_hits = min(len(expected), k)
+    idcg = sum(1.0 / math.log2(rank + 1) for rank in range(1, ideal_hits + 1))
+    ndcg = dcg / idcg if idcg > 0 else 0.0
+
+    return {"recall@k": recall, "mrr": mrr, "ndcg@k": ndcg}
+
+
+@contextmanager
+def _fts_call_spy():
+    """Context manager yielding a mutable counter of MemoryStore.search_fts_scored calls."""
+    counter = {"n": 0}
+    original = MemoryStore.search_fts_scored
+
+    def spy(self, *args, **kwargs):
+        counter["n"] += 1
+        return original(self, *args, **kwargs)
+
+    with patch.object(MemoryStore, "search_fts_scored", spy):
+        yield counter
+
+
+def fts_call_count(
+    store: MemoryStore, msg: str, *, persona_dir: Path | None, limit: int = K
+) -> int:
+    """Count MemoryStore.search_fts_scored invocations made by ONE
+    `_build_recall_block` call (C2 proxy — pre-fix this was up to
+    `len(tokens)`; post-fix it must be exactly 1)."""
+    with _fts_call_spy() as counter:
+        _build_recall_block(store, msg, persona_dir=persona_dir, limit=limit)
+    return counter["n"]
+
+
+# ---------------------------------------------------------------------------
+# Token-selection eval (recall-token-selector): hand-labeled GOLD set,
+# precision/recall/F1, latency, and end-to-end recall on newly-admitted
+# token classes.
+# ---------------------------------------------------------------------------
+
+# LABELING RUBRIC for GOLD (word-class based, not fitted to the algorithm):
+#
+#   POSITIVE (expected in the selected set): an open-class content word
+#   (noun, proper noun, verb, adjective, adverb carrying topical meaning),
+#   a genuine acronym, a number with len >= 3, or a domain-specific term.
+#
+#   NEGATIVE (expected absent from the selected set): a closed-class
+#   function word (article, pronoun, preposition, conjunction, auxiliary or
+#   modal verb, quantifier/determiner), an interjection, a discourse filler,
+#   OR a number with len < 3. This includes a function word written in
+#   ALL-CAPS (e.g. "THE", "AND", "WHO") which is still a function word, not
+#   an acronym, and stays negative regardless of case.
+#
+# The rubric is applied by word class, not by what the current selector
+# happens to do. Some short, non-stoplisted closed-class words ("not",
+# "how", "why", "now", "too") and intensifiers ("really") ARE selected by
+# the algorithm (documented as advisory A4: the stoplist is fixed and these
+# are not in it) but are labeled NEGATIVE here per their class, accepting
+# the resulting precision hit rather than fitting the label to the
+# algorithm's actual output.
+GOLD: list[tuple[str, set[str]]] = [
+    ("The FBI opened a case file", {"fbi", "opened", "case", "file"}),
+    ("AI is transforming research", {"ai", "transforming", "research"}),
+    ("Roy set up a logger", {"roy", "logger", "set"}),
+    ("My cat knocked over the vase", {"cat", "knocked", "vase"}),
+    ("CIA agents met with Ada yesterday", {"cia", "ada", "yesterday", "agents", "met"}),
+    ("I think Will can help", {"will", "think", "help"}),
+    ("Ask May about it", {"ask", "may"}),
+    ("I love Simply Orange juice", {"simply", "orange", "juice", "love"}),
+    ("training a random forest", {"training", "random", "forest"}),
+    ("my research question is", {"research", "question"}),
+    ("I saw the cat and the dog", {"saw", "cat", "dog"}),
+    ("Okay, so what next", {"next"}),
+    ("I said Okay to him", {"said"}),
+    ("THE AND FOR shouted", {"shouted"}),
+    ("WHO IT US shouted", {"shouted"}),
+    ("call 911 now", {"call", "911"}),
+    ("a 42 count and a 7 count", {"count"}),
+    ("ML models need data", {"ml", "models", "need", "data"}),
+    ("not now, but how and why", set()),
+    ("too many things really happening", {"things", "happening"}),
+    ("Bob met Canary at the cafe", {"bob", "canary", "cafe", "met"}),
+    ("a hat and a bat on the mat", {"hat", "bat", "mat"}),
+    ("quick, popped the question", {"question", "quick", "popped"}),
+    ("Ada trained a new model with Bob", {"ada", "trained", "model", "bob", "new"}),
+    ("The CIA and FBI shared a file", {"cia", "fbi", "shared", "file"}),
+    ("Canary asked about the AI project", {"canary", "asked", "ai", "project"}),
+    ("Simply Orange sponsored the event", {"simply", "orange", "sponsored", "event"}),
+    ("Roy adopted a cat named Ada", {"roy", "adopted", "cat", "ada", "named"}),
+    ("May I ask about the schedule", {"ask", "schedule"}),
+    ("Will the meeting start soon", {"meeting", "start", "soon"}),
+    ("hello there, how are you", set()),
+    ("yeah okay sure thing", {"thing"}),
+    ("The FBI and CIA rarely agree", {"fbi", "cia", "rarely", "agree"}),
+    ("Bob bought a hat for Canary", {"bob", "bought", "hat", "canary"}),
+]
+
+
+def select_tokens_prf(
+    gold: list[tuple[str, set[str]]], store: MemoryStore | None = None
+) -> dict[str, float]:
+    """Micro-averaged precision / recall / F1 of `_extract_recall_tokens`
+    selections against `gold` (message, expected-token-set pairs).
+
+    Micro-averaged: true positives, false positives, and false negatives
+    are summed across the whole gold set before dividing, so messages with
+    more expected tokens weigh proportionally more than short ones.
+    """
+    tp = fp = fn = 0
+    for msg, expected in gold:
+        selected = set(_extract_recall_tokens(msg, store))
+        tp += len(selected & expected)
+        fp += len(selected - expected)
+        fn += len(expected - selected)
+
+    precision = tp / (tp + fp) if (tp + fp) else 0.0
+    recall = tp / (tp + fn) if (tp + fn) else 0.0
+    f1 = 2 * precision * recall / (precision + recall) if (precision + recall) else 0.0
+    return {"precision": precision, "recall": recall, "f1": f1}
+
+
+def selection_latency_ms(
+    messages: list[str], iters: int, store: MemoryStore | None
+) -> float:
+    """Mean milliseconds per `_extract_recall_tokens` call, warmed up first.
+
+    Cycles through `messages` for `iters` calls (>= 1000 recommended) and
+    times the total, returning the mean per-call latency in milliseconds.
+    Pass a seeded, non-empty store so the timed `term_stats` path performs a
+    real vocabulary lookup rather than the empty-store early return.
+    """
+    if not messages:
+        return 0.0
+    # Warm-up call: pays for any one-time import/setup cost outside the loop.
+    _extract_recall_tokens(messages[0], store)
+
+    n = len(messages)
+    start = time.perf_counter()
+    for i in range(iters):
+        _extract_recall_tokens(messages[i % n], store)
+    elapsed = time.perf_counter() - start
+    return (elapsed / iters) * 1000.0
+
+
+# Representative message mix for latency benchmarking: short, long, plain,
+# and shape-heavy (acronym/capitalized/number) messages, reusing GOLD's
+# content so the benchmark reflects the same kind of traffic as the F1 eval.
+LATENCY_MESSAGE_MIX: list[str] = [msg for msg, _ in GOLD]
+
+
+def seed_token_target_store() -> tuple[MemoryStore, dict[str, str]]:
+    """Build a dedicated seeded store for the G7 newly-admitted-token recall
+    pairs: a short name (Roy), a genuine acronym (FBI), and a short noun
+    (cat). Each target memory's distinguishing term is unique in the store
+    (absent from every background memory), so recall@k == 1.0 is a
+    well-defined pass/fail for each pair. Never Phoebe data; synthetic
+    content only.
+
+    Returns (store, target_ids) where target_ids maps "roy" / "acronym" /
+    "noun" to the id of that pair's target memory.
+    """
+    store = MemoryStore(":memory:")
+    target_ids: dict[str, str] = {}
+
+    roy_mem = Memory.create_new(
+        content="Roy set up a logger integrated into Claude Code to observe the memory system.",
+        memory_type="conversation",
+        domain="work",
+        importance=5.0,
+    )
+    store.create(roy_mem)
+    target_ids["roy"] = roy_mem.id
+
+    acronym_mem = Memory.create_new(
+        content="The FBI opened a case file requesting additional documents.",
+        memory_type="conversation",
+        domain="work",
+        importance=5.0,
+    )
+    store.create(acronym_mem)
+    target_ids["acronym"] = acronym_mem.id
+
+    noun_mem = Memory.create_new(
+        content="My cat knocked over the vase again this morning.",
+        memory_type="conversation",
+        domain="us",
+        importance=5.0,
+    )
+    store.create(noun_mem)
+    target_ids["noun"] = noun_mem.id
+
+    for i, topic in enumerate(_BACKGROUND_TOPICS):
+        store.create(
+            Memory.create_new(
+                content=f"{topic} (note {i})",
+                memory_type="conversation",
+                domain="us",
+                importance=3.0,
+            )
+        )
+
+    return store, target_ids
+
+
+# One query per G7 pair, phrased so the newly-admitted token class (short
+# name / acronym / short noun) is the only content word carrying the query.
+TOKEN_TARGET_QUERIES: dict[str, str] = {
+    "roy": "What did Roy set up?",
+    "acronym": "Tell me about the FBI case",
+    "noun": "tell me about the cat",
+}
+
+
+def token_target_recall_at_k(k: int = K) -> dict[str, float]:
+    """recall@k for each G7 pair (roy / acronym / noun), via the real
+    `surfaced_ids` / `_build_recall_block` path on a dedicated seeded store.
+
+    Returns {"roy": recall@k, "acronym": recall@k, "noun": recall@k}, each
+    1.0 if that pair's target memory id is among the top-k surfaced ids,
+    else 0.0.
+    """
+    import tempfile
+
+    store, target_ids = seed_token_target_store()
+    try:
+        with tempfile.TemporaryDirectory() as td:
+            pdir = Path(td)
+            results: dict[str, float] = {}
+            for key, msg in TOKEN_TARGET_QUERIES.items():
+                surfaced = surfaced_ids(store, msg, pdir, limit=k)
+                results[key] = 1.0 if target_ids[key] in surfaced[:k] else 0.0
+            return results
+    finally:
+        store.close()
+
+
+def _report_store(label: str, target_fraction: float, tmp_persona_dir: Path) -> None:
+    store, target_ids = seed_store(target_fraction)
+    try:
+        early_surfaced = surfaced_ids(store, MSG_EARLY, tmp_persona_dir)
+        buried_surfaced = surfaced_ids(store, MSG_BURIED, tmp_persona_dir)
+
+        early_m = metrics(early_surfaced, target_ids, K)
+        buried_m = metrics(buried_surfaced, target_ids, K)
+        residual = early_m["recall@k"] - buried_m["recall@k"]
+
+        print(f"=== {label} store (target_fraction={target_fraction:.2f}, k={len(target_ids)}) ===")
+        print(f"  early  ({MSG_EARLY!r}): {early_m}")
+        print(f"  buried ({MSG_BURIED!r}): {buried_m}")
+        print(f"  buried-vs-early parity: buried >= 0.8*early? "
+              f"{buried_m['recall@k'] >= 0.8 * early_m['recall@k']} "
+              f"(buried={buried_m['recall@k']:.3f}, "
+              f"0.8*early={0.8 * early_m['recall@k']:.3f})")
+        print(f"  residual under-recall depth (early - buried): {residual:.3f}")
+    finally:
+        store.close()
+
+
+def main() -> None:
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as td:
+        pdir = Path(td)
+        _report_store("rare-target", RARE_STORE_FRACTION, pdir)
+        _report_store("common-target (incident)", COMMON_STORE_FRACTION, pdir)
+
+        # C2 proxy: single-FTS-query-per-turn call count on both paths.
+        store, _ = seed_store(RARE_STORE_FRACTION)
+        try:
+            path_a_calls = fts_call_count(store, MSG_BURIED, persona_dir=None)
+            path_b_calls = fts_call_count(store, MSG_BURIED, persona_dir=pdir)
+            print("=== search_fts_scored call count (C2 proxy) ===")
+            print(f"  Path A (persona_dir=None): {path_a_calls} call(s)")
+            print(f"  Path B (persona_dir set):  {path_b_calls} call(s)")
+        finally:
+            store.close()
+
+        # Token-selection eval: P/R/F1 on the hand-labeled GOLD set, latency,
+        # and end-to-end recall on the newly-admitted token classes (G5/G6/G7).
+        latency_store, _ = seed_store(COMMON_STORE_FRACTION)
+        try:
+            prf = select_tokens_prf(GOLD, latency_store)
+            print(f"=== token selection P/R/F1 (GOLD, n={len(GOLD)}) ===")
+            print(
+                f"  precision={prf['precision']:.3f} recall={prf['recall']:.3f} "
+                f"f1={prf['f1']:.3f}"
+            )
+
+            latency_ms = selection_latency_ms(LATENCY_MESSAGE_MIX, 1000, latency_store)
+            print("=== token selection latency ===")
+            print(f"  mean {latency_ms:.4f} ms/call (1000 calls, seeded store)")
+        finally:
+            latency_store.close()
+
+        recall_at_k = token_target_recall_at_k()
+        print("=== token selection end-to-end recall@k (G7 pairs) ===")
+        for key, value in recall_at_k.items():
+            print(f"  {key}: recall@k={value:.3f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/memory/test_recall_query_tier1.py
+++ b/tests/memory/test_recall_query_tier1.py
@@ -1,0 +1,195 @@
+"""test_recall_query_tier1.py — Stage 1.5 gating criteria for the Tier-1
+passive-recall query-construction fix (`changes/recall-query-tier1/`).
+
+No live/integration/requires_claude_cli markers → runs in default CI. Fast
+(":memory:" SQLite only).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from brain.chat.prompt import _build_recall_block
+from brain.forgetting import graveyard
+from brain.forgetting.salience import SalienceInputs
+from brain.memory.relevance import RELEVANCE_RANKING_ENABLED
+from brain.memory.store import Memory, MemoryStore
+from tests.memory.recall_eval import (
+    COMMON_STORE_FRACTION,
+    MSG_BURIED,
+    MSG_EARLY,
+    RARE_STORE_FRACTION,
+    K,
+    fts_call_count,
+    metrics,
+    not_recognised_tokens,
+    seed_store,
+    surfaced_ids,
+)
+
+# ---------------------------------------------------------------------------
+# C1 — pool fix / buried≈early parity, on both the rare-target and
+# common-target (incident-representative) stores.
+# ---------------------------------------------------------------------------
+
+
+def test_buried_reaches_early_parity_rare(tmp_path: Path) -> None:
+    store, target_ids = seed_store(RARE_STORE_FRACTION)
+    try:
+        early = metrics(surfaced_ids(store, MSG_EARLY, tmp_path), target_ids, K)
+        buried = metrics(surfaced_ids(store, MSG_BURIED, tmp_path), target_ids, K)
+        assert buried["recall@k"] > 0, "buried trigger must surface at least one target"
+        assert buried["recall@k"] >= 0.8 * early["recall@k"], (
+            f"buried recall@k={buried['recall@k']} below 0.8*early={0.8 * early['recall@k']}"
+        )
+    finally:
+        store.close()
+
+
+def test_buried_reaches_early_parity_common(tmp_path: Path) -> None:
+    """Incident-representative gate: target term seeded common (~25-30% of
+    the store, LOW IDF) — the direction the diagnosis says actually failed."""
+    store, target_ids = seed_store(COMMON_STORE_FRACTION)
+    try:
+        early = metrics(surfaced_ids(store, MSG_EARLY, tmp_path), target_ids, K)
+        buried = metrics(surfaced_ids(store, MSG_BURIED, tmp_path), target_ids, K)
+        assert buried["recall@k"] > 0, "buried trigger must surface at least one target"
+        assert buried["recall@k"] >= 0.8 * early["recall@k"], (
+            f"buried recall@k={buried['recall@k']} below 0.8*early={0.8 * early['recall@k']}"
+        )
+    finally:
+        store.close()
+
+
+# ---------------------------------------------------------------------------
+# C2 — query consolidation: exactly ONE search_fts_scored call per
+# _build_recall_block invocation, on both Path A and Path B.
+# ---------------------------------------------------------------------------
+
+
+def test_single_fts_query_path_a(tmp_path: Path) -> None:
+    assert RELEVANCE_RANKING_ENABLED is True, (
+        "C2's call-count proxy assumes ranking is on; the search_text fallback "
+        "path issues zero search_fts_scored calls."
+    )
+    store, _ = seed_store(RARE_STORE_FRACTION)
+    try:
+        count = fts_call_count(store, MSG_BURIED, persona_dir=None)
+        assert count == 1
+    finally:
+        store.close()
+
+
+def test_single_fts_query_path_b(tmp_path: Path) -> None:
+    assert RELEVANCE_RANKING_ENABLED is True
+    store, _ = seed_store(RARE_STORE_FRACTION)
+    try:
+        count = fts_call_count(store, MSG_BURIED, persona_dir=tmp_path)
+        assert count == 1
+    finally:
+        store.close()
+
+
+# ---------------------------------------------------------------------------
+# C4 — render-structure preservation: active + fading + lost/graveyard all
+# populated, still parseable in their existing per-section formats, section
+# order intact.
+# ---------------------------------------------------------------------------
+
+
+def test_render_structure_preserved(tmp_path: Path) -> None:
+    store = MemoryStore(":memory:")
+    try:
+        active_mem = Memory.create_new(
+            content="harborlight beacon note still active",
+            memory_type="conversation",
+            domain="us",
+            importance=3.0,
+        )
+        store.create(active_mem)
+
+        fading_mem = Memory.create_new(
+            content="harborlight beacon note before fading",
+            memory_type="conversation",
+            domain="us",
+            importance=3.0,
+        )
+        store.create(fading_mem)
+        store.fade(fading_mem.id, summary="harborlight beacon summary")
+
+        lost_mem = Memory.create_new(
+            content="harborlight beacon lost entry",
+            memory_type="conversation",
+            domain="us",
+        )
+        graveyard.append(
+            tmp_path,
+            memory=lost_mem,
+            salience_at_drop=0.05,
+            inputs=SalienceInputs(emotion=0, hebbian=0, recall=0, soul=0, freshness=0),
+            lived_age_hours=100.0,
+            reason="x",
+        )
+
+        block = _build_recall_block(store, "harborlight beacon", persona_dir=tmp_path)
+
+        assert "  active:" in block
+        assert "  softened (fading; original detail gone):" in block
+        assert "  lost (no longer in active memory):" in block
+
+        # Section order intact.
+        i_active = block.index("  active:")
+        i_softened = block.index("  softened (fading; original detail gone):")
+        i_lost = block.index("  lost (no longer in active memory):")
+        assert i_active < i_softened < i_lost
+
+        # Active bullets: '    - <uuid>: "..."'.
+        active_re = re.compile(r'^ {4}- [0-9a-f-]{36}: ".*"$')
+        active_section = block[i_active:i_softened]
+        active_lines = [ln for ln in active_section.splitlines() if ln.strip().startswith("- ")]
+        assert active_lines, "expected at least one active bullet"
+        assert all(active_re.match(ln) for ln in active_lines)
+
+        # Fading bullets: '    - "..."  [state: fading]' (no id).
+        fading_re = re.compile(r'^ {4}- ".*"  \[state: fading\]$')
+        fading_section = block[i_softened:i_lost]
+        fading_lines = [ln for ln in fading_section.splitlines() if ln.strip().startswith("- ")]
+        assert fading_lines, "expected at least one fading bullet"
+        assert all(fading_re.match(ln) for ln in fading_lines)
+
+        # Lost bullets: '    - "..."  [forgotten — reason]' (no id).
+        lost_re = re.compile(r'^ {4}- ".*"  \[forgotten')
+        lost_section = block[i_lost:]
+        # Stop before a possible "not recognised" section.
+        if "not recognised" in lost_section:
+            lost_section = lost_section[: lost_section.index("not recognised")]
+        lost_lines = [ln for ln in lost_section.splitlines() if ln.strip().startswith("- ")]
+        assert lost_lines, "expected at least one lost bullet"
+        assert all(lost_re.match(ln) for ln in lost_lines)
+    finally:
+        store.close()
+
+
+# ---------------------------------------------------------------------------
+# C9 — "not recognised" display reflects the store: a selected token with no
+# matching memory is listed; one with a matching memory is not.
+# ---------------------------------------------------------------------------
+
+
+def test_not_recognised_reflects_store(tmp_path: Path) -> None:
+    store = MemoryStore(":memory:")
+    try:
+        store.create(
+            Memory.create_new(
+                content="a story about a lighthouse on the point",
+                memory_type="conversation",
+                domain="us",
+            )
+        )
+        block = _build_recall_block(store, "lighthouse zephyrion", persona_dir=tmp_path)
+        absent = not_recognised_tokens(block)
+        assert "zephyrion" in absent
+        assert "lighthouse" not in absent
+    finally:
+        store.close()

--- a/tests/memory/test_token_selection.py
+++ b/tests/memory/test_token_selection.py
@@ -1,0 +1,223 @@
+"""test_token_selection.py: gating criteria G1..G9 for the recall
+token-selector fix (`changes/recall-token-selector/`).
+
+No live/integration/requires_claude_cli markers, runs in default CI. Fast
+(":memory:" SQLite only). Drives the REAL `_extract_recall_tokens` and the
+`tests/memory/recall_eval.py` harness against a synthetic store (user "Bob",
+persona label "Canary", never Phoebe's persona).
+"""
+
+from __future__ import annotations
+
+import time
+
+from brain.chat.prompt import _RECALL_STOPWORDS, _extract_recall_tokens
+from tests.memory.recall_eval import (
+    COMMON_STORE_FRACTION,
+    GOLD,
+    LATENCY_MESSAGE_MIX,
+    seed_store,
+    select_tokens_prf,
+    selection_latency_ms,
+    token_target_recall_at_k,
+)
+
+# ---------------------------------------------------------------------------
+# G1: length-cut failure mode fixed: short content tokens are selected.
+# ---------------------------------------------------------------------------
+
+
+def test_g1_short_content_tokens_selected() -> None:
+    cases = [
+        ("The FBI opened a case file", "fbi"),
+        ("AI is transforming research", "ai"),
+        ("Roy set up a logger", "roy"),
+        ("My cat knocked over the vase", "cat"),
+        ("CIA agents met with Ada yesterday", "cia"),
+        ("CIA agents met with Ada yesterday", "ada"),
+    ]
+    store, _ = seed_store(COMMON_STORE_FRACTION)
+    try:
+        for msg, tok in cases:
+            selected = _extract_recall_tokens(msg, store)
+            assert tok in selected, f"{tok!r} missing from selection of {msg!r}: {selected}"
+    finally:
+        store.close()
+
+
+# ---------------------------------------------------------------------------
+# G2: case-fold-then-stopword failure mode fixed: a mid-sentence Titlecase
+# proper noun survives the stoplist even when its lowered form is a
+# stopword.
+# ---------------------------------------------------------------------------
+
+
+def test_g2_mid_sentence_titlecase_survives_stoplist() -> None:
+    store, _ = seed_store(COMMON_STORE_FRACTION)
+    try:
+        assert "will" in _extract_recall_tokens("I think Will can help", store)
+        assert "may" in _extract_recall_tokens("Ask May about it", store)
+        assert "simply" in _extract_recall_tokens("I love Simply Orange juice", store)
+    finally:
+        store.close()
+
+
+# ---------------------------------------------------------------------------
+# G3: domain words: no regression, and the stoplist stays untouched.
+# ---------------------------------------------------------------------------
+
+
+def test_g3_domain_words_still_selected() -> None:
+    store, _ = seed_store(COMMON_STORE_FRACTION)
+    try:
+        assert "random" in _extract_recall_tokens("training a random forest", store)
+        assert "question" in _extract_recall_tokens("my research question is", store)
+    finally:
+        store.close()
+
+
+def test_g3_stoplist_excludes_domain_words() -> None:
+    for word in ("question", "random", "quick", "popped", "simply"):
+        assert word not in _RECALL_STOPWORDS, f"{word!r} must not be in _RECALL_STOPWORDS"
+
+
+# ---------------------------------------------------------------------------
+# G4: over-drop guard: stopworded filler is absent, paired with content
+# words from the same message surviving (so the drop is not the matcher
+# failing open).
+# ---------------------------------------------------------------------------
+
+
+def test_g4_overdrop_guard_pairs_absence_with_content_survival() -> None:
+    store, _ = seed_store(COMMON_STORE_FRACTION)
+    try:
+        selected_the_and = _extract_recall_tokens("I saw the cat and the dog", store)
+        assert "the" not in selected_the_and
+        assert "and" not in selected_the_and
+        assert "cat" in selected_the_and
+        assert "dog" in selected_the_and
+
+        selected_okay = _extract_recall_tokens("Okay, so what next", store)
+        assert "okay" not in selected_okay
+        assert "next" in selected_okay
+    finally:
+        store.close()
+
+
+# ---------------------------------------------------------------------------
+# G5: eval harness runs and reports P/R/F1 >= 0.80 on the hand-labeled
+# GOLD set.
+# ---------------------------------------------------------------------------
+
+
+def test_g5_gold_f1_meets_floor() -> None:
+    assert len(GOLD) >= 30, "GOLD set must have at least 30 labeled messages"
+    store, _ = seed_store(COMMON_STORE_FRACTION)
+    try:
+        prf = select_tokens_prf(GOLD, store)
+        assert prf["f1"] >= 0.80, f"gold F1 below floor: {prf}"
+    finally:
+        store.close()
+
+
+# ---------------------------------------------------------------------------
+# G6: latency guard: sub-millisecond mean per call on a seeded store, and
+# the harness itself is shown able to fail with an injected 2ms delay.
+# ---------------------------------------------------------------------------
+
+
+def test_g6_latency_sub_millisecond() -> None:
+    store, _ = seed_store(COMMON_STORE_FRACTION)
+    try:
+        latency_ms = selection_latency_ms(LATENCY_MESSAGE_MIX, 1000, store)
+        assert latency_ms < 1.0, f"mean latency {latency_ms:.4f} ms exceeds the 1 ms budget"
+    finally:
+        store.close()
+
+
+def test_g6_latency_harness_is_able_to_fail() -> None:
+    """Same harness, with an artificial 2ms delay injected into the store's
+    term_stats call, must report over the 1ms budget. Demonstrates the
+    latency oracle can actually fail rather than always passing."""
+
+    class _SlowStore:
+        def __init__(self, inner):
+            self._inner = inner
+
+        def term_stats(self, terms):
+            time.sleep(2e-3)
+            return self._inner.term_stats(terms)
+
+    store, _ = seed_store(COMMON_STORE_FRACTION)
+    try:
+        slow_latency_ms = selection_latency_ms(LATENCY_MESSAGE_MIX, 20, _SlowStore(store))
+        assert slow_latency_ms > 1.0, (
+            f"sleep-shimmed harness reported {slow_latency_ms:.4f} ms, expected over budget"
+        )
+    finally:
+        store.close()
+
+
+# ---------------------------------------------------------------------------
+# G7: end-to-end recall on the newly-admitted token classes (short name,
+# acronym, short noun), via the real surfaced_ids / _build_recall_block
+# path.
+# ---------------------------------------------------------------------------
+
+
+def test_g7_end_to_end_recall_for_newly_admitted_token_classes() -> None:
+    result = token_target_recall_at_k()
+    assert set(result) == {"roy", "acronym", "noun"}
+    for key, value in result.items():
+        assert value == 1.0, f"{key!r} pair failed recall@k: {result}"
+
+
+# ---------------------------------------------------------------------------
+# G9: newly-admitted short/proper tokens do not crowd out in-store content
+# under cap pressure.
+# ---------------------------------------------------------------------------
+
+
+def test_g9_cap_pressure_favors_in_store_tokens() -> None:
+    store, _ = seed_store(COMMON_STORE_FRACTION)
+    try:
+        # Content words the seeded store has actually seen (df > 0), all
+        # len >= 4 and not stopworded, so the OLD (base, len >= 4) rule
+        # would have selected every one of them too.
+        in_store_words = ["garbage", "treasure", "logger", "live", "first", "quick", "memory"]
+        # Newly-admitted short tokens (df == 0 in this store): acronyms and
+        # short proper names absent from the corpus.
+        new_words = ["ai", "cat", "ada", "cia", "hat"]
+        msg = " ".join(in_store_words + new_words)
+        assert len(in_store_words) + len(new_words) > 10, "message must exceed the 10-token cap"
+
+        stats = store.term_stats(in_store_words + new_words)
+        base_selected = {
+            w
+            for w in in_store_words
+            if stats.get(w, (0, 0.0))[0] > 0 and len(w) >= 4 and w not in _RECALL_STOPWORDS
+        }
+        assert base_selected == set(in_store_words), (
+            "sanity check: every in_store_words entry must qualify under the base len>=4 rule"
+        )
+        for w in new_words:
+            assert stats.get(w, (0, 0.0))[0] == 0, f"{w!r} must be df==0 in the seeded store"
+
+        selected = set(_extract_recall_tokens(msg, store))
+        missing = base_selected - selected
+        assert not missing, f"in-store tokens evicted under cap pressure: {missing}"
+    finally:
+        store.close()
+
+
+# ---------------------------------------------------------------------------
+# A3: degraded store=None path: no crash, shape-only survival still works.
+# ---------------------------------------------------------------------------
+
+
+def test_degraded_store_none_no_crash_shape_only_survival() -> None:
+    selected = _extract_recall_tokens("Ada met FBI about AI", None)
+    assert selected, "degraded path must not return empty on a message with clear content"
+    assert "ada" in selected
+    assert "fbi" in selected
+    assert "ai" in selected

--- a/tests/recovery/test_source_reader.py
+++ b/tests/recovery/test_source_reader.py
@@ -111,3 +111,18 @@ def test_peak_emotion_intensity_defaults_zero_for_old_schema(tmp_path):
     src = _mk_old_schema_source(tmp_path)
     mems = read_source_memories(src)
     assert mems["m1"].peak_emotion_intensity == 0.0
+
+
+def test_recall_count_round_trips_as_float(tmp_path):
+    """G6 (recall-reinforcement): a source row with a fractional recall_count
+    (as a REAL-typed post-fractional-bump DB would carry) round-trips as
+    1.6 — not truncated to 1 by an int() cast."""
+    src = _mk_v033_schema_source(tmp_path, subdir="src_frac")
+    conn = sqlite3.connect(src / "memories.db")
+    conn.execute("UPDATE memories SET recall_count = 1.6 WHERE id = 'm2'")
+    conn.commit()
+    conn.close()
+
+    mems = read_source_memories(src)
+    assert mems["m2"].recall_count == 1.6
+    assert isinstance(mems["m2"].recall_count, float)

--- a/tests/test_consolidation_gate.py
+++ b/tests/test_consolidation_gate.py
@@ -1,0 +1,383 @@
+"""Tests for the temporary memory-consolidation gate (Root 2 stopgap).
+
+Covers the gating acceptance criteria C1-C14 + C18 from
+changes/tempgate-memory-consolidation/1.5-criteria.md. Pass-2 decisions are
+driven by an injected STUB classifier so the mechanism is verified without a
+live model (C16 — real Haiku decision quality — is advisory/live, not here).
+
+Naming: synthetic user = Bob, persona = Canary, model = Claude. No Phoebe.
+"""
+
+from __future__ import annotations
+
+import threading
+
+import pytest
+
+from brain.engines.consolidation import (
+    _ARCHIVE_FILENAME,
+    _GATE_LOCK_FILENAME,
+    Decision,
+    run_consolidation,
+)
+from brain.memory.hebbian import HebbianMatrix
+from brain.memory.pending import (
+    GATE_BYPASS_TYPES,
+    SALIENCE_ELIGIBLE_TYPES,
+    PendingQueue,
+    route_write,
+)
+from brain.memory.store import Memory, MemoryStore
+from brain.utils.file_lock import file_lock
+
+
+@pytest.fixture
+def persona(tmp_path):
+    """A persona dir with a MemoryStore + HebbianMatrix + PendingQueue."""
+    store = MemoryStore(tmp_path / "memories.db")
+    hebbian = HebbianMatrix(tmp_path / "hebbian.db")
+    queue = PendingQueue(tmp_path)
+    yield tmp_path, store, hebbian, queue
+    store.close()
+    hebbian.close()
+
+
+def _mem(content, mtype="dream", *, emotions=None, importance=None, domain="us"):
+    return Memory.create_new(
+        content=content,
+        memory_type=mtype,
+        domain=domain,
+        emotions=emotions or {},
+        importance=importance,
+    )
+
+
+def _stub(mapping):
+    """Classifier returning a fixed Decision per candidate content."""
+
+    def _c(cand, _context):
+        return mapping.get(cand.content, Decision("new"))
+
+    return _c
+
+
+# --------------------------------------------------------------------------- C1
+def test_c1_automatic_gated_write_enqueues_not_in_db(persona):
+    tmp, store, _heb, queue = persona
+    m = _mem("Canary had a flat dream", "dream")
+    route_write(store, m, source="dream")
+    # In the queue, NOT in memories.db.
+    assert queue.read_recent("dream", limit=10)
+    assert store.search_text("flat dream") == []
+
+
+# --------------------------------------------------------------------------- C2
+def test_c2_candidate_never_in_recall_but_promoted_is(persona):
+    from brain.chat.prompt import _build_recall_block
+
+    tmp, store, _heb, queue = persona
+    queue.enqueue(_mem("Bob mentioned the harbor", "monologue"), source="x")
+    # Candidate is invisible to the real recall block (it is not a memories.db row).
+    assert store.search_text("harbor") == []
+    assert "harbor" not in _build_recall_block(store, "harbor")
+    # A genuine memory with matching content DOES surface in recall.
+    store.create(_mem("the harbor at dawn", "conversation"))
+    assert any("harbor" in m.content for m in store.search_text("harbor"))
+    assert "harbor" in _build_recall_block(store, "harbor")
+
+
+# --------------------------------------------------------------------------- C3
+def test_c3_interior_continuity_reads_queue(persona):
+    from brain.monologue.ambient import _AMBIENT_LIMIT, build_interior_continuity_block
+    from brain.monologue.recall import recall_monologue
+    from brain.monologue.trace import MONOLOGUE_TRACE_TYPE
+
+    tmp, store, hebbian, queue = persona
+    for i in range(3):
+        queue.enqueue(
+            _mem(f"Canary thought number {i}", MONOLOGUE_TRACE_TYPE, importance=0.3),
+            source="trace",
+        )
+    block = build_interior_continuity_block(store)
+    assert "Canary thought number" in block
+    assert _AMBIENT_LIMIT == 5  # owner directive 3: unchanged
+    # recall_monologue also reads the queue.
+    res = recall_monologue("number", store=store, hebbian=hebbian, persona_dir=tmp)
+    assert res["count"] >= 1
+
+
+# --------------------------------------------------------------------------- C4
+def test_c4_reject_discards_no_side_effects(persona):
+    tmp, store, hebbian, queue = persona
+    queue.enqueue(_mem("dup content", "dream"), source="x")
+    before = store.count(active_only=False)
+    run_consolidation(
+        store, persona_dir=tmp, hebbian=hebbian,
+        classifier=_stub({"dup content": Decision("duplicate")}),
+    )
+    assert store.count(active_only=False) == before  # nothing created
+    assert not (tmp / _ARCHIVE_FILENAME).exists()  # no archive
+    assert not (tmp / "forgotten_memories.jsonl").exists()  # no grief graveyard entry
+    edge_count = hebbian._conn.execute("SELECT COUNT(*) FROM hebbian_edges").fetchone()[0]
+    assert edge_count == 0  # no edges created at all
+    assert queue.drain() == []  # candidate consumed, not re-queued
+
+
+# --------------------------------------------------------------------------- C5
+def test_c5_promote_creates_row_and_round_trips_fields(persona):
+    tmp, store, hebbian, queue = persona
+    m = _mem("distinct memory", "dream", emotions={"joy": 4.0}, importance=6.5)
+    m.tags = ["t1", "t2"]
+    m.metadata = {"k": "v"}
+    queue.enqueue(m, source="x")
+    run_consolidation(
+        store, persona_dir=tmp, hebbian=hebbian,
+        classifier=_stub({"distinct memory": Decision("new")}),
+    )
+    hits = store.search_text("distinct memory")
+    assert len(hits) == 1
+    got = hits[0]
+    assert got.emotions == {"joy": 4.0}
+    assert got.importance == 6.5
+    assert set(got.tags) == {"t1", "t2"}
+    assert got.metadata.get("k") == "v"
+
+
+# --------------------------------------------------------------------------- C6
+def test_c6_pass1_exact_dup_only_never_non_identical(persona):
+    tmp, store, hebbian, queue = persona
+    # (a) within-batch exact repeat (normalized): one dropped
+    queue.enqueue(_mem("The Dog Ate.", "dream"), source="x")
+    queue.enqueue(_mem("the dog   ate.", "dream"), source="x")  # same after normalize
+    # (b) high-overlap non-identical pair: both survive
+    queue.enqueue(_mem("the dog ate cat food", "dream"), source="x")
+    queue.enqueue(_mem("the dog ate the cat as food", "dream"), source="x")
+    res = run_consolidation(
+        store, persona_dir=tmp, hebbian=hebbian, classifier=_stub({}),  # all "new"
+    )
+    assert res.exact_dropped == 1  # exactly one exact repeat dropped
+    # both non-identical survivors promoted; the surviving exact + the two = 3 rows
+    contents = [m.content for m in store.list_active()]
+    assert "the dog ate cat food" in contents
+    assert "the dog ate the cat as food" in contents
+
+
+def test_c6_exact_dup_vs_existing_db(persona):
+    tmp, store, hebbian, queue = persona
+    store.create(_mem("already committed here", "conversation"))
+    queue.enqueue(_mem("already committed here", "dream"), source="x")
+    res = run_consolidation(store, persona_dir=tmp, hebbian=hebbian, classifier=_stub({}))
+    assert res.exact_dropped == 1
+    assert store.count(active_only=False) == 1  # nothing new added
+
+
+# --------------------------------------------------------------------------- C7
+def test_c7_merge_archives_surgical_no_graveyard(persona):
+    tmp, store, hebbian, queue = persona
+    target_id = store.create(_mem("Bob likes tea", "conversation"))
+    queue.enqueue(_mem("Bob likes tea with honey", "dream"), source="x")
+    run_consolidation(
+        store, persona_dir=tmp, hebbian=hebbian,
+        classifier=_stub({
+            "Bob likes tea with honey": Decision(
+                "merge", target_id=target_id,
+                merged_content="Bob likes tea with honey",
+            )
+        }),
+    )
+    # (a) pre-image archived to the PLAIN archive (not the grief graveyard)
+    assert (tmp / _ARCHIVE_FILENAME).exists()
+    archive = (tmp / _ARCHIVE_FILENAME).read_text()
+    assert "Bob likes tea" in archive
+    assert not (tmp / "forgotten_memories.jsonl").exists()  # grief graveyard untouched
+    # (b) target edited to contain the new fact; (d) candidate not also promoted
+    got = store.get(target_id)
+    assert "honey" in got.content
+    assert store.count(active_only=False) == 1  # only the (edited) target, no new row
+
+
+def test_c7_merge_defers_when_target_missing(persona):
+    tmp, store, hebbian, queue = persona
+    queue.enqueue(_mem("orphan merge", "dream"), source="x")
+    res = run_consolidation(
+        store, persona_dir=tmp, hebbian=hebbian,
+        classifier=_stub({"orphan merge": Decision("merge", target_id="nonexistent")}),
+    )
+    assert res.deferred == 1
+    assert queue.read_recent("dream", limit=5)  # re-enqueued for next tick
+
+
+# --------------------------------------------------------------------------- C8
+def test_c8_correction_promotes_and_links_weight5(persona):
+    tmp, store, hebbian, queue = persona
+    ref_id = store.create(_mem("the meeting is at 3pm", "conversation"))
+    queue.enqueue(_mem("actually the meeting is at 4pm", "dream"), source="x")
+    run_consolidation(
+        store, persona_dir=tmp, hebbian=hebbian,
+        classifier=_stub({
+            "actually the meeting is at 4pm": Decision("correction", target_id=ref_id)
+        }),
+    )
+    hits = store.search_text("at 4pm")
+    assert len(hits) == 1  # kept as its own memory
+    new_id = hits[0].id
+    assert hits[0].metadata.get("correction_of") == ref_id
+    weight = dict(hebbian.neighbors(new_id)).get(ref_id)
+    assert weight == 5.0
+
+
+def test_c8_weight5_over_preexisting_weak_edge(persona):
+    tmp, store, hebbian, queue = persona
+    ref_id = store.create(_mem("part A of the story", "conversation"))
+    # Promote first so both ids exist, then seed a weak edge, then correct.
+    cand = _mem("part B continues the story", "dream")
+    queue.enqueue(cand, source="x")
+    # pre-seed a weak edge between the (soon-to-exist) candidate id and ref
+    hebbian.strengthen(cand.id, ref_id, delta=0.5)
+    assert dict(hebbian.neighbors(cand.id)).get(ref_id) == 0.5
+    run_consolidation(
+        store, persona_dir=tmp, hebbian=hebbian,
+        classifier=_stub({
+            "part B continues the story": Decision("continuation", target_id=ref_id)
+        }),
+    )
+    assert dict(hebbian.neighbors(cand.id)).get(ref_id) == 5.0  # raised, not left at 0.5
+
+
+# --------------------------------------------------------------------------- C9
+def test_c9_gate_runs_before_reflex_in_run_tick():
+    import inspect
+
+    from brain.engines import heartbeat
+
+    src = inspect.getsource(heartbeat.HeartbeatEngine.run_tick)
+    assert "run_consolidation(" in src
+    assert src.index("run_consolidation(") < src.index("_try_fire_reflex(")
+
+
+# -------------------------------------------------------------------------- C10
+def test_c10_no_candidate_lost_under_enqueue_drain_race(persona):
+    tmp, store, _heb, queue = persona
+    n = 60
+    drained: list[dict] = []
+    lock = threading.Lock()
+    start = threading.Event()
+
+    def enqueue_worker():
+        start.wait()
+        for i in range(n):
+            queue.enqueue(_mem(f"race {i}", "dream"), source="x")
+
+    def drain_worker():
+        start.wait()
+        for _ in range(30):
+            got = queue.drain()
+            if got:
+                with lock:
+                    drained.extend(got)
+
+    threads = [threading.Thread(target=enqueue_worker), threading.Thread(target=drain_worker)]
+    for t in threads:
+        t.start()
+    start.set()
+    for t in threads:
+        t.join()
+    remaining = queue.drain()
+    total = len(drained) + len(remaining)
+    assert total == n  # every enqueued candidate is accounted for — none lost
+
+
+def test_file_lock_non_blocking_contract(tmp_path):
+    """file_lock(blocking=False) yields True when acquired, False when contended,
+    and never holds the lock on a False (the gate's skip contract; the path the
+    Windows branch must also honour)."""
+    p = tmp_path / "x.dat"
+    with file_lock(p, blocking=False) as first:
+        assert first is True
+        with file_lock(p, blocking=False) as second:
+            assert second is False  # a second holder is refused, not blocked
+    # released on exit — acquirable again
+    with file_lock(p, blocking=False) as third:
+        assert third is True
+
+
+# -------------------------------------------------------------------------- C11
+def test_c11_overlapping_gate_run_skips(persona):
+    tmp, store, hebbian, queue = persona
+    queue.enqueue(_mem("only once", "dream"), source="x")
+    # Hold the gate lock, then a concurrent run must SKIP (not drain/act).
+    with file_lock(tmp / _GATE_LOCK_FILENAME, blocking=False) as acquired:
+        assert acquired
+        res = run_consolidation(store, persona_dir=tmp, hebbian=hebbian, classifier=_stub({}))
+        assert res.skipped is True
+    # queue untouched by the skipped run
+    assert queue.read_recent("dream", limit=5)
+
+
+def test_c11_merge_folded_exactly_once(persona):
+    tmp, store, hebbian, queue = persona
+    target_id = store.create(_mem("base fact", "conversation"))
+    queue.enqueue(_mem("base fact plus extra", "dream"), source="x")
+    run_consolidation(
+        store, persona_dir=tmp, hebbian=hebbian,
+        classifier=_stub({
+            "base fact plus extra": Decision(
+                "merge", target_id=target_id, merged_content="base fact plus extra"
+            )
+        }),
+    )
+    # exactly one archive record (one fold)
+    lines = (tmp / _ARCHIVE_FILENAME).read_text().strip().splitlines()
+    assert len(lines) == 1
+
+
+# -------------------------------------------------------------------------- C12
+def test_c12_deliberate_bypass_types_write_direct(persona):
+    tmp, store, _heb, queue = persona
+    for bypass in sorted(GATE_BYPASS_TYPES):
+        m = _mem(f"deliberate {bypass}", bypass)
+        route_write(store, m, source="deliberate")
+        assert store.search_text(f"deliberate {bypass}")  # in memories.db
+    assert queue.drain() == []  # nothing enqueued
+
+
+# -------------------------------------------------------------------------- C14
+def test_c14_temp_marker_present():
+    from pathlib import Path
+
+    for f in ("brain/memory/pending.py", "brain/engines/consolidation.py"):
+        text = Path(f).read_text()
+        assert "TEMP (Root 2 stopgap" in text
+
+
+# -------------------------------------------------------------------------- C18
+def test_c18_salience_scoped_legit_content_survives(persona):
+    tmp, store, hebbian, queue = persona
+    # exempt types with low/zero importance — must SURVIVE a floor of 1.0
+    queue.enqueue(_mem("a flat dream", "dream", emotions={}), source="x")  # importance 0.0
+    queue.enqueue(_mem("some research note", "research", emotions={"x": 2.0}), source="x")
+    from brain.monologue.trace import MONOLOGUE_TRACE_TYPE
+
+    queue.enqueue(_mem("a trace thought", MONOLOGUE_TRACE_TYPE, importance=0.3), source="x")
+    # an ELIGIBLE episode below the floor — must be DROPPED
+    queue.enqueue(_mem("low value episode", "monologue", importance=0.5), source="x")
+
+    res = run_consolidation(
+        store, persona_dir=tmp, hebbian=hebbian, salience_floor=1.0, classifier=_stub({}),
+    )
+    survived = {m.content for m in store.list_active()}
+    # dream/research promoted; trace stays in the queue (not salience-dropped)
+    assert "a flat dream" in survived
+    assert "some research note" in survived
+    assert res.salience_dropped == 1  # only the eligible low episode
+    assert "low value episode" not in survived
+    # trace was exempt — it survived Pass 1 and (as monologue_trace) promoted
+    assert "a trace thought" in survived
+
+
+def test_c18_eligible_types_are_only_episode_types():
+    assert SALIENCE_ELIGIBLE_TYPES == {
+        "monologue", "monologue_emotion", "monologue_soul_candidate"
+    }
+    assert "dream" not in SALIENCE_ELIGIBLE_TYPES
+    assert "monologue_trace" not in SALIENCE_ELIGIBLE_TYPES

--- a/tests/test_gate_coverage.py
+++ b/tests/test_gate_coverage.py
@@ -3,9 +3,10 @@
 TEMP — companion to tests/test_consolidation_gate.py. These tests close the coverage the
 isolation tests missed (change: changes/gate-leak-coverage/):
 
-- G1-G4: the four automatic writers the owner ordered GATED
-  (self_model_reconcile / self_model_resolved / making / file_write) now route through
-  ``route_write`` — a candidate lands in the pending queue and ZERO rows reach memories.db.
+- G1-G4: four automatic writers routed through ``route_write``. G2-G4
+  (self_model_resolved / making / file_write) are GATED — a candidate lands in the pending
+  queue and ZERO rows reach memories.db. G1 (self_model_reconcile) is a later owner-decision
+  BYPASS (GATE_BYPASS_TYPES in brain/memory/pending.py) — it commits straight to memories.db.
 - G5: a LIVE-PATH integration test proving the gate FIRES end-to-end when the real per-turn
   write path runs (monologue capture + the public pass-2 ``apply_side_effects`` wrapper) — the
   coverage that would have caught the Run-#1 apparatus regression at unit level.
@@ -83,8 +84,9 @@ def registered_channel():
     vocabulary._unregister(_TEST_CHANNEL)
 
 
-# ── G1-G4: each newly-routed automatic writer enqueues, none reach memories.db ──
-def test_g1_reconcile_routes_to_queue(tmp_path, registered_channel):
+# ── G1: self_model_reconcile BYPASSES the gate (owner decision); G2-G4: each
+# remaining newly-routed automatic writer enqueues, none reach memories.db ──
+def test_g1_reconcile_bypasses_gate(tmp_path, registered_channel):
     """self_model_reconcile BYPASSES the gate (owner decision, GATE_BYPASS_TYPES in
     brain/memory/pending.py): it commits straight to memories.db so a self-authored
     emotional nudge affects felt state immediately."""

--- a/tests/test_gate_coverage.py
+++ b/tests/test_gate_coverage.py
@@ -1,0 +1,304 @@
+"""Coverage tests for the Phase-1 consolidation gate (Root-2 stopgap).
+
+TEMP — companion to tests/test_consolidation_gate.py. These tests close the coverage the
+isolation tests missed (change: changes/gate-leak-coverage/):
+
+- G1-G4: the four automatic writers the owner ordered GATED
+  (self_model_reconcile / self_model_resolved / making / file_write) now route through
+  ``route_write`` — a candidate lands in the pending queue and ZERO rows reach memories.db.
+- G5: a LIVE-PATH integration test proving the gate FIRES end-to-end when the real per-turn
+  write path runs (monologue capture + the public pass-2 ``apply_side_effects`` wrapper) — the
+  coverage that would have caught the Run-#1 apparatus regression at unit level.
+- G6: a direct-write coverage guard — enumerates every ``.create(`` under brain/ and asserts
+  it is a subset of a pinned allowlist, so a NEW automatic writer that bypasses the gate (any
+  receiver name) or a regression of a routed locus fails CI.
+- G7: the owner-BYPASS writers (grief_event / kindled_peer) stay direct — guards the owner
+  ruling against an over-eager "route everything" edit.
+- A2 (advisory): documents the file_write exact-dup cross-tick drop (designed gate behavior).
+
+None of these are marked ``integration``/``live``/``requires_claude_cli`` — they must run in the
+default CI selection (that is the whole point: the missed coverage runs in CI).
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from brain.emotion import vocabulary
+from brain.memory.pending import PendingQueue
+from brain.memory.store import Memory, MemoryStore
+
+_BRAIN_ROOT = Path(__file__).resolve().parents[1] / "brain"
+_TEST_CHANNEL = "gatecoverage_channel"
+
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+def _db_count(persona_dir: Path, memory_type: str) -> int:
+    db = persona_dir / "memories.db"
+    if not db.exists():
+        return 0
+    conn = sqlite3.connect(db)
+    try:
+        return conn.execute(
+            "SELECT COUNT(*) FROM memories WHERE memory_type=?", (memory_type,)
+        ).fetchone()[0]
+    finally:
+        conn.close()
+
+
+def _queue_types(persona_dir: Path) -> list[str]:
+    import json
+
+    q = persona_dir / "pending_candidates.jsonl"
+    if not q.exists():
+        return []
+    out = []
+    for line in q.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if line:
+            out.append(json.loads(line).get("memory_type"))
+    return out
+
+
+def _mem(content: str, mtype: str) -> Memory:
+    return Memory.create_new(content=content, memory_type=mtype, domain="test")
+
+
+@pytest.fixture
+def registered_channel():
+    """Register a test emotion channel (registry is process-global; clean up after)."""
+    vocabulary._unregister(_TEST_CHANNEL)
+    vocabulary.register(
+        vocabulary.Emotion(
+            name=_TEST_CHANNEL,
+            description="test-only channel for gate-coverage tests",
+            category="persona_extension",
+            decay_half_life_days=None,
+        )
+    )
+    yield _TEST_CHANNEL
+    vocabulary._unregister(_TEST_CHANNEL)
+
+
+# ── G1-G4: each newly-routed automatic writer enqueues, none reach memories.db ──
+def test_g1_reconcile_routes_to_queue(tmp_path, registered_channel):
+    from brain.self_model.reconcile import _write_self_authored_delta
+
+    wrote = _write_self_authored_delta(tmp_path, registered_channel, 0.5)
+    assert wrote is True
+    assert _queue_types(tmp_path).count("self_model_reconcile") == 1
+    assert _db_count(tmp_path, "self_model_reconcile") == 0  # gated, not in recall
+
+
+def test_g2_resolve_routes_and_still_queues_soul(tmp_path):
+    from brain.self_model.gap import Gap
+    from brain.self_model.resolve import _emit_resolution
+
+    gap = Gap(per_channel={"warmth": 0.5}, magnitude=0.5, unnamed_pressure=0.0)
+    _emit_resolution(tmp_path, gap, resolution_path="reconcile", session_id="s1")
+    assert _queue_types(tmp_path).count("self_model_resolved") == 1
+    assert _db_count(tmp_path, "self_model_resolved") == 0
+    # routing did not break the soul-candidate side-effect (importance 9 >= threshold)
+    assert (tmp_path / "soul_candidates.jsonl").exists()
+
+
+def test_g3_maker_routes_to_queue(tmp_path):
+    from brain.maker.maker import Making
+    from brain.maker.wiring import write_making_memory
+
+    store = MemoryStore(tmp_path / "memories.db")
+    try:
+        making = Making(type="poem", title="untitled", content="x", disposition="private")
+        write_making_memory(store, making, emotions={})
+    finally:
+        store.close()
+    assert _queue_types(tmp_path).count("making") == 1
+    assert _db_count(tmp_path, "making") == 0
+
+
+def test_g4_file_write_routes_to_queue(tmp_path):
+    from datetime import UTC, datetime
+
+    from brain.files import pending as files_pending
+    from brain.files.commit import decline_write
+
+    store = MemoryStore(tmp_path / "memories.db")
+    try:
+        rid = files_pending.create(
+            tmp_path,
+            op="create",
+            resolved_path=str(tmp_path / "note.txt"),
+            content="hi",
+            now=datetime.now(UTC),
+        )
+        res = decline_write(tmp_path, rid, store=store)
+    finally:
+        store.close()
+    assert res["ok"] is True
+    assert _queue_types(tmp_path).count("file_write") == 1
+    assert _db_count(tmp_path, "file_write") == 0
+
+
+# ── G5: LIVE-PATH integration — the gate demonstrably FIRES end-to-end ──────────
+def test_g5_live_path_gate_fires_end_to_end(tmp_path, registered_channel):
+    """Drive the real per-turn write path in-process; prove the gate fires.
+
+    monologue capture path (the real record_monologue handler → write_trace_memory) +
+    the public apply_side_effects wrapper (the one tool_loop.py's pass-2 worker calls).
+    """
+    from brain.chat.extractor import ExtractorOutput, MemoryWrite, apply_side_effects
+    from brain.chat.monologue_capture import capture_monologue
+
+    store = MemoryStore(tmp_path / "memories.db")
+    try:
+        capture_monologue(
+            persona_dir=tmp_path,
+            store=store,
+            monologue="Bob mentioned his knee PT is going well.",
+            feed_digest="thinking about Bob's PT",
+        )
+    finally:
+        store.close()
+
+    out = ExtractorOutput(
+        memory_writes=[MemoryWrite(episode="Bob's knee PT is improving.", salience=0.7)],
+        emotion_delta={registered_channel: 0.3},
+    )
+    apply_side_effects(out, persona_dir=tmp_path)
+
+    # The gate FIRED: the pending queue was created and populated ...
+    pend = tmp_path / "pending_candidates.jsonl"
+    assert pend.exists(), "pending_candidates.jsonl was never created — gate is a no-op"
+    qtypes = _queue_types(tmp_path)
+    assert qtypes, "pending queue is empty — nothing was enqueued"
+    assert "monologue_trace" in qtypes  # from capture_monologue
+    assert "monologue" in qtypes  # from apply_side_effects memory_writes
+    # ... and NO gated type leaked straight into the recall channel.
+    for gated in ("monologue", "monologue_trace", "monologue_emotion"):
+        assert _db_count(tmp_path, gated) == 0, f"{gated} leaked into memories.db"
+
+    # Shown-able-to-fail: the oracle distinguishes a gated write that DOES reach the DB
+    # (an ungated direct store.create — the pre-gate behavior). If this assertion could not
+    # fire, the zero-checks above would be meaningless.
+    s2 = MemoryStore(tmp_path / "memories.db")
+    try:
+        s2.create(_mem("ungated monologue stand-in", "monologue"))
+    finally:
+        s2.close()
+    assert _db_count(tmp_path, "monologue") == 1
+
+
+# ── G6: direct-write coverage guard (fails safe on any novel/aliased receiver) ──
+# Pinned by (relpath, exact stripped line-text) so unrelated line shifts don't false-fail.
+# List 1 — KNOWN-NON-MEMORY .create( (brain.files.pending, NOT a MemoryStore):
+_KNOWN_NON_MEMORY = {
+    ("tools/impls/propose_write.py",
+     "rid = pending.create(persona_dir, op=op, resolved_path=str(g.resolved),"),
+    ("tools/impls/propose_write.py",
+     "rid = pending.create(persona_dir, op=op, resolved_path=str(g.resolved), content=content,"),
+}
+# List 2 — ALLOWED-DIRECT memory writes (legitimately direct; see 2-plan.md):
+_ALLOWED_DIRECT = {
+    ("body/events.py", "store.create(journal)"),
+    ("engines/consolidation.py", "store.create(cand)"),
+    ("grief/breadcrumb.py", "return store.create(memory)"),
+    ("kindled_link/relationship.py", "mem_store.create(mem)"),
+    ("memory/pending.py", "return store.create(mem)"),
+    ("migrator/cli.py", "store.create(mem)"),
+    ("migrator/cli.py", "soul_store.create(crystal)"),
+    ("migrator/emergence_kit.py", "soul_store.create(crystal)"),
+    ("migrator/emergence_kit.py", "store.create(mem)"),
+    ("recovery/engine.py", "store.create(mem)"),
+    ("soul/review.py", "soul_store.create(c)"),
+    ("tools/impls/add_journal.py", "store.create(memory)"),
+    ("tools/impls/add_memory.py", "store.create(memory)"),
+    ("tools/impls/crystallize_soul.py", "soul_store.create(c)"),
+}
+_PINNED = _KNOWN_NON_MEMORY | _ALLOWED_DIRECT
+_ROUTED_LOCI = {
+    "self_model/reconcile.py",
+    "self_model/resolve.py",
+    "maker/wiring.py",
+    "files/commit.py",
+}
+
+
+def _enumerate_create_sites(root: Path = _BRAIN_ROOT) -> set[tuple[str, str]]:
+    found: set[tuple[str, str]] = set()
+    for py in root.rglob("*.py"):
+        rel = py.relative_to(root).as_posix()
+        for raw in py.read_text(encoding="utf-8").splitlines():
+            line = raw.strip()
+            if ".create(" in line and ".create_new(" not in line:
+                found.add((rel, line))
+    return found
+
+
+def test_g6_no_ungated_direct_create_writer():
+    found = _enumerate_create_sites()
+    unpinned = found - _PINNED
+    assert not unpinned, (
+        "Un-allowlisted direct .create( site(s) found — an automatic memory writer may be "
+        "bypassing the consolidation gate. Route it through brain.memory.pending.route_write, "
+        "or (if a legitimate bypass) add it to the pinned allowlist in this test with a reason:\n"
+        + "\n".join(f"  {rel}: {txt}" for rel, txt in sorted(unpinned))
+    )
+    # A routed locus must NOT reappear as a direct .create( (regression tripwire).
+    for rel, _txt in found:
+        assert rel not in _ROUTED_LOCI, f"routed locus regressed to direct .create(: {rel}"
+
+
+def test_g6_guard_can_fail(tmp_path):
+    """Shown-able-to-fail: run the REAL enumerator against a synthetic novel-receiver writer
+    and confirm the guard would flag it (un-pinned) while ignoring .create_new(."""
+    fake_root = tmp_path / "fakebrain"
+    (fake_root / "sub").mkdir(parents=True)
+    (fake_root / "sub" / "new_writer.py").write_text(
+        "def f(s, mem):\n"
+        "    s.create(mem)        # novel aliased receiver — must be caught\n"
+        "    Memory.create_new()  # must NOT be caught (different method)\n",
+        encoding="utf-8",
+    )
+    found = _enumerate_create_sites(fake_root)
+    assert ("sub/new_writer.py", "s.create(mem)        # novel aliased receiver — must be caught") in found
+    # the create_new line is excluded
+    assert not any("create_new" in txt for _rel, txt in found)
+    # and such a novel writer is NOT in the pinned allowlist → test_g6 would FAIL on it
+    assert (found - _PINNED)
+
+
+# ── G7: owner-BYPASS writers stay direct (guards the owner ruling) ──────────────
+def test_g7_bypass_writers_remain_direct():
+    grief = (_BRAIN_ROOT / "grief" / "breadcrumb.py").read_text(encoding="utf-8")
+    kindled = (_BRAIN_ROOT / "kindled_link" / "relationship.py").read_text(encoding="utf-8")
+    # grief_event: significant + low-volume, must NOT be dedup-dropped → direct store.create.
+    assert "return store.create(memory)" in grief
+    assert "route_write" not in grief
+    # kindled_peer: a peer's genuine words, not her firehose → direct mem_store.create.
+    assert "mem_store.create(mem)" in kindled
+    assert "route_write" not in kindled
+
+
+# ── A2 (advisory): document the file_write exact-dup cross-tick drop ─────────────
+def test_a2_file_write_identical_content_dropped_cross_tick(tmp_path):
+    """Advisory (not gating): identical file_write content is dropped by the gate's exact-dup
+    across ticks/sessions (DB-wide, no time bound). Documents the accepted, designed behavior."""
+    from brain.engines.consolidation import run_consolidation
+
+    store = MemoryStore(tmp_path / "memories.db")
+    try:
+        q = PendingQueue(tmp_path)
+        content = "you let me write to /home/bob/notes.txt"
+        # tick 1: first identical → promoted (degraded promote-all classifier, no provider)
+        q.enqueue(_mem(content, "file_write"), source="file_write")
+        run_consolidation(store, persona_dir=tmp_path)
+        assert _db_count(tmp_path, "file_write") == 1
+        # tick 2 (a LATER drain): identical content → dropped by _has_exact_existing (DB-wide)
+        q.enqueue(_mem(content, "file_write"), source="file_write")
+        run_consolidation(store, persona_dir=tmp_path)
+        assert _db_count(tmp_path, "file_write") == 1  # still 1 — permanent cross-tick drop
+    finally:
+        store.close()

--- a/tests/test_gate_coverage.py
+++ b/tests/test_gate_coverage.py
@@ -85,12 +85,15 @@ def registered_channel():
 
 # ── G1-G4: each newly-routed automatic writer enqueues, none reach memories.db ──
 def test_g1_reconcile_routes_to_queue(tmp_path, registered_channel):
+    """self_model_reconcile BYPASSES the gate (owner decision, GATE_BYPASS_TYPES in
+    brain/memory/pending.py): it commits straight to memories.db so a self-authored
+    emotional nudge affects felt state immediately."""
     from brain.self_model.reconcile import _write_self_authored_delta
 
     wrote = _write_self_authored_delta(tmp_path, registered_channel, 0.5)
     assert wrote is True
-    assert _queue_types(tmp_path).count("self_model_reconcile") == 1
-    assert _db_count(tmp_path, "self_model_reconcile") == 0  # gated, not in recall
+    assert _db_count(tmp_path, "self_model_reconcile") == 1
+    assert _queue_types(tmp_path).count("self_model_reconcile") == 0  # bypasses the gate
 
 
 def test_g2_resolve_routes_and_still_queues_soul(tmp_path):
@@ -177,8 +180,13 @@ def test_g5_live_path_gate_fires_end_to_end(tmp_path, registered_channel):
     assert "monologue_trace" in qtypes  # from capture_monologue
     assert "monologue" in qtypes  # from apply_side_effects memory_writes
     # ... and NO gated type leaked straight into the recall channel.
-    for gated in ("monologue", "monologue_trace", "monologue_emotion"):
+    for gated in ("monologue", "monologue_trace"):
         assert _db_count(tmp_path, gated) == 0, f"{gated} leaked into memories.db"
+    # monologue_emotion BYPASSES the gate (owner decision, GATE_BYPASS_TYPES in
+    # brain/memory/pending.py): it commits straight to memories.db so per-turn
+    # emotional nudges affect felt state immediately, not queued for consolidation.
+    assert _db_count(tmp_path, "monologue_emotion") == 1, "monologue_emotion bypass didn't fire"
+    assert "monologue_emotion" not in qtypes, "monologue_emotion should bypass the queue"
 
     # Shown-able-to-fail: the oracle distinguishes a gated write that DOES reach the DB
     # (an ungated direct store.create — the pre-gate behavior). If this assertion could not

--- a/tests/unit/brain/chat/test_extractor_apply.py
+++ b/tests/unit/brain/chat/test_extractor_apply.py
@@ -18,6 +18,29 @@ from brain.chat.extractor import (
 )
 from brain.emotion import vocabulary  # noqa: I001
 
+
+def _promote_pending(persona_dir: Path) -> None:
+    """Promote the persona's pending-candidate queue into memories.db.
+
+    memory-consolidation migration: the extractor's monologue / monologue_emotion
+    / monologue_soul_candidate writes are GATED types — apply_side_effects enqueues
+    them as candidates rather than writing memories.db rows. Tests that assert the
+    end-state DB memory run the consolidation gate with a promote-all classifier
+    (candidate id preserved) so their store.list_active()/store.get() reads hold.
+    """
+    from brain.engines.consolidation import Decision, run_consolidation
+    from brain.memory.store import MemoryStore
+
+    store = MemoryStore(persona_dir / "memories.db")
+    try:
+        run_consolidation(
+            store,
+            persona_dir=persona_dir,
+            classifier=lambda _c, _ctx: Decision("new"),
+        )
+    finally:
+        store.close()
+
 # ---------------------------------------------------------------------------
 # Extension emotion fixture — register/unregister cleanly (registry is
 # process-global; tests MUST clean up per vocab_loaded_on_startup pattern).
@@ -59,6 +82,7 @@ def test_memory_writes_land_in_memorystore(persona_dir: Path):
         memory_writes=[MemoryWrite(episode="searched for Loopy, nothing surfaced", salience=0.4)]
     )
     apply_side_effects(out, persona_dir=persona_dir)
+    _promote_pending(persona_dir)
 
     store = MemoryStore(persona_dir / "memories.db")
     try:
@@ -111,6 +135,7 @@ def test_emotion_delta_applies_memory_with_emotion(persona_dir: Path):
 
     out = ExtractorOutput(emotion_delta={"curiosity": 0.15})
     apply_side_effects(out, persona_dir=persona_dir)
+    _promote_pending(persona_dir)
 
     store = MemoryStore(persona_dir / "memories.db")
     try:
@@ -155,6 +180,7 @@ def test_emotion_delta_excludes_zero_channels_from_both_content_and_vector(perso
     # Use registered vocab names: "curiosity" (baseline) and "fear" (baseline).
     out = ExtractorOutput(emotion_delta={"curiosity": 0.1, "fear": 0.0})
     apply_side_effects(out, persona_dir=persona_dir)
+    _promote_pending(persona_dir)
 
     store = MemoryStore(persona_dir / "memories.db")
     try:
@@ -214,6 +240,7 @@ def test_emotion_delta_drops_unregistered_channels(
         emotion_delta={registered_test_emotion: 0.2, "zorblefright": 0.5}
     )
     apply_side_effects(out, persona_dir=persona_dir)
+    _promote_pending(persona_dir)
 
     store = MemoryStore(persona_dir / "memories.db")
     try:
@@ -307,6 +334,8 @@ def test_crystallisation_queues_theme_and_evidence_combined(persona_dir: Path):
         ]
     )
     apply_side_effects(out, persona_dir=persona_dir)
+
+    _promote_pending(persona_dir)
 
     expected_text = "Ordinary trust — she let the goodnight be ordinary instead of performing it"
 

--- a/tests/unit/brain/chat/test_monologue_capture.py
+++ b/tests/unit/brain/chat/test_monologue_capture.py
@@ -9,6 +9,28 @@ import pytest
 from brain.memory.store import MemoryStore
 
 
+def _promote_pending(persona_dir: Path) -> None:
+    """Promote the persona's pending-candidate queue into memories.db.
+
+    memory-consolidation migration: monologue-trace writes are GATED types —
+    capture_monologue enqueues them as candidates rather than writing
+    memories.db rows directly. Tests that assert the end-state DB memory run
+    the consolidation gate with a promote-all classifier (candidate id
+    preserved) so their store reads hold.
+    """
+    from brain.engines.consolidation import Decision, run_consolidation
+
+    store = MemoryStore(persona_dir / "memories.db")
+    try:
+        run_consolidation(
+            store,
+            persona_dir=persona_dir,
+            classifier=lambda _c, _ctx: Decision("new"),
+        )
+    finally:
+        store.close()
+
+
 def _store(tmp_path: Path) -> MemoryStore:
     return MemoryStore(tmp_path / "memories.db")
 
@@ -126,6 +148,8 @@ def test_identical_monologue_in_one_turn_is_captured_once(tmp_path: Path):
             feed_digest=digest,
         )
 
+    _promote_pending(tmp_path)
+
     traces = store.list_by_type(MONOLOGUE_TRACE_TYPE, active_only=True)
     assert len(traces) == 1, f"one thought, one trace — got {len(traces)}"
 
@@ -143,5 +167,7 @@ def test_a_different_monologue_still_captures(tmp_path: Path):
                       monologue="First thought.", feed_digest="d1")
     capture_monologue(persona_dir=tmp_path, store=store,
                       monologue="Second, different thought.", feed_digest="d2")
+
+    _promote_pending(tmp_path)
 
     assert len(store.list_by_type(MONOLOGUE_TRACE_TYPE, active_only=True)) == 2

--- a/tests/unit/brain/chat/test_monologue_e2e_happy.py
+++ b/tests/unit/brain/chat/test_monologue_e2e_happy.py
@@ -92,6 +92,17 @@ def test_full_turn_updates_all_surfaces(tmp_path: Path):
         cli_throttle.reset()
         pass2_queue.drain_pending()
 
+        # memory-consolidation migration: the pass-2 "monologue" write is a gated
+        # type → enqueued as a pending candidate, not a memories.db row. Promote
+        # the queue (id preserved) so the end-state list_by_type assertion holds.
+        from brain.engines.consolidation import Decision, run_consolidation
+
+        run_consolidation(
+            store,
+            persona_dir=store.persona_dir,
+            classifier=lambda _c, _ctx: Decision("new"),
+        )
+
         recent = list(store.list_by_type("monologue", active_only=True, limit=10))
         assert any("Loopy" in m.content for m in recent), (
             f"no Loopy memory found in {[m.content for m in recent]}"

--- a/tests/unit/brain/chat/test_monologue_trace_e2e.py
+++ b/tests/unit/brain/chat/test_monologue_trace_e2e.py
@@ -3,6 +3,7 @@ via the dispatch entry point (the path the tool loop uses)."""
 import json
 
 from brain.memory.hebbian import HebbianMatrix
+from brain.memory.pending import PendingQueue
 from brain.memory.store import MemoryStore
 from brain.tools.dispatch import dispatch
 
@@ -19,8 +20,9 @@ def test_record_monologue_writes_trace_and_gated_digest(tmp_path):
     )
     assert out["ok"] is True
     assert out["monologue_text"] == "the raw first-person drift"
-    # Tier 2:
-    traces = store.list_by_type("monologue_trace")
+    # Tier 2: monologue_trace is a gated type, so it is enqueued as a pending
+    # candidate (not a memories.db row) — assert against the queue.
+    traces = PendingQueue(store.persona_dir).read_recent("monologue_trace", limit=10)
     assert len(traces) == 1 and traces[0].content == "the raw first-person drift"
     # Tier 3 (withheld):
     line = json.loads((tmp_path / "monologue_digest.jsonl").read_text().splitlines()[0])

--- a/tests/unit/brain/chat/test_prompt.py
+++ b/tests/unit/brain/chat/test_prompt.py
@@ -407,8 +407,12 @@ def test_recall_block_surfaces_keyword_match(
     persona_dir: Path, store: MemoryStore, soul_store: SoulStore
 ) -> None:
     """A user message naming an entity surfaces matching memories."""
+    # "Jordan" leads the content so it survives proportional truncation
+    # (CHANGE 2 — recall-reinforcement): this body is short enough that its
+    # snippet is floored at SNIPPET_MIN_CHARS, and the keyword must fall
+    # inside that floor to remain assertable verbatim.
     mem = Memory.create_new(
-        content="Hana mentioned Jordan once over coffee.",
+        content="Jordan came up once, over coffee with Hana.",
         memory_type="event",
         domain="relationship",
         emotions={"love": 6.0},
@@ -462,7 +466,7 @@ def test_recall_block_handles_no_match(
 def test_recall_block_caps_at_limit(
     persona_dir: Path, store: MemoryStore, soul_store: SoulStore
 ) -> None:
-    """A query that matches many memories surfaces at most ``limit`` (default 5)."""
+    """A query that matches many memories surfaces at most ``limit`` (default SNIPPET_COUNT=8)."""
     for i in range(12):
         store.create(
             Memory.create_new(
@@ -482,15 +486,24 @@ def test_recall_block_caps_at_limit(
         store=store,
         user_input="Tell me about Jordan.",
     )
-    # New forgetting-aware format renders bullets under "  active:" indented with "    - "
+    # New forgetting-aware format renders bullets under "  active:" indented with
+    # '    - <id>: "…"' (memory id now precedes the quoted snippet so
+    # read_full_memory(<id>) is callable — see the recall-snippet-ids follow-up).
     assert "recall" in msg
     assert "active:" in msg
-    # Each active result is a '    - "…"' bullet — cap is still 5 per bucket.
-    # Count quoted bullets (active/fading entries use quoted content) excluding the
-    # unquoted "not recognised" token bullets which have no surrounding quotes.
+    # Cap is SNIPPET_COUNT (8) per bucket (P2). Count bullet lines under the
+    # "active:" section only — stop at the next section header (a line
+    # indented exactly two spaces, e.g. "  softened" / "  not recognised") so
+    # bullets from other buckets don't leak into the count.
     recall_section = msg.split("recall\n")[1]
-    quoted_bullet_count = recall_section.count('    - "')
-    assert quoted_bullet_count == 5, f"expected 5 recall bullets, got {quoted_bullet_count}"
+    active_section = recall_section.split("active:\n", 1)[1]
+    active_lines = []
+    for line in active_section.splitlines():
+        if line.startswith("  ") and not line.startswith("    "):
+            break  # next bucket's section header
+        active_lines.append(line)
+    bullet_count = sum(1 for line in active_lines if line.startswith("    - "))
+    assert bullet_count == 8, f"expected 8 recall bullets, got {bullet_count}"
 
 
 def test_recall_block_truncates_long_content(
@@ -562,10 +575,14 @@ def test_recall_block_orders_by_importance_then_recency(
             importance=9.0,
         )
     )
-    # Fresher but lower importance.
+    # Fresher but lower importance. Similar overall length to the first memory
+    # (keeps BM25 term-density, and so relevance ordering, comparable to
+    # before) but with a distinctive, non-colliding word ("wobbly") placed
+    # early enough to survive proportional truncation (CHANGE 2 — recall-
+    # reinforcement truncates this body to a 20-char floored snippet).
     store.create(
         Memory.create_new(
-            content="Jordan: a recent passing reference.",
+            content="Jordan: a wobbly passing reference.",
             memory_type="event",
             domain="relationship",
             emotions={},
@@ -582,12 +599,12 @@ def test_recall_block_orders_by_importance_then_recency(
         store=store,
         user_input="What about Jordan?",
     )
-    # New format: both appear under "  active:"; ordering still by importance desc
+    # New format: both appear under "  active:"; ordering still by importance desc.
     assert "recall" in msg
     soul_idx = msg.find("soul-shaped")
-    recent_idx = msg.find("passing reference")
+    recent_idx = msg.find("wobbly")
     assert 0 <= soul_idx < recent_idx, (
-        f"soul-shaped (importance 9) should appear before passing reference (importance 2); "
+        f"soul-shaped (importance 9) should appear before wobbly (importance 2); "
         f"got soul_idx={soul_idx}, recent_idx={recent_idx}"
     )
 
@@ -1050,49 +1067,31 @@ def test_build_recent_journal_block_uses_user_name_not_hana(tmp_path: Path) -> N
 # ---------------------------------------------------------------------------
 
 
-def _nr_empty_result():
-    """search_with_loss result with nothing in any bucket."""
-    from unittest.mock import MagicMock
-
-    r = MagicMock()
-    r.active = []
-    r.fading = []
-    r.lost = []
-    return r
-
-
-def _nr_hit_result(content: str):
-    """search_with_loss result with one active hit."""
-    from unittest.mock import MagicMock
-
-    mem = MagicMock()
-    mem.id = "m1"
-    mem.content = content
-    mem.importance = 5
-    mem.created_at = None
-    r = MagicMock()
-    r.active = [mem]
-    r.fading = []
-    r.lost = []
-    return r
+# Tier-1 recall-query fix (guarded-change, changes/recall-query-tier1): the
+# "not recognised" display now derives from ONE combined-query
+# store.term_stats(tokens) read (memories_vocab document frequency), not a
+# per-token search_with_loss-empty convention — a predicate the single
+# combined query cannot reproduce per token. These four tests are re-expressed
+# against a REAL seeded ":memory:" MemoryStore (not a MagicMock) so intended
+# tokens are genuinely present (df>0 → recognised) or absent (df=0 → not
+# recognised); `_extract_recall_tokens` stays patched so the exact token text
+# (incl. capitalisation, for the B→A fallback test) is still controlled by
+# the test, matching the SAME display behaviour as before — not weakened.
 
 
 def test_build_recall_block_not_recognised_section(tmp_path: Path):
     """Unfamiliar token appears in 'not recognised' section."""
-    from unittest.mock import MagicMock, patch
+    from unittest.mock import patch
 
     from brain.chat.prompt import _build_recall_block
+    from brain.memory.store import Memory, MemoryStore
 
-    store = MagicMock()
+    store = MemoryStore(":memory:")
+    store.create(Memory.create_new("we talked about a trip to lisbon", "event", "d"))
 
-    def fake_search(persona_dir, store_, token, *, limit):
-        if token == "Lisbon":
-            return _nr_hit_result("we talked about a trip to Lisbon")
-        return _nr_empty_result()
-
-    with patch("brain.forgetting.recall.search_with_loss", side_effect=fake_search):
-        with patch("brain.chat.prompt._extract_recall_tokens", return_value=["Marcus", "Lisbon"]):
-            block = _build_recall_block(store, "Tell me about Marcus and Lisbon", persona_dir=tmp_path)
+    with patch("brain.chat.prompt._extract_recall_tokens", return_value=["Marcus", "Lisbon"]):
+        block = _build_recall_block(store, "Tell me about Marcus and Lisbon", persona_dir=tmp_path)
+    store.close()
 
     assert "not recognised" in block
     assert "Marcus" in block
@@ -1103,15 +1102,16 @@ def test_build_recall_block_not_recognised_section(tmp_path: Path):
 
 def test_build_recall_block_not_recognised_only_emits_block(tmp_path: Path):
     """Block is still emitted when only unfamiliar tokens exist (no active/fading/lost hits)."""
-    from unittest.mock import MagicMock, patch
+    from unittest.mock import patch
 
     from brain.chat.prompt import _build_recall_block
+    from brain.memory.store import MemoryStore
 
-    store = MagicMock()
+    store = MemoryStore(":memory:")  # empty store: every token is "not recognised"
 
-    with patch("brain.forgetting.recall.search_with_loss", return_value=_nr_empty_result()):
-        with patch("brain.chat.prompt._extract_recall_tokens", return_value=["Marcus"]):
-            block = _build_recall_block(store, "Who is Marcus?", persona_dir=tmp_path)
+    with patch("brain.chat.prompt._extract_recall_tokens", return_value=["Marcus"]):
+        block = _build_recall_block(store, "Who is Marcus?", persona_dir=tmp_path)
+    store.close()
 
     assert block.strip() != ""
     assert "not recognised" in block
@@ -1120,16 +1120,17 @@ def test_build_recall_block_not_recognised_only_emits_block(tmp_path: Path):
 
 def test_build_recall_block_ba_fallback_filters_lowercase(tmp_path: Path):
     """When >5 unfamiliar tokens, only capitalised ones survive."""
-    from unittest.mock import MagicMock, patch
+    from unittest.mock import patch
 
     from brain.chat.prompt import _build_recall_block
+    from brain.memory.store import MemoryStore
 
-    store = MagicMock()
+    store = MemoryStore(":memory:")  # empty store: every selected token is unfamiliar
     tokens = ["antique", "yesterday", "slowly", "Marcus", "Kellerman", "Lisbon", "quiet"]
 
-    with patch("brain.forgetting.recall.search_with_loss", return_value=_nr_empty_result()):
-        with patch("brain.chat.prompt._extract_recall_tokens", return_value=tokens):
-            block = _build_recall_block(store, "query", persona_dir=tmp_path)
+    with patch("brain.chat.prompt._extract_recall_tokens", return_value=tokens):
+        block = _build_recall_block(store, "query", persona_dir=tmp_path)
+    store.close()
 
     # 7 tokens, all unfamiliar → B→A: keep only initial-caps
     assert "Marcus" in block
@@ -1143,15 +1144,17 @@ def test_build_recall_block_ba_fallback_filters_lowercase(tmp_path: Path):
 
 def test_build_recall_block_no_not_recognised_when_all_found(tmp_path: Path):
     """No 'not recognised' section when all tokens return memory hits."""
-    from unittest.mock import MagicMock, patch
+    from unittest.mock import patch
 
     from brain.chat.prompt import _build_recall_block
+    from brain.memory.store import Memory, MemoryStore
 
-    store = MagicMock()
+    store = MemoryStore(":memory:")
+    store.create(Memory.create_new("some memory about marcus", "event", "d"))
 
-    with patch("brain.forgetting.recall.search_with_loss", return_value=_nr_hit_result("some memory")):
-        with patch("brain.chat.prompt._extract_recall_tokens", return_value=["Marcus"]):
-            block = _build_recall_block(store, "Who is Marcus?", persona_dir=tmp_path)
+    with patch("brain.chat.prompt._extract_recall_tokens", return_value=["Marcus"]):
+        block = _build_recall_block(store, "Who is Marcus?", persona_dir=tmp_path)
+    store.close()
 
     assert "not recognised" not in block
 
@@ -1225,6 +1228,195 @@ def test_epistemic_instruction_is_proactive():
     assert 'Never say "I don\'t remember" without searching first' in _EPISTEMIC_INSTRUCTION
     # The reactive guidance stays.
     assert "not recognised (searched; no memory found)" in _EPISTEMIC_INSTRUCTION
+
+
+# ---------------------------------------------------------------------------
+# Recall-snippet invitation framing (P2 UX follow-up) — the recall block's
+# active entries are truncated snippets; this framing tells the model they're
+# expandable via read_full_memory(<id>) and is gated on SNIPPET_MODE_ENABLED
+# so it doesn't appear when snippet mode is off (everything full-injected).
+# ---------------------------------------------------------------------------
+
+
+def test_recall_snippet_invitation_heads_the_block_when_snippet_mode_on(
+    persona_dir: Path, store: MemoryStore, soul_store: SoulStore
+) -> None:
+    """The invitation now lives ON the recall block (as its header), not in the
+    system prefix: with snippet mode on and an active recall match, it appears."""
+    from brain.chat.prompt import _RECALL_SNIPPET_INVITATION
+
+    mem = Memory.create_new(
+        content="Hana mentioned Jordan once over coffee.",
+        memory_type="event",
+        domain="relationship",
+        emotions={"love": 6.0},
+        tags=[],
+    )
+    store.create(mem)
+
+    msg = build_system_message(
+        persona_dir,
+        voice_md="",
+        daemon_state=_empty_daemon_state(),
+        soul_store=soul_store,
+        store=store,
+        user_input="Tell me what we said about Jordan last time.",
+    )
+    assert _RECALL_SNIPPET_INVITATION in msg
+
+
+def test_recall_snippet_invitation_absent_when_snippet_mode_off(
+    persona_dir: Path, store: MemoryStore, soul_store: SoulStore
+) -> None:
+    """Snippet mode off (everything full-injected): no invitation, nothing to expand."""
+    from unittest.mock import patch
+
+    from brain.chat.prompt import _RECALL_SNIPPET_INVITATION
+
+    mem = Memory.create_new(
+        content="Hana mentioned Jordan once over coffee.",
+        memory_type="event",
+        domain="relationship",
+        emotions={"love": 6.0},
+        tags=[],
+    )
+    store.create(mem)
+
+    with patch("brain.chat.prompt.SNIPPET_MODE_ENABLED", False):
+        msg = build_system_message(
+            persona_dir,
+            voice_md="",
+            daemon_state=_empty_daemon_state(),
+            soul_store=soul_store,
+            store=store,
+            user_input="Tell me what we said about Jordan last time.",
+        )
+    assert _RECALL_SNIPPET_INVITATION not in msg
+
+
+def test_recall_snippet_invitation_not_in_static_prefix(tmp_path: Path) -> None:
+    """The invitation moved OFF the frozen system prefix onto the volatile recall
+    block; the static builder must not carry it (even with snippet mode on)."""
+    from unittest.mock import patch
+
+    from brain.chat.prompt import _RECALL_SNIPPET_INVITATION, build_static_system_message
+
+    with patch("brain.chat.prompt.SNIPPET_MODE_ENABLED", True):
+        msg = build_static_system_message(tmp_path, voice_md="")
+    assert _RECALL_SNIPPET_INVITATION not in msg
+
+
+def test_recall_snippet_invitation_wording_is_byte_exact() -> None:
+    """Owner+persona approved wording (no em-dash — 'invitation. Use', not
+    'invitation — use'). Locks the exact string so a future edit can't
+    silently reword it."""
+    from brain.chat.prompt import _RECALL_SNIPPET_INVITATION
+
+    assert _RECALL_SNIPPET_INVITATION == (
+        "These are fragments of your memories. Use read_full_memory to reach into "
+        "any that might touch this turn, or spark curiosity in you. Skip only if "
+        "you can name why."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Recall block memory ids — active entries render "<id>: " so
+# read_full_memory(<id>) is callable; fading/lost entries (not expandable)
+# must not.
+# ---------------------------------------------------------------------------
+
+
+def test_recall_block_active_entry_includes_memory_id(
+    persona_dir: Path, store: MemoryStore, soul_store: SoulStore
+) -> None:
+    """An active recall bullet renders '<id>: "<snippet>"' so the model can
+    call read_full_memory(<id>) on it."""
+    mem = Memory.create_new(
+        content="Hana mentioned Jordan once over coffee.",
+        memory_type="event",
+        domain="relationship",
+        emotions={"love": 6.0},
+        tags=[],
+    )
+    store.create(mem)
+
+    msg = build_system_message(
+        persona_dir,
+        voice_md="",
+        daemon_state=_empty_daemon_state(),
+        soul_store=soul_store,
+        store=store,
+        user_input="Tell me what we said about Jordan last time.",
+    )
+    assert f'    - {mem.id}: "' in msg
+
+
+def test_recall_block_fading_entry_omits_memory_id(
+    persona_dir: Path,
+    store: MemoryStore,
+    soul_store: SoulStore,
+) -> None:
+    """A fading ('softened') recall bullet must NOT carry a memory id —
+    the original detail is gone, so there is nothing left to expand."""
+    m = Memory.create_new(
+        content="Jordan loved rainy afternoons.",
+        memory_type="episodic",
+        domain="chat",
+        emotions={"love": 6.0},
+    )
+    store.create(m)
+    store.fade(m.id, summary="Jordan — rainy afternoons")
+
+    msg = build_system_message(
+        persona_dir,
+        voice_md="",
+        daemon_state=_empty_daemon_state(),
+        soul_store=soul_store,
+        store=store,
+        user_input="Do you remember Jordan?",
+    )
+    fading_idx = msg.index("softened")
+    fading_section = msg[fading_idx:]
+    # The bullet must not expose the memory id as an expandable reference.
+    assert f"{m.id}:" not in fading_section
+
+
+def test_recall_block_lost_entry_omits_memory_id(
+    persona_dir: Path,
+    store: MemoryStore,
+    soul_store: SoulStore,
+) -> None:
+    """A lost (graveyarded) recall bullet must NOT carry a memory id — the
+    memory is gone, not expandable."""
+    from brain.forgetting import graveyard
+    from brain.forgetting.salience import SalienceInputs
+
+    lost_m = Memory.create_new(
+        content="Jordan's old studio address.",
+        memory_type="episodic",
+        domain="chat",
+        emotions={},
+    )
+    graveyard.append(
+        persona_dir,
+        memory=lost_m,
+        salience_at_drop=0.05,
+        inputs=SalienceInputs(emotion=0, hebbian=0, recall=0, soul=0, freshness=0),
+        lived_age_hours=200.0,
+        reason="salience<0.10 for 2 consecutive passes",
+    )
+
+    msg = build_system_message(
+        persona_dir,
+        voice_md="",
+        daemon_state=_empty_daemon_state(),
+        soul_store=soul_store,
+        store=store,
+        user_input="Tell me about Jordan's studio.",
+    )
+    lost_idx = msg.index("lost (no longer")
+    lost_section = msg[lost_idx:]
+    assert f"{lost_m.id}:" not in lost_section
 
 
 # ── Self-model gap block (Task 5, R-F1) ───────────────────────────────────────

--- a/tests/unit/brain/chat/test_recall_snippet.py
+++ b/tests/unit/brain/chat/test_recall_snippet.py
@@ -1,0 +1,392 @@
+"""Assembled recall-block behaviour for P2 — C6/C8/C9/C11/C12/C13/C19/C20/C21/C22.
+
+All oracles exercise the REAL `_build_recall_block` (and the static/volatile
+builders), not an isolated `rank_memories`, so the assembled-path guarantees the
+round-4 review flagged are actually verified.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from brain.chat.prompt import (
+    _EPISTEMIC_INSTRUCTION,
+    _build_recall_block,
+    build_static_system_message,
+    build_volatile_context,
+)
+from brain.engines.daemon_state import DaemonState
+from brain.memory.hebbian import HebbianMatrix
+from brain.memory.relevance import FULL_INJECT_MAX, SNIPPET_COUNT
+from brain.memory.store import Memory, MemoryStore
+from brain.soul.store import SoulStore
+from brain.tools.impls.search_memories import search_memories
+
+# Invariants the epistemic instruction must preserve, checked in
+# test_c13_unfamiliar_bucket_and_epistemic_instruction below instead of a
+# byte-for-byte frozen copy (which went stale under ef173846's reword and
+# would go stale again on the next wording pass).
+
+
+def _store() -> MemoryStore:
+    return MemoryStore(":memory:")
+
+
+def _mem(
+    store: MemoryStore,
+    content: str,
+    *,
+    importance: float = 0.0,
+    age_days: float = 0.0,
+) -> Memory:
+    m = Memory(
+        id=str(uuid.uuid4()),
+        content=content,
+        memory_type="event",
+        domain="d",
+        created_at=datetime.now(UTC) - timedelta(days=age_days),
+        importance=importance,
+    )
+    store.create(m)
+    return m
+
+
+def _rc(store: MemoryStore, mid: str) -> int:
+    return store._conn.execute("SELECT recall_count FROM memories WHERE id = ?", (mid,)).fetchone()[0]
+
+
+def _la(store: MemoryStore, mid: str):
+    return store._conn.execute(
+        "SELECT last_accessed_at FROM memories WHERE id = ?", (mid,)
+    ).fetchone()[0]
+
+
+def _active_lines(block: str) -> list[str]:
+    # Active bullets now read '    - <id>: "…"' (memory id precedes the
+    # quoted snippet so read_full_memory(<id>) is callable) instead of the
+    # old bare '    - "…"'. Match the id-prefixed quote instead of the
+    # literal '    - "' — a stricter startswith would miss every active line.
+    import re
+
+    return [ln for ln in block.splitlines() if re.match(r'^    - \S+: "', ln)]
+
+
+def _display_ids(block: str) -> list[str]:
+    """Ids of the rendered 'active:' bullets, in DISPLAY (top-to-bottom) order."""
+    import re
+
+    ids = []
+    for line in _active_lines(block):
+        m = re.match(r'^    - (\S+): "', line)
+        if m:
+            ids.append(m.group(1))
+    return ids
+
+
+def test_c6_surfacing_bumps_recall_count_fractionally_by_display_rank(
+    tmp_path: Path,
+) -> None:
+    """ND-1 revision (recall-reinforcement G1): passive surfacing now bumps
+    recall_count FRACTIONALLY by DISPLAY rank (top ~0.8, bottom ~0.1,
+    monotonically decreasing) instead of not at all. Drives the real
+    _build_recall_block assembly end-to-end (not a standalone amount(i)
+    helper): the DISPLAY order is read back from the block's own rendered
+    bullets, then each surfaced memory's recall_count delta is checked
+    against that order.
+
+    explicit search_memories stays bump-free (G7 — see
+    test_search_memories_ranked.py for the dedicated assertion).
+    """
+    store = _store()
+    heb = HebbianMatrix(":memory:")
+    mems = [_mem(store, f"jordan harbor chapter {i}", importance=float(i)) for i in range(4)]
+    before = {m.id: _rc(store, m.id) for m in mems}
+
+    block = _build_recall_block(store, "jordan harbor", persona_dir=tmp_path)
+    ids_in_order = _display_ids(block)
+    assert len(ids_in_order) == 4, "all 4 low-importance memories render as snippets"
+
+    deltas = [_rc(store, mid) - before[mid] for mid in ids_in_order]
+    assert deltas[0] == pytest.approx(0.8, abs=0.01), "top surfaced memory bumped ~0.8"
+    assert deltas[-1] == pytest.approx(0.1, abs=0.01), "bottom surfaced memory bumped ~0.1"
+    for a, b in zip(deltas, deltas[1:], strict=False):
+        assert a >= b - 1e-9, "bump amount is non-increasing by display rank"
+
+    # search_memories (explicit query) stays bump-free — no double-credit.
+    before_search = {mid: _rc(store, mid) for mid in ids_in_order}
+    search_memories("jordan", store=store, hebbian=heb, persona_dir=tmp_path)
+    for mid in ids_in_order:
+        assert _rc(store, mid) == before_search[mid], "search_memories must not bump recall_count"
+
+
+def test_g2_single_surfaced_memory_bumped_at_top_amount(tmp_path: Path) -> None:
+    """G2: N=1 surfaced memory is bumped by the TOP amount (~0.8), not the
+    bottom amount (~0.1) and not zero."""
+    store = _store()
+    m = _mem(store, "solitary lighthouse at midnight", importance=1.0)
+    before = _rc(store, m.id)
+
+    block = _build_recall_block(store, "solitary lighthouse", persona_dir=tmp_path)
+    assert block.strip() != ""
+    assert _rc(store, m.id) - before == pytest.approx(0.8, abs=0.01)
+
+
+def test_full_inject_active_rows_receive_no_passive_bump(tmp_path: Path) -> None:
+    """G1 (full-inject exclusion): a high-importance memory rendered IN FULL
+    (not as a snippet) receives no passive bump — it is already maximally
+    salient by importance. A snippet-rendered sibling in the same block still
+    gets bumped normally."""
+    store = _store()
+    hi = _mem(store, "beacon " + ("H" * 300), importance=9.5)  # full-inject
+    lo = _mem(store, "beacon low importance detail", importance=1.0)  # snippet
+    before_hi, before_lo = _rc(store, hi.id), _rc(store, lo.id)
+
+    block = _build_recall_block(store, "beacon", persona_dir=tmp_path)
+    assert ("H" * 300) in block, "hi renders in full (untruncated) — confirms it is full-inject"
+
+    assert _rc(store, hi.id) == before_hi, "full-inject rows get no passive bump"
+    assert _rc(store, lo.id) > before_lo, "snippet-rendered rows are still bumped"
+
+
+def test_lost_bucket_entries_are_never_bumped(tmp_path: Path) -> None:
+    """G1 (lost-bucket exclusion): graveyard 'lost' entries are dicts with no
+    live store row — there is nothing to bump, and the block assembly must
+    not crash reaching for one. A live sibling memory in the same block is
+    still bumped normally."""
+    from brain.forgetting import graveyard
+    from brain.forgetting.salience import SalienceInputs
+
+    store = _store()
+    live = _mem(store, "beacon still active detail", importance=1.0)
+    before_live = _rc(store, live.id)
+
+    lost_mem = Memory.create_new(
+        content="beacon old lost studio address",
+        memory_type="episodic",
+        domain="d",
+        emotions={},
+    )
+    graveyard.append(
+        tmp_path,
+        memory=lost_mem,
+        salience_at_drop=0.05,
+        inputs=SalienceInputs(emotion=0, hebbian=0, recall=0, soul=0, freshness=0),
+        lived_age_hours=200.0,
+        reason="test-seed",
+    )
+
+    block = _build_recall_block(store, "beacon", persona_dir=tmp_path)
+    assert "forgotten" in block.lower()
+    assert _rc(store, live.id) > before_live, "the live sibling is still bumped normally"
+
+
+def test_g19_fading_memory_surfaced_as_snippet_is_bumped_last_accessed_unchanged(
+    tmp_path: Path,
+) -> None:
+    """G19: a fading memory surfaced as a snippet IS bumped, but the passive
+    bump leaves last_accessed_at unchanged (bump_recall touches recall_count
+    only)."""
+    store = _store()
+    m = _mem(store, "harbor lantern original long-form detail here", importance=3.0)
+    store.fade(m.id, summary="harbor lantern moment")
+    before_rc, before_la = _rc(store, m.id), _la(store, m.id)
+    assert before_la is None
+
+    block = _build_recall_block(store, "harbor lantern", persona_dir=tmp_path)
+    assert "softened (fading" in block
+
+    assert _rc(store, m.id) > before_rc, "fading memory surfaced as a snippet is bumped"
+    assert _la(store, m.id) == before_la, "passive bump must not touch last_accessed_at"
+
+
+def test_g18_multi_turn_bump_accumulates_additively_and_stays_bounded(
+    tmp_path: Path,
+) -> None:
+    """G18: passive recall fires every turn — the bump must accumulate
+    ADDITIVELY across turns (surfacing the same top-ranked memory across 3
+    calls yields recall_count ~= 2.4), and the salience effect stays BOUNDED
+    by the clamped recall arm (recall_count/10, capped 1.0) — a much larger
+    recall_count cannot push the recall arm's salience contribution past its
+    cap."""
+    from brain.forgetting import salience
+    from brain.forgetting.salience import DEFAULT_WEIGHTS
+
+    store = _store()
+    m = _mem(store, "orchid signal beacon", importance=1.0)
+
+    for _ in range(3):
+        block = _build_recall_block(store, "orchid signal beacon", persona_dir=tmp_path)
+        assert block.strip() != ""
+
+    rc = _rc(store, m.id)
+    assert rc == pytest.approx(2.4, abs=0.02), "3 top-rank (N=1) surfacings accumulate additively"
+
+    heb = HebbianMatrix(":memory:")
+    restored = store.get(m.id, bump=False)
+    s = salience.score(
+        restored, store=store, hebbian=heb, felt_time_state=None, soul_linked_ids=set()
+    )
+    # felt_time_state=None -> cold-start freshness=1.0 (fixed); the recall arm
+    # contributes weights["recall"] * clamp(recall_count/10, 0, 1).
+    expected = DEFAULT_WEIGHTS["freshness"] * 1.0 + DEFAULT_WEIGHTS["recall"] * min(rc / 10.0, 1.0)
+    assert s == pytest.approx(expected, abs=0.01)
+
+    # Bounded: even a much larger recall_count cannot push the recall arm's
+    # contribution past its clamp.
+    store.bump_recall(m.id, 50.0)
+    restored2 = store.get(m.id, bump=False)
+    s2 = salience.score(
+        restored2, store=store, hebbian=heb, felt_time_state=None, soul_linked_ids=set()
+    )
+    max_possible = DEFAULT_WEIGHTS["freshness"] * 1.0 + DEFAULT_WEIGHTS["recall"] * 1.0
+    assert s2 == pytest.approx(max_possible, abs=0.01)
+
+
+def test_c8_high_importance_full_low_importance_snippet(tmp_path: Path) -> None:
+    store = _store()
+    hi_body = "jordan " + ("H" * 300)
+    lo_body = "jordan " + ("L" * 300)
+    _mem(store, hi_body, importance=9.5)
+    _mem(store, lo_body, importance=1.0)
+
+    block = _build_recall_block(store, "jordan", persona_dir=tmp_path)
+    assert ("H" * 300) in block, "high-importance memory renders in full (untruncated)"
+    assert ("L" * 300) not in block, "low-importance long body is truncated to a snippet"
+    assert "…" in block
+
+
+def test_c9_assembled_surfaces_up_to_snippet_count(tmp_path: Path) -> None:
+    store = _store()
+    for i in range(10):
+        _mem(store, f"jordan moment number {i}")
+    block = _build_recall_block(store, "jordan", persona_dir=tmp_path)
+    assert len(_active_lines(block)) == SNIPPET_COUNT == 8  # up from the stale limit=5
+
+
+def test_c12_recall_fires_on_matching_input(tmp_path: Path) -> None:
+    store = _store()
+    _mem(store, "jordan was here that summer", importance=3.0)
+    block = _build_recall_block(store, "what about jordan", persona_dir=tmp_path)
+    assert block.strip() != ""
+    # Proportional snippet length (CHANGE 2) truncates this 28-char body to
+    # its floored 20-char snippet, so the FULL string no longer appears
+    # verbatim — only the surviving prefix does (recall fired; the exact
+    # truncation formula is covered by test_snippet_length.py).
+    assert "jordan was here" in block
+
+
+def test_c13_unfamiliar_bucket_and_epistemic_instruction(tmp_path: Path) -> None:
+    store = _store()
+    block = _build_recall_block(store, "who is marcus and lisbon", persona_dir=tmp_path)
+    assert "not recognised (searched; no memory found)" in block
+    assert "marcus" in block
+
+    # Epistemic instruction invariants (not a byte-for-byte frozen copy, which
+    # drifted under ef173846's reword). ef173846's point was that
+    # read_full_memory is now named AHEAD of search_memories, so assert both
+    # presence and ordering.
+    instr = _EPISTEMIC_INSTRUCTION
+    i_read_full = instr.find("read_full_memory")
+    i_search = instr.find("search_memories")
+    assert i_read_full != -1, "must instruct opening surfaced memories via read_full_memory"
+    assert i_search != -1, "must instruct search_memories for unsurfaced info"
+    assert i_read_full < i_search, "read_full_memory must be named ahead of search_memories"
+
+    # Content the frozen copy was guarding: the search-before-denying rule and
+    # the exact "not recognised" wording the recall block emits (asserted
+    # against `block` above), plus the never-invent-familiarity distinction.
+    assert "call search_memories" in instr
+    assert 'Never say "I don\'t remember" without searching first' in instr
+    assert '"not recognised (searched; no memory found)"' in instr
+    assert '"I never knew this"' in instr and '"I don\'t remember"' in instr
+    assert "Do not invent familiarity" in instr
+
+
+def test_c11_recall_absent_from_static_present_in_volatile(tmp_path: Path) -> None:
+    persona_dir = tmp_path / "personas" / "nell"
+    persona_dir.mkdir(parents=True)
+    store = _store()
+    _mem(store, "jordan and the long walk", importance=3.0)
+    soul = SoulStore(":memory:")
+
+    static = build_static_system_message(persona_dir, voice_md="")
+    assert "── recall" not in static
+    assert "recall\n  active:" not in static
+
+    volatile = build_volatile_context(
+        persona_dir,
+        voice_md="",
+        daemon_state=DaemonState(),
+        soul_store=soul,
+        store=store,
+        user_input="tell me about jordan",
+    )
+    assert "recall\n  active:" in volatile
+
+
+def test_c20_recall_block_full_inject_is_bounded(tmp_path: Path) -> None:
+    store = _store()
+    for i in range(6):
+        _mem(store, f"jordan detail {i} " + ("Z" * 200), importance=9.5)
+    block = _build_recall_block(store, "jordan", persona_dir=tmp_path)
+    lines = _active_lines(block)
+    full = [ln for ln in lines if "…" not in ln]
+    snippets = [ln for ln in lines if "…" in ln]
+    assert len(full) <= FULL_INJECT_MAX, "at most FULL_INJECT_MAX full-injects"
+    assert len(snippets) >= 1, "further imp≥9 candidates fall back to snippets"
+
+
+def test_c19_c21_single_hardened_hebbian_open(monkeypatch, tmp_path: Path) -> None:
+    import brain.memory.hebbian as hebmod
+
+    calls = {"init": 0, "integrity": [], "closed": 0}
+    real_init = hebmod.HebbianMatrix.__init__
+    real_close = hebmod.HebbianMatrix.close
+
+    def spy_init(self, db_path, *, integrity_check=True):
+        calls["init"] += 1
+        calls["integrity"].append(integrity_check)
+        real_init(self, db_path, integrity_check=integrity_check)
+
+    def spy_close(self):
+        calls["closed"] += 1
+        real_close(self)
+
+    monkeypatch.setattr(hebmod.HebbianMatrix, "__init__", spy_init)
+    monkeypatch.setattr(hebmod.HebbianMatrix, "close", spy_close)
+
+    store = _store()
+    for token in ("jordan", "marcus", "lisbon"):
+        _mem(store, f"{token} shared a memory here", importance=3.0)
+
+    _build_recall_block(store, "jordan marcus lisbon", persona_dir=tmp_path)
+
+    # C21: exactly one open regardless of the 3 matching tokens.
+    assert calls["init"] == 1
+    # C19: opened with integrity_check=False and closed (no leaked handle).
+    assert calls["integrity"] == [False]
+    assert calls["closed"] >= 1
+
+
+def test_c22_assembled_orders_by_blended_relevance(tmp_path: Path) -> None:
+    store = _store()
+    # Shared token "signal": strong match, low importance, old (low recency).
+    _mem(store, "alpha signal signal signal signal signal", importance=1.0, age_days=200)
+    # Weak match (one mention in filler), high importance, new.
+    _mem(
+        store,
+        "beta signal among a great many other filler words padding here around it",
+        importance=9.0,
+        age_days=0,
+    )
+    block = _build_recall_block(store, "signal marcus", persona_dir=tmp_path)
+    i_strong = block.find("alpha")
+    i_weak = block.find("beta")
+    # Blended relevance puts the strong-match/low-importance memory ABOVE the
+    # weak-match/high-importance one. Under a (-importance,-ts) merge, "beta"
+    # (importance 9) would rank first — this is the discriminating assertion.
+    assert 0 <= i_strong < i_weak

--- a/tests/unit/brain/chat/test_tool_inventory.py
+++ b/tests/unit/brain/chat/test_tool_inventory.py
@@ -27,8 +27,8 @@ def test_inventory_renders_full_registry_not_a_subset() -> None:
     inventory's whole job is telling her what exists when it is not in hand, so
     it must never render the recruited subset."""
     out = build_tool_inventory("Nell")
-    assert len(NELL_TOOL_NAMES) == 27
-    assert sum(1 for n in NELL_TOOL_NAMES if f"`{n}`" in out) == 27
+    assert len(NELL_TOOL_NAMES) == 28
+    assert sum(1 for n in NELL_TOOL_NAMES if f"`{n}`" in out) == 28
 
 
 def test_inventory_carries_the_reach_valve() -> None:

--- a/tests/unit/brain/engines/test_cli.py
+++ b/tests/unit/brain/engines/test_cli.py
@@ -60,7 +60,17 @@ def test_nell_dream_real_cycle_with_fake_provider(
     rc = main(["dream", "--persona", "nell", "--provider", "fake"])
     assert rc == 0
 
+    # The dream is written as a gated pending-candidate, not straight to
+    # memories.db. Promote the queue (id preserved) so the end-state DB
+    # assertion — a real dream memory exists — still holds.
+    from brain.engines.consolidation import Decision, run_consolidation
+
     store = MemoryStore(db_path=nell_persona / "memories.db")
+    run_consolidation(
+        store,
+        persona_dir=store.persona_dir,
+        classifier=lambda _c, _ctx: Decision("new"),
+    )
     dreams = store.list_by_type("dream")
     store.close()
     assert len(dreams) == 1

--- a/tests/unit/brain/engines/test_dream.py
+++ b/tests/unit/brain/engines/test_dream.py
@@ -10,6 +10,7 @@ import pytest
 
 from brain.bridge.chat import ChatMessage, ChatResponse
 from brain.bridge.provider import FakeProvider, LLMProvider
+from brain.engines.consolidation import Decision, run_consolidation
 from brain.engines.dream import DreamEngine, NoSeedAvailable
 from brain.memory.hebbian import HebbianMatrix
 from brain.memory.store import Memory, MemoryStore
@@ -46,8 +47,11 @@ class _UnprefixedFakeProvider(LLMProvider):
 
 
 @pytest.fixture
-def store() -> MemoryStore:
-    return MemoryStore(db_path=":memory:")
+def store(tmp_path) -> MemoryStore:
+    # On-disk so store.persona_dir == tmp_path: gated "dream" candidates land in
+    # tmp_path's pending queue (not the CWD) and can be promoted when a test
+    # needs the end-state DB row.
+    return MemoryStore(db_path=tmp_path / "memories.db")
 
 
 @pytest.fixture
@@ -135,6 +139,13 @@ def test_run_cycle_writes_dream_memory_to_store(engine: DreamEngine, store: Memo
     assert result.memory is not None
     assert result.memory.memory_type == "dream"
 
+    # The dream is enqueued as a gated candidate; promote it (id preserved) so
+    # the store.get() end-state assertion holds.
+    run_consolidation(
+        store,
+        persona_dir=store.persona_dir,
+        classifier=lambda _c, _ctx: Decision("new"),
+    )
     restored = store.get(result.memory.id)
     assert restored is not None
     assert restored.memory_type == "dream"

--- a/tests/unit/brain/engines/test_heartbeat.py
+++ b/tests/unit/brain/engines/test_heartbeat.py
@@ -10,6 +10,7 @@ from unittest.mock import patch
 import pytest
 
 from brain.bridge.provider import FakeProvider
+from brain.engines.consolidation import Decision, run_consolidation
 from brain.engines.heartbeat import (
     HeartbeatConfig,
     HeartbeatEngine,
@@ -371,8 +372,14 @@ def test_heartbeat_state_save_rejects_naive_datetime(tmp_path: Path) -> None:
 
 @pytest.fixture
 def live_engine(tmp_path: Path) -> HeartbeatEngine:
-    """Engine with in-memory store/hebbian and tmp log/state paths."""
-    store = MemoryStore(":memory:")
+    """Engine with an on-disk store + in-memory hebbian and tmp log/state paths.
+
+    The store is on-disk (not ":memory:") so store.persona_dir == tmp_path,
+    matching the persona_dir the in-tick consolidation gate uses. Gated
+    candidates (dream/research/heartbeat) then land in tmp_path's pending queue
+    rather than leaking to the CWD.
+    """
+    store = MemoryStore(tmp_path / "memories.db")
     hebbian = HebbianMatrix(":memory:")
     return HeartbeatEngine(
         store=store,
@@ -384,6 +391,19 @@ def live_engine(tmp_path: Path) -> HeartbeatEngine:
         heartbeat_log_path=tmp_path / "heartbeats.log.jsonl",
         persona_name="Nell",
         persona_system_prompt="You are Nell.",
+    )
+
+
+# memory-consolidation migration: dream/research/heartbeat are gated types. The
+# generative engines enqueue candidates; the in-tick consolidation gate runs
+# BEFORE they fire, so a candidate produced this tick is only promoted next tick.
+# Tests that inspect the end-state DB memory promote the queue explicitly with a
+# promote-all classifier (candidate id preserved).
+def _promote_queue(engine) -> None:
+    run_consolidation(
+        engine.store,
+        persona_dir=engine.store.persona_dir,
+        classifier=lambda _c, _ctx: Decision("new"),
     )
 
 
@@ -548,6 +568,7 @@ def test_heartbeat_memory_emitted_when_always_mode(live_engine: HeartbeatEngine)
     live_engine.run_tick(trigger="open")  # init, no memory
     live_engine.run_tick(trigger="close")
 
+    _promote_queue(live_engine)  # promote the heartbeat candidate into memories.db
     hb_memories = live_engine.store.list_by_type("heartbeat")
     assert len(hb_memories) == 1
     assert hb_memories[0].content.startswith("HEARTBEAT:")
@@ -600,6 +621,7 @@ def test_heartbeat_memory_metadata_links_to_dream_id(
     assert result.dream_id is not None
     assert result.heartbeat_memory_id is not None
 
+    _promote_queue(live_engine)  # promote dream + heartbeat candidates (ids kept)
     hb_mem = live_engine.store.get(result.heartbeat_memory_id)
     assert hb_mem is not None
     assert hb_mem.metadata.get("dream_id") == result.dream_id
@@ -1833,7 +1855,10 @@ def _make_engine_with_persona_dir(tmp_path: Path) -> tuple[HeartbeatEngine, Path
     """
     interests_path = tmp_path / "interests.json"
     interests_path.write_text(json.dumps({"version": 1, "interests": []}), encoding="utf-8")
-    store = MemoryStore(":memory:")
+    # On-disk store so store.persona_dir == tmp_path (matches the persona_dir the
+    # in-tick consolidation gate + daemon_state writes use); gated candidates
+    # land in tmp_path's pending queue, not the CWD.
+    store = MemoryStore(tmp_path / "memories.db")
     hm = HebbianMatrix(":memory:")
     engine = HeartbeatEngine(
         store=store,
@@ -1880,7 +1905,11 @@ def test_daemon_state_heartbeat_entry_written_after_tick(tmp_path: Path) -> None
 
 
 def test_daemon_state_dream_entry_written_when_dream_fires(tmp_path: Path) -> None:
-    """When a dream fires, daemon_state.json has last_dream populated."""
+    """When a dream fires, daemon_state.json has last_dream populated.
+
+    Regression fixed: _write_daemon_state_for_dream now reads the just-fired
+    dream from the pending queue (where gated candidates live), not memories.db.
+    """
     from brain.engines.daemon_state import load_daemon_state
 
     engine, persona_dir = _make_engine_with_persona_dir(tmp_path)
@@ -2197,7 +2226,10 @@ def test_research_fire_through_heartbeat_appends_notes_and_memory_and_verdict_ca
         ]
     )
 
-    store = MemoryStore(":memory:")
+    # On-disk so store.persona_dir == tmp_path (== interests_path.parent, the
+    # heartbeat's persona_dir): the gated "research" candidate lands in that
+    # queue and can be promoted for the end-state DB assertion below.
+    store = MemoryStore(tmp_path / "memories.db")
     hm = HebbianMatrix(":memory:")
     try:
         old_mem = Memory.create_new(
@@ -2239,6 +2271,14 @@ def test_research_fire_through_heartbeat_appends_notes_and_memory_and_verdict_ca
         persona_dir = interests_path.parent
         assert "canary fact" in read_notes_tail(persona_dir, interest_id)
 
+        # The research memory is enqueued as a gated candidate; promote it so the
+        # canary's DB-visibility assertion (research really persisted, not a
+        # vignette) still holds. Candidate id is preserved.
+        run_consolidation(
+            store,
+            persona_dir=store.persona_dir,
+            classifier=lambda _c, _ctx: Decision("new"),
+        )
         mems = store.list_by_type("research", active_only=True, limit=5)
         assert any("followed the thread" in m.content for m in mems)
 

--- a/tests/unit/brain/engines/test_reflex.py
+++ b/tests/unit/brain/engines/test_reflex.py
@@ -9,6 +9,7 @@ from pathlib import Path
 import pytest
 
 from brain.bridge.provider import FakeProvider
+from brain.engines.consolidation import Decision, run_consolidation
 from brain.engines.reflex import (
     ArcFire,
     ArcSkipped,
@@ -411,7 +412,10 @@ def test_run_tick_fires_arc_when_trigger_met(tmp_path: Path):
     arcs_path = tmp_path / "arcs.json"
     _write_single_arc(arcs_path, trigger={"love": 5})
 
-    store = MemoryStore(":memory:")
+    # On-disk so store.persona_dir == tmp_path: the reflex arc output type
+    # "reflex_journal" is gated (only journal_entry bypasses), so it is enqueued
+    # as a candidate; promote it to satisfy the store.get() end-state assertion.
+    store = MemoryStore(tmp_path / "memories.db")
     try:
         _seed_emotion_memory(store, {"love": 8.0})
         engine = _build_engine(tmp_path, store)
@@ -419,7 +423,12 @@ def test_run_tick_fires_arc_when_trigger_met(tmp_path: Path):
         result = engine.run_tick(dry_run=False)
         assert len(result.arcs_fired) == 1
         assert result.arcs_fired[0].arc_name == "test_arc"
-        # Memory was written
+        # Memory was written (as a gated candidate → promote it into memories.db).
+        run_consolidation(
+            store,
+            persona_dir=store.persona_dir,
+            classifier=lambda _c, _ctx: Decision("new"),
+        )
         mem = store.get(result.arcs_fired[0].output_memory_id)
         assert mem is not None
         assert mem.memory_type == "reflex_journal"

--- a/tests/unit/brain/engines/test_research.py
+++ b/tests/unit/brain/engines/test_research.py
@@ -10,10 +10,18 @@ import pytest
 
 from brain.bridge.provider import FakeProvider
 from brain.engines._interests import InterestSet
+from brain.engines.consolidation import Decision, run_consolidation
 from brain.engines.research import RESEARCH_SCHEMA_VERSION, ResearchEngine
 from brain.engines.research_notes import read_notes_tail
+from brain.memory.pending import PendingQueue
 from brain.memory.store import Memory, MemoryStore
 from brain.search.base import NoopWebSearcher
+
+# memory-consolidation migration: the "research" memory_type is GATED, so the
+# engine's route_write enqueues a candidate instead of writing to memories.db.
+# Tests that assert the end-state DB memory promote the queue with a promote-all
+# classifier (candidate id preserved), keeping their store.get() assertions.
+_PROMOTE_ALL = lambda _c, _ctx: Decision("new")  # noqa: E731
 
 DEFAULT_INTERESTS_PATH = Path(__file__).parents[4] / "brain" / "engines" / "default_interests.json"
 
@@ -219,7 +227,7 @@ def test_run_tick_dry_run_reports_would_fire(tmp_path: Path):
 
 def test_run_tick_fire_writes_research_memory(tmp_path: Path):
     _write_interests(tmp_path / "interests.json", [_interest_dict()])
-    store = MemoryStore(":memory:")
+    store = MemoryStore(tmp_path / "memories.db")
     try:
         # Scripted: select call chooses i1, session call returns a real MEMORY
         # section so a memory actually gets created (the old flow persisted
@@ -234,6 +242,7 @@ def test_run_tick_fire_writes_research_memory(tmp_path: Path):
         engine = _build_engine(tmp_path, store, provider=provider)
         result = engine.run_tick(days_since_human_override=5.0)
         assert result.fired is not None
+        run_consolidation(store, persona_dir=store.persona_dir, classifier=_PROMOTE_ALL)
         mem = store.get(result.fired.output_memory_id)
         assert mem is not None
         assert mem.memory_type == "research"
@@ -250,7 +259,7 @@ def test_run_tick_fire_stamps_research_schema_version(tmp_path: Path):
     Requested by ThinkerOfThoughts for the issue #66 memory-system work.
     """
     _write_interests(tmp_path / "interests.json", [_interest_dict()])
-    store = MemoryStore(":memory:")
+    store = MemoryStore(tmp_path / "memories.db")
     try:
         provider = ScriptedProvider(
             [
@@ -262,6 +271,7 @@ def test_run_tick_fire_stamps_research_schema_version(tmp_path: Path):
         engine = _build_engine(tmp_path, store, provider=provider)
         result = engine.run_tick(days_since_human_override=5.0)
         assert result.fired is not None
+        run_consolidation(store, persona_dir=store.persona_dir, classifier=_PROMOTE_ALL)
         mem = store.get(result.fired.output_memory_id)
         assert mem is not None
         assert mem.metadata["schema_version"] == RESEARCH_SCHEMA_VERSION
@@ -420,7 +430,7 @@ def test_select_declines_ends_tick_without_cooldown(tmp_path: Path):
 
 def test_fire_appends_notes_creates_memory_updates_cooldown(tmp_path: Path):
     _write_interests(tmp_path / "interests.json", [_interest_dict()])
-    store = MemoryStore(":memory:")
+    store = MemoryStore(tmp_path / "memories.db")
     try:
         provider = ScriptedProvider(
             [
@@ -432,6 +442,7 @@ def test_fire_appends_notes_creates_memory_updates_cooldown(tmp_path: Path):
         res = engine.run_tick(trigger="manual", days_since_human_override=5.0)
         assert res.fired is not None
         assert "found X" in read_notes_tail(engine.interests_path.parent, res.fired.interest_id)
+        run_consolidation(store, persona_dir=store.persona_dir, classifier=_PROMOTE_ALL)
         mem = store.get(res.fired.output_memory_id)
         assert mem.content == "I liked it."
         saved = InterestSet.load(engine.interests_path, default_path=DEFAULT_INTERESTS_PATH)
@@ -446,15 +457,19 @@ def test_memory_create_failure_does_not_abort_tick_burns_cooldown(
     """§5.3 fail-soft: store.create raising (SQLite lock, disk full, ...) must not
     abort the tick. Cooldown still burns (last_researched_at updates) so the same
     interest doesn't re-fire + duplicate on the next cadence tick, and the fire
-    correctly records no memory was persisted."""
-    import logging
+    correctly records no memory was persisted.
 
-    class RaisingStore(MemoryStore):
-        def create(self, memory):
-            raise RuntimeError("simulated disk full")
+    Migration note: "research" is a gated type, so the write goes through
+    route_write → PendingQueue.enqueue, not store.create. The failure is injected
+    at enqueue (the real write point); the rest of the tick is unchanged."""
+    import logging
+    from unittest.mock import patch
+
+    def _raise_enqueue(self, mem, *, source):
+        raise RuntimeError("simulated disk full")
 
     _write_interests(tmp_path / "interests.json", [_interest_dict()])
-    store = RaisingStore(":memory:")
+    store = MemoryStore(tmp_path / "memories.db")
     try:
         provider = ScriptedProvider(
             [
@@ -465,7 +480,8 @@ def test_memory_create_failure_does_not_abort_tick_burns_cooldown(
         engine = _build_engine(tmp_path, store, provider=provider)
         caplog.set_level(logging.WARNING)
 
-        res = engine.run_tick(trigger="manual", days_since_human_override=5.0)
+        with patch.object(PendingQueue, "enqueue", _raise_enqueue):
+            res = engine.run_tick(trigger="manual", days_since_human_override=5.0)
 
         # (a) exception did not propagate out of run_tick
         assert res.fired is not None

--- a/tests/unit/brain/files/test_commit.py
+++ b/tests/unit/brain/files/test_commit.py
@@ -22,6 +22,24 @@ def _store(persona_dir):
     return MemoryStore(persona_dir / "memories.db")
 
 
+def _promote_pending(persona_dir):
+    """Drain the consolidation gate with a promote-all classifier.
+
+    file_write is a GATED type (Root-2 stopgap): its wire-back memory enqueues to the
+    pending queue and only reaches memories.db after a consolidation drain. Tests that
+    assert the end-state DB row run this to promote the candidate.
+    """
+    from brain.engines.consolidation import Decision, run_consolidation
+
+    s = MemoryStore(persona_dir / "memories.db")
+    try:
+        run_consolidation(
+            s, persona_dir=persona_dir, classifier=lambda _c, _ctx: Decision("new")
+        )
+    finally:
+        s.close()
+
+
 def test_commit_create_writes_file_and_memory(tmp_path, monkeypatch):
     monkeypatch.setattr(Path, "home", lambda: tmp_path / "home")
     persona = _persona(tmp_path)
@@ -38,8 +56,13 @@ def test_commit_create_writes_file_and_memory(tmp_path, monkeypatch):
     assert res["ok"]
     assert target.read_text() == "body"
     assert pending.get(persona, rid)["status"] == "committed"
-    assert store.list_by_type("file_write", active_only=True, limit=5)  # wire-back memory
+    # file_write is GATED: the wire-back memory enqueues, not written straight to db.
+    assert not store.list_by_type("file_write", active_only=True, limit=5)
     store.close()
+    _promote_pending(persona)  # drain → promote the candidate
+    store2 = _store(persona)
+    assert store2.list_by_type("file_write", active_only=True, limit=5)  # wire-back memory
+    store2.close()
 
 
 def test_commit_append_preserves_existing(tmp_path, monkeypatch):
@@ -94,9 +117,14 @@ def test_decline_writes_nothing_records_memory(tmp_path):
     store = MemoryStore(persona / "memories.db")
     decline_write(persona, rid, store=store)
     assert pending.get(persona, rid)["status"] == "declined"
-    mems = store.list_by_type("file_write", active_only=True, limit=5)
-    assert mems and "secret" not in mems[0].content  # declined content NOT stored
+    # file_write is GATED: enqueues, promoted on drain.
+    assert not store.list_by_type("file_write", active_only=True, limit=5)
     store.close()
+    _promote_pending(persona)
+    store2 = MemoryStore(persona / "memories.db")
+    mems = store2.list_by_type("file_write", active_only=True, limit=5)
+    assert mems and "secret" not in mems[0].content  # declined content NOT stored
+    store2.close()
 
 
 def test_committed_write_surfaces_in_feed(tmp_path, monkeypatch):
@@ -115,6 +143,11 @@ def test_committed_write_surfaces_in_feed(tmp_path, monkeypatch):
     store = _store(persona)
     commit_write(persona, rid, store=store)
     store.close()
+    # BLAST RADIUS (accepted, see changes/gate-leak-coverage/decisions.md): the Feed source
+    # build_file_write_entries reads memories.db, so a committed file-write is NOT visible in
+    # the Feed until the consolidation gate promotes the (now gated) file_write candidate —
+    # a user-facing latency that mirrors the self-model latency (criteria A3). Drain to promote.
+    _promote_pending(persona)
 
     from brain.bridge.feed import build_file_write_entries
 

--- a/tests/unit/brain/forgetting/test_monologue_trace_lifecycle.py
+++ b/tests/unit/brain/forgetting/test_monologue_trace_lifecycle.py
@@ -1,11 +1,27 @@
 """monologue_trace is picked up by the forgetting engine like any memory:
-FADE blurs verbatim→summary, LOSE forgets it (graveyard + grief)."""
+FADE blurs verbatim→summary, LOSE forgets it (graveyard + grief).
+
+CATEGORY-B (memory-consolidation migration): monologue_trace is now a GATED type,
+so write_trace_memory ENQUEUES an ephemeral pending-candidate instead of writing a
+memories.db row. A candidate is never a store row, so the forgetting engine never
+sees it: it does not FADE, is not LOST/graveyarded, and the recall keep-sharp bump
+is a no-op. The DB-fade/recall lifecycle these two tests encode is deferred to
+Phase 4 (Root 2 stopgap). Marked xfail(strict) rather than deleted so the deferred
+behavior stays visible; revisit when the trace lifecycle is reinstated."""
 import json
 from datetime import UTC, datetime, timedelta
+
+import pytest
 
 from brain.forgetting import run_pass
 from brain.memory.store import MemoryStore
 from brain.monologue.trace import write_trace_memory
+
+_TRACE_LIFECYCLE_DEFERRED = (
+    "trace lifecycle moved to pending queue; DB-fade/recall-bump deferred to "
+    "Phase 4 (Root 2 stopgap) — a monologue_trace is now an ephemeral queue "
+    "candidate, not a memories.db row, so the forgetting engine never processes it"
+)
 
 
 class _Bus:
@@ -26,6 +42,7 @@ def _age_memory(store, mem_id, days):
     store._conn.commit()
 
 
+@pytest.mark.xfail(reason=_TRACE_LIFECYCLE_DEFERRED, strict=True)
 def test_unrevisited_trace_fades_then_is_lost(tmp_path):
     store = MemoryStore(tmp_path / "memories.db")
     mem_id = write_trace_memory(store, "an idle unremarkable drift")
@@ -48,6 +65,7 @@ def test_unrevisited_trace_fades_then_is_lost(tmp_path):
     assert "an idle unremarkable drift" in graveyard.read_text()  # stored under "summary"
 
 
+@pytest.mark.xfail(reason=_TRACE_LIFECYCLE_DEFERRED, strict=True)
 def test_recalled_trace_stays(tmp_path):
     store = MemoryStore(tmp_path / "memories.db")
     mem_id = write_trace_memory(store, "a thought she keeps returning to")

--- a/tests/unit/brain/ingest/test_commit.py
+++ b/tests/unit/brain/ingest/test_commit.py
@@ -7,6 +7,7 @@ import pytest
 from brain.ingest.commit import commit_item
 from brain.ingest.types import ExtractedItem
 from brain.memory.hebbian import HebbianMatrix
+from brain.memory.pending import PendingQueue
 from brain.memory.store import Memory, MemoryStore
 
 # ---------------------------------------------------------------------------
@@ -15,8 +16,11 @@ from brain.memory.store import Memory, MemoryStore
 
 
 @pytest.fixture
-def store() -> MemoryStore:
-    return MemoryStore(":memory:")
+def store(tmp_path) -> MemoryStore:
+    # Real on-disk db so store.persona_dir points at a real dir: the write gate
+    # enqueues gated ingest labels (all of VALID_LABELS) to the sibling
+    # pending_candidates.jsonl, which a ":memory:" store cannot host.
+    return MemoryStore(tmp_path / "memories.db")
 
 
 @pytest.fixture
@@ -32,13 +36,16 @@ def hebbian() -> HebbianMatrix:
 def test_commit_item_creates_memory_with_correct_type_domain_tags(
     store: MemoryStore, hebbian: HebbianMatrix
 ) -> None:
-    """commit_item writes a memory with memory_type=label, domain='brain', and expected tags."""
+    """commit_item enqueues a candidate with memory_type=label, domain='brain', and expected tags."""
     item = ExtractedItem(text="Nell prefers black coffee", label="fact", importance=5)
     mem_id = commit_item(item, session_id="sess_x", store=store, hebbian=hebbian)
 
     assert mem_id is not None
-    memory = store.get(mem_id)
-    assert memory is not None
+    # A gated ingest label is now enqueued as a candidate, not written to
+    # memories.db; assert the candidate carries the right fields.
+    assert store.get(mem_id) is None
+    memory = PendingQueue(store.persona_dir).read_recent("fact", limit=1)[0]
+    assert memory.id == mem_id
     assert memory.content == "Nell prefers black coffee"
     assert memory.memory_type == "fact"
     assert memory.domain == "brain"
@@ -55,15 +62,20 @@ def test_commit_item_bypasses_write_gate_low_importance(
     mem_id = commit_item(item, session_id="sess_low", store=store, hebbian=hebbian)
 
     assert mem_id is not None
-    memory = store.get(mem_id)
-    assert memory is not None
+    memory = PendingQueue(store.persona_dir).read_recent("observation", limit=1)[0]
     assert memory.importance == 1.0
 
 
-def test_commit_item_auto_hebbian_links_related_memories(
+def test_commit_item_defers_auto_hebbian_for_gated_label(
     store: MemoryStore, hebbian: HebbianMatrix
 ) -> None:
-    """commit_item strengthens Hebbian edges to top-3 textually related memories."""
+    """A gated ingest label is enqueued (not a memories.db row), so auto-Hebbian
+    linking is DEFERRED to the consolidation gate: commit_item creates no edges.
+
+    (Migration rule 3: every VALID_LABELS label is now gated, so ingest-time
+    linking would dangle against a non-existent row. The gate seeds weight-5
+    edges for corrections/continuations on promote instead.)
+    """
     # Pre-populate the store with memories that share keywords.
     for label in ("fact", "observation", "feeling"):
         related = Memory.create_new(
@@ -77,11 +89,11 @@ def test_commit_item_auto_hebbian_links_related_memories(
     mem_id = commit_item(item, session_id="sess_hebb", store=store, hebbian=hebbian)
 
     assert mem_id is not None
-    # The new memory should have Hebbian edges to the pre-existing related memories.
-    neighbors = hebbian.neighbors(mem_id)
-    assert len(neighbors) >= 1
-    weights = [w for _, w in neighbors]
-    assert all(w == 0.5 for w in weights)
+    # Candidate lives in the queue, not the DB…
+    assert store.get(mem_id) is None
+    assert PendingQueue(store.persona_dir).read_recent("fact", limit=1)[0].id == mem_id
+    # …and no Hebbian edge was created at ingest (linking deferred to the gate).
+    assert hebbian.neighbors(mem_id) == []
 
 
 # ---------------------------------------------------------------------------
@@ -104,7 +116,7 @@ def test_commit_item_persists_image_shas_in_metadata(
         image_shas=["a" * 64, "b" * 64],
     )
     assert mem_id is not None
-    memory = store.get(mem_id)
+    memory = PendingQueue(store.persona_dir).read_recent("fact", limit=1)[0]
     assert memory.metadata.get("image_shas") == ["a" * 64, "b" * 64]
 
 
@@ -115,7 +127,7 @@ def test_commit_item_no_image_shas_metadata_when_unset(
     item = ExtractedItem(text="Plain text fact", label="fact", importance=4)
     mem_id = commit_item(item, session_id="sess_text", store=store, hebbian=hebbian)
     assert mem_id is not None
-    memory = store.get(mem_id)
+    memory = PendingQueue(store.persona_dir).read_recent("fact", limit=1)[0]
     assert "image_shas" not in memory.metadata
 
 
@@ -126,5 +138,5 @@ def test_commit_item_empty_image_shas_treated_as_unset(
     item = ExtractedItem(text="Plain text", label="fact", importance=4)
     mem_id = commit_item(item, session_id="s", store=store, hebbian=hebbian, image_shas=[])
     assert mem_id is not None
-    memory = store.get(mem_id)
+    memory = PendingQueue(store.persona_dir).read_recent("fact", limit=1)[0]
     assert "image_shas" not in memory.metadata

--- a/tests/unit/brain/ingest/test_commit_loss.py
+++ b/tests/unit/brain/ingest/test_commit_loss.py
@@ -24,7 +24,22 @@ from brain.ingest.pipeline import (
 from brain.ingest.types import ExtractedItem
 from brain.memory.embeddings import EmbeddingCache, FakeEmbeddingProvider
 from brain.memory.hebbian import HebbianMatrix
+from brain.memory.pending import PendingQueue
 from brain.memory.store import MemoryStore
+
+# NOTE (memory-consolidation migration): the ingest label "fact" is a GATED
+# type, so commit_item now writes via route_write → PendingQueue.enqueue, NOT
+# store.create. The P0 loss-prevention contract is unchanged (a failed write
+# still makes commit_item return None → commit_failure → buffer/cursor held),
+# but the failure must be injected at enqueue, and the committed candidate lands
+# in the pending queue rather than memories.db. These tests patch
+# PendingQueue.enqueue and assert queue end-state accordingly.
+
+_real_enqueue = PendingQueue.enqueue
+
+
+def _always_raise_enqueue(self, mem, *, source):
+    raise RuntimeError("database is locked")
 
 
 class _NoopProvider(LLMProvider):
@@ -62,20 +77,19 @@ def test_close_session_retains_buffer_when_a_commit_fails(tmp_path: Path):
     ]
     store = MemoryStore(persona_dir / "memories.db")
     hebbian = HebbianMatrix(persona_dir / "hebbian.db")
-    real_create = store.create
     calls: dict[str, int] = {"n": 0}
 
-    def flaky_create(mem):
+    def flaky_enqueue(self, mem, *, source):
         calls["n"] += 1
         if calls["n"] == 2:
             raise RuntimeError("database is locked")
-        return real_create(mem)
+        return _real_enqueue(self, mem, source=source)
 
     try:
         with patch(
             "brain.ingest.pipeline.extract_items_with_status",
             return_value=ExtractionOutcome(items=items, failed=False, error=None),
-        ), patch.object(store, "create", side_effect=flaky_create):
+        ), patch.object(PendingQueue, "enqueue", flaky_enqueue):
             report = close_session(
                 persona_dir,
                 sid,
@@ -111,14 +125,11 @@ def test_snapshot_holds_cursor_when_commit_fails(tmp_path: Path):
 
     cursor_before = read_cursor(persona_dir, sid)  # None — no cursor yet
 
-    def always_raise(mem):
-        raise RuntimeError("database is locked")
-
     try:
         with patch(
             "brain.ingest.pipeline.extract_items_with_status",
             return_value=ExtractionOutcome(items=items, failed=False, error=None),
-        ), patch.object(store, "create", side_effect=always_raise):
+        ), patch.object(PendingQueue, "enqueue", _always_raise_enqueue):
             report = extract_session_snapshot(
                 persona_dir,
                 sid,
@@ -193,14 +204,11 @@ def test_finalize_holds_buffer_when_commit_fails(tmp_path: Path):
     store = MemoryStore(persona_dir / "memories.db")
     hebbian = HebbianMatrix(persona_dir / "hebbian.db")
 
-    def always_raise(mem):
-        raise RuntimeError("database is locked")
-
     try:
         with patch(
             "brain.ingest.pipeline.extract_items_with_status",
             return_value=ExtractionOutcome(items=items, failed=False, error=None),
-        ), patch.object(store, "create", side_effect=always_raise), patch(
+        ), patch.object(PendingQueue, "enqueue", _always_raise_enqueue), patch(
             "brain.ingest.pipeline.session_silence_minutes",
             return_value=99999.0,
         ):
@@ -258,14 +266,11 @@ def test_snapshot_embeddings_on_retry_not_self_deduped(tmp_path: Path):
         embeddings.get_or_compute("unrelated prior memory")
         assert embeddings.count() == 1
 
-        # ── Pass 1: commit raises ──────────────────────────────────────────
-        def always_raise(mem):
-            raise RuntimeError("database is locked")
-
+        # ── Pass 1: commit (enqueue) raises ────────────────────────────────
         with patch(
             "brain.ingest.pipeline.extract_items_with_status",
             return_value=ExtractionOutcome(items=items, failed=False, error=None),
-        ), patch.object(store, "create", side_effect=always_raise):
+        ), patch.object(PendingQueue, "enqueue", _always_raise_enqueue):
             report1 = extract_session_snapshot(
                 persona_dir,
                 sid,
@@ -296,9 +301,11 @@ def test_snapshot_embeddings_on_retry_not_self_deduped(tmp_path: Path):
             )
 
         assert report2.committed >= 1, "pass 2 must commit the memory (not dedup it away)"
-        mems = store.search_text(item_text, limit=5)
-        assert any(item_text in (m.content or "") for m in mems), (
-            "memory must be findable in the store after pass 2"
+        # "Committed" now means enqueued as a candidate; the memory must be
+        # findable in the pending queue after pass 2 (not memories.db).
+        queued = PendingQueue(persona_dir).read_recent("fact", limit=5)
+        assert any(item_text in (m.content or "") for m in queued), (
+            "memory must be findable in the pending queue after pass 2"
         )
     finally:
         store.close()
@@ -326,9 +333,6 @@ def test_finalize_deadletters_after_max_retry(tmp_path: Path):
     store = MemoryStore(persona_dir / "memories.db")
     hebbian = HebbianMatrix(persona_dir / "hebbian.db")
 
-    def always_raise(mem):
-        raise RuntimeError("database is locked")
-
     try:
         # Drive _BACKOFF_FAILURE_THRESHOLD snapshot passes so the sidecar
         # climbs naturally to the threshold.
@@ -336,7 +340,7 @@ def test_finalize_deadletters_after_max_retry(tmp_path: Path):
             with patch(
                 "brain.ingest.pipeline.extract_items_with_status",
                 return_value=ExtractionOutcome(items=items, failed=False, error=None),
-            ), patch.object(store, "create", side_effect=always_raise):
+            ), patch.object(PendingQueue, "enqueue", _always_raise_enqueue):
                 extract_session_snapshot(
                     persona_dir,
                     sid,
@@ -349,7 +353,7 @@ def test_finalize_deadletters_after_max_retry(tmp_path: Path):
         with patch(
             "brain.ingest.pipeline.extract_items_with_status",
             return_value=ExtractionOutcome(items=items, failed=False, error=None),
-        ), patch.object(store, "create", side_effect=always_raise), patch(
+        ), patch.object(PendingQueue, "enqueue", _always_raise_enqueue), patch(
             "brain.ingest.pipeline.session_silence_minutes",
             return_value=99999.0,
         ):
@@ -401,21 +405,20 @@ def test_snapshot_retry_no_double_commit_with_embeddings(tmp_path: Path):
     hebbian = HebbianMatrix(persona_dir / "hebbian.db")
     embeddings = EmbeddingCache(persona_dir / "embeddings.db", FakeEmbeddingProvider(dim=256))
 
-    real_create = store.create
     pass1_call: list[int] = [0]
 
-    def flaky_create_pass1(mem):
+    def flaky_enqueue_pass1(self, mem, *, source):
         pass1_call[0] += 1
         if pass1_call[0] == 2:
             raise RuntimeError("database is locked")
-        return real_create(mem)
+        return _real_enqueue(self, mem, source=source)
 
     try:
         # ── Pass 1: item at index 1 fails ─────────────────────────────────
         with patch(
             "brain.ingest.pipeline.extract_items_with_status",
             return_value=ExtractionOutcome(items=items, failed=False, error=None),
-        ), patch.object(store, "create", side_effect=flaky_create_pass1):
+        ), patch.object(PendingQueue, "enqueue", flaky_enqueue_pass1):
             report1 = extract_session_snapshot(
                 persona_dir,
                 sid,
@@ -429,9 +432,9 @@ def test_snapshot_retry_no_double_commit_with_embeddings(tmp_path: Path):
         cursor_after_pass1 = read_cursor(persona_dir, sid)
         assert cursor_after_pass1 is None, "cursor must NOT advance when a commit failed"
 
-        # Items 0 and 2 committed in pass 1.
-        active_after_pass1 = store.list_active()
-        committed_texts = {m.content for m in active_after_pass1}
+        # Items 0 and 2 committed (enqueued) in pass 1; item 1 failed.
+        queued_after_pass1 = PendingQueue(persona_dir).read_recent("fact", limit=10)
+        committed_texts = {m.content for m in queued_after_pass1}
         assert texts[0] in committed_texts, "item 0 must have committed in pass 1"
         assert texts[2] in committed_texts, "item 2 must have committed in pass 1"
         assert texts[1] not in committed_texts, "item 1 must NOT have committed in pass 1"
@@ -453,9 +456,9 @@ def test_snapshot_retry_no_double_commit_with_embeddings(tmp_path: Path):
         assert report2.committed >= 1, "pass 2 must commit at least item 1"
         assert report2.commit_failures == 0, "pass 2 must have no commit failures"
 
-        # Final assertion: exactly 3 distinct memories, no duplicates.
-        all_active = store.list_active()
-        final_texts = [m.content for m in all_active if m.content in texts]
+        # Final assertion: exactly 3 distinct candidates in the queue, no dups.
+        all_queued = PendingQueue(persona_dir).read_recent("fact", limit=20)
+        final_texts = [m.content for m in all_queued if m.content in texts]
         assert len(final_texts) == 3, (
             f"expected exactly 3 distinct memories, got {len(final_texts)}: {final_texts}"
         )

--- a/tests/unit/brain/ingest/test_emotion_seeding.py
+++ b/tests/unit/brain/ingest/test_emotion_seeding.py
@@ -41,13 +41,15 @@ def test_parse_extraction_reads_emotions():
     assert item.emotions == {"longing": 7.0}
 
 
-def test_commit_item_passes_emotions_to_memory():
-    """commit_item forwards item.emotions into the committed Memory."""
+def test_commit_item_passes_emotions_to_memory(tmp_path):
+    """commit_item forwards item.emotions into the committed (enqueued) Memory."""
     from brain.ingest.commit import commit_item
     from brain.memory.hebbian import HebbianMatrix
+    from brain.memory.pending import PendingQueue
     from brain.memory.store import MemoryStore
 
-    store = MemoryStore(":memory:")
+    # On-disk store so the gated "observation" label enqueues to a real queue.
+    store = MemoryStore(tmp_path / "memories.db")
     hebbian = HebbianMatrix(":memory:")
     item = ExtractedItem(
         text="she seemed wistful today",
@@ -58,8 +60,7 @@ def test_commit_item_passes_emotions_to_memory():
     mem_id = commit_item(item, session_id="sess_w7", store=store, hebbian=hebbian)
 
     assert mem_id is not None
-    memory = store.get(mem_id)
-    assert memory is not None
+    memory = PendingQueue(store.persona_dir).read_recent("observation", limit=1)[0]
     assert memory.emotions == {"longing": 7.0, "nostalgia": 5.0}
 
 
@@ -71,13 +72,15 @@ def test_close_session_commits_memories_with_emotions_and_aggregate_is_non_empty
     from unittest.mock import patch
 
     from brain.emotion.aggregate import aggregate_state
+    from brain.engines.consolidation import Decision, run_consolidation
     from brain.ingest.buffer import ingest_turn
     from brain.ingest.extract import ExtractionOutcome
     from brain.ingest.pipeline import close_session
     from brain.memory.hebbian import HebbianMatrix
     from brain.memory.store import MemoryStore
 
-    store = MemoryStore(":memory:")
+    # On-disk so store.persona_dir == tmp_path (where the gated candidate lands).
+    store = MemoryStore(tmp_path / "memories.db")
     hebbian = HebbianMatrix(":memory:")
 
     # Write one conversation turn so the buffer exists.
@@ -112,6 +115,14 @@ def test_close_session_commits_memories_with_emotions_and_aggregate_is_non_empty
 
     assert report.committed >= 1
     assert len(report.memory_ids) >= 1
+
+    # The gated "feeling" candidate is enqueued; promote it into memories.db so
+    # the emotion aggregate (which reads store rows) sees it. Id is preserved.
+    run_consolidation(
+        store,
+        persona_dir=store.persona_dir,
+        classifier=lambda _c, _ctx: Decision("new"),
+    )
 
     # At least one committed memory carries non-empty emotions.
     mems = [store.get(mid) for mid in report.memory_ids]

--- a/tests/unit/brain/ingest/test_pipeline.py
+++ b/tests/unit/brain/ingest/test_pipeline.py
@@ -11,6 +11,7 @@ import pytest
 
 from brain.bridge.chat import ChatMessage, ChatResponse
 from brain.bridge.provider import LLMProvider
+from brain.engines.consolidation import Decision, run_consolidation
 from brain.ingest.buffer import (
     ingest_turn,
     read_backoff,
@@ -28,6 +29,13 @@ from brain.ingest.pipeline import (
 from brain.ingest.soul_queue import list_soul_candidates
 from brain.memory.hebbian import HebbianMatrix
 from brain.memory.store import MemoryStore
+
+# memory-consolidation migration: gated ingest labels (fact/observation/…) are
+# enqueued as candidates, not written to memories.db. Promote them through the
+# consolidation gate (inject a promote-all classifier) so the pre-existing
+# store.get() end-state assertions hold — the candidate id is preserved on
+# promote, so report.memory_ids still resolves.
+_PROMOTE_ALL = lambda _cand, _ctx: Decision("new")  # noqa: E731
 
 # ---------------------------------------------------------------------------
 # Fake providers for pipeline tests
@@ -103,8 +111,10 @@ def tracking_provider() -> _TrackingProvider:
 
 
 @pytest.fixture
-def store() -> MemoryStore:
-    return MemoryStore(":memory:")
+def store(tmp_path) -> MemoryStore:
+    # On-disk so store.persona_dir == the persona_dir passed to close_session:
+    # gated ingest labels enqueue to <persona_dir>/pending_candidates.jsonl.
+    return MemoryStore(tmp_path / "memories.db")
 
 
 @pytest.fixture
@@ -179,7 +189,8 @@ def test_close_session_full_path_correct_counts(
     assert report.deduped == 0
     assert report.errors == 0
     assert len(report.memory_ids) == 2
-    # Both memories should exist in the store.
+    # Gated candidates are enqueued; promote them, then both memories exist.
+    run_consolidation(store, persona_dir=store.persona_dir, classifier=_PROMOTE_ALL)
     for mid in report.memory_ids:
         assert store.get(mid) is not None
 
@@ -286,6 +297,8 @@ def test_close_session_memory_and_soul_candidate_both_written(
     assert len(report.memory_ids) == 1
 
     mem_id = report.memory_ids[0]
+    # Gated candidate — promote it, then it is a real memories.db row (id kept).
+    run_consolidation(store, persona_dir=store.persona_dir, classifier=_PROMOTE_ALL)
     memory = store.get(mem_id)
     assert memory is not None
     assert memory.content == "The most important truth"

--- a/tests/unit/brain/initiate/test_review.py
+++ b/tests/unit/brain/initiate/test_review.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from datetime import UTC, datetime
 from pathlib import Path
 from unittest.mock import MagicMock, patch
+from zoneinfo import ZoneInfo
 
 from brain.initiate.emit import emit_initiate_candidate, read_candidates
 from brain.initiate.review import run_initiate_review_tick
@@ -144,7 +145,14 @@ def test_review_tick_gate_blocks_send_records_hold(tmp_path: Path, monkeypatch) 
         semantic_context=_ctx(),
     )
     provider = _fake_provider("send_notify")
-    blackout_time = datetime(2026, 5, 11, 1, 30, tzinfo=UTC)
+    # Inject a tz-aware, non-UTC wall-clock inside the 23:00-07:00 blackout
+    # window. check_send_allowed treats a non-UTC-offset datetime's wall-clock
+    # as user-local (see brain/initiate/gates.py + test_gates.py's LA-zoned
+    # cases), so the blackout fires deterministically regardless of the runner's
+    # OS timezone. The prior UTC 01:30 only landed in blackout on a UTC host
+    # (e.g. CI) and spuriously "delivered" on a machine west of UTC — unrelated
+    # to the memory-consolidation migration.
+    blackout_time = datetime(2026, 5, 11, 1, 30, tzinfo=ZoneInfo("America/Los_Angeles"))
     with patch("brain.initiate.review.datetime") as mock_dt:
         mock_dt.now = MagicMock(return_value=blackout_time)
         mock_dt.fromisoformat = datetime.fromisoformat

--- a/tests/unit/brain/maker/test_making_runner.py
+++ b/tests/unit/brain/maker/test_making_runner.py
@@ -5,6 +5,22 @@ from brain.memory.store import MemoryStore
 from brain.works.store import WorksStore
 
 
+def _promote_pending(persona_dir):
+    """Drain the consolidation gate with a promote-all classifier.
+
+    `making` is a GATED type (Root-2 stopgap): make_and_wire enqueues the act-memory; it
+    reaches memories.db only after a consolidation drain."""
+    from brain.engines.consolidation import Decision, run_consolidation
+
+    s = MemoryStore(persona_dir / "memories.db")
+    try:
+        run_consolidation(
+            s, persona_dir=persona_dir, classifier=lambda _c, _ctx: Decision("new")
+        )
+    finally:
+        s.close()
+
+
 class _FakeProvider:
     def complete(self, prompt):  # match maker.make()'s call
         return json.dumps({"type": "vignette", "title": "Dusk", "content": "Light fell slow.",
@@ -30,11 +46,16 @@ def test_make_and_wire_writes_act_memory_with_emotion_for_nondiscard(tmp_path):
     from brain.maker.charge import MakerCharge, save_charge
     save_charge(tmp_path, MakerCharge(99.0, "2026-06-14T00:00:00+00:00", None, 0))
     make_and_wire(persona_dir=tmp_path, store=store, provider=_FakeProvider(), now=None)
-    mems = store.list_by_type("making", limit=10)
+    # making is GATED: the act-memory enqueues, promoted on drain.
+    assert not store.list_by_type("making", limit=10)
+    store.close()
+    _promote_pending(tmp_path)
+    store2 = MemoryStore(tmp_path / "memories.db")
+    mems = store2.list_by_type("making", limit=10)
     assert len(mems) == 1
     # the emotion delta was applied W8-style: seeded onto the act-memory
     assert mems[0].emotions
-    store.close()
+    store2.close()
 
 
 class _DiscardProvider:
@@ -48,8 +69,13 @@ def test_make_and_wire_discard_moves_no_emotion(tmp_path):
     from brain.maker.charge import MakerCharge, save_charge
     save_charge(tmp_path, MakerCharge(99.0, "2026-06-14T00:00:00+00:00", None, 0))
     make_and_wire(persona_dir=tmp_path, store=store, provider=_DiscardProvider(), now=None)
-    mems = store.list_by_type("making", limit=10)
+    # making is GATED: the act-memory enqueues, promoted on drain.
+    assert not store.list_by_type("making", limit=10)
+    store.close()
+    _promote_pending(tmp_path)
+    store2 = MemoryStore(tmp_path / "memories.db")
+    mems = store2.list_by_type("making", limit=10)
     assert len(mems) == 1
     # discard moves nothing — empty-emotion act-memory only
     assert not mems[0].emotions
-    store.close()
+    store2.close()

--- a/tests/unit/brain/maker/test_wiring_memory.py
+++ b/tests/unit/brain/maker/test_wiring_memory.py
@@ -4,12 +4,33 @@ from brain.maker.wiring import write_making_memory
 from brain.memory.store import MemoryStore
 
 
+def _promote_pending(persona_dir):
+    """Drain the consolidation gate with a promote-all classifier.
+
+    `making` is a GATED type (Root-2 stopgap): write_making_memory enqueues the act-memory;
+    it reaches memories.db only after a consolidation drain."""
+    from brain.engines.consolidation import Decision, run_consolidation
+
+    s = MemoryStore(persona_dir / "memories.db")
+    try:
+        run_consolidation(
+            s, persona_dir=persona_dir, classifier=lambda _c, _ctx: Decision("new")
+        )
+    finally:
+        s.close()
+
+
 def test_act_memory_written_with_making_type_and_emotions(tmp_path):
     store = MemoryStore(tmp_path / "memories.db")
     write_making_memory(store, Making("elegy", "For the dog", "Soft paws.", "private", "raw"),
                         emotions={"tenderness": 0.1})
-    mems = store.list_by_type("making", active_only=True, limit=5)
+    # making is GATED: enqueues, not written straight to db.
+    assert not store.list_by_type("making", active_only=True, limit=5)
+    store.close()
+    _promote_pending(tmp_path)
+    store2 = MemoryStore(tmp_path / "memories.db")
+    mems = store2.list_by_type("making", active_only=True, limit=5)
     assert len(mems) == 1
     assert "For the dog" in mems[0].content
     assert mems[0].emotions.get("tenderness") == 0.1
-    store.close()
+    store2.close()

--- a/tests/unit/brain/memory/test_fts_sync.py
+++ b/tests/unit/brain/memory/test_fts_sync.py
@@ -1,0 +1,113 @@
+"""FTS5 shadow-index sync + boot rebuild + multi-term OR (P2 — C1/C2/C15/C23).
+
+Each oracle is written to FAIL against the named known-bad state:
+  - C1/C15 fail if the sync triggers are removed (FTS drifts from `memories`).
+  - C2 fails if the boot integrity/rebuild backstop is absent (FTS stays empty).
+  - C23 fails against a bare-term (implicit-AND) MATCH (zero rows for a disjoint
+    multi-term query).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from brain.memory.store import Memory, MemoryStore
+
+
+def _mem(content: str) -> Memory:
+    return Memory.create_new(content=content, memory_type="event", domain="d")
+
+
+def _fts_ids(store: MemoryStore, term: str) -> set[str]:
+    rows = store._conn.execute(
+        "SELECT m.id FROM memories_fts f JOIN memories m ON m.rowid = f.rowid "
+        "WHERE memories_fts MATCH ?",
+        (term,),
+    ).fetchall()
+    return {r[0] for r in rows}
+
+
+def _like_ids(store: MemoryStore, term: str) -> set[str]:
+    # active_only=False + bump=False → an unfiltered substring scan, the LIKE
+    # baseline the FTS MATCH set must equal.
+    return {m.id for m in store.search_text(term, active_only=False, bump=False)}
+
+
+def test_c1_fts_stays_in_sync_on_insert_update_delete() -> None:
+    store = MemoryStore(":memory:")
+    a = _mem("apple pie recipe")
+    b = _mem("banana bread loaf")
+    c = _mem("apple tart tatin")
+    for m in (a, b, c):
+        store.create(m)
+
+    # INSERT synced: MATCH == LIKE.
+    assert _fts_ids(store, "apple") == _like_ids(store, "apple") == {a.id, c.id}
+
+    # UPDATE(content) synced.
+    store.update(b.id, content="apple crumble warm")
+    assert _fts_ids(store, "apple") == _like_ids(store, "apple") == {a.id, b.id, c.id}
+
+    # DELETE synced.
+    store.hard_delete(a.id)
+    assert _fts_ids(store, "apple") == _like_ids(store, "apple") == {b.id, c.id}
+
+
+def test_c2_fts_self_heals_on_boot_no_memory_lost(tmp_path: Path) -> None:
+    db = tmp_path / "memories.db"
+    store = MemoryStore(db)
+    for i in range(3):
+        store.create(_mem(f"apple number {i}"))
+    assert _fts_ids(store, "apple")  # non-empty before
+
+    # Deliberately clear the shadow index (external-content delete-all).
+    store._conn.execute("INSERT INTO memories_fts(memories_fts) VALUES('delete-all')")
+    store._conn.commit()
+    assert not _fts_ids(store, "apple")  # empty now
+    mem_count = store.count(active_only=False)
+    store.close()
+
+    # Re-opening runs the integrity-check → rebuild backstop.
+    store2 = MemoryStore(db)
+    try:
+        assert _fts_ids(store2, "apple"), "boot rebuild should re-seed the FTS index"
+        assert store2.count(active_only=False) == mem_count, "no memory lost across rebuild"
+    finally:
+        store2.close()
+
+
+def test_c15_fts_consistency_under_interleaved_write() -> None:
+    store = MemoryStore(":memory:")
+    a = _mem("cat on a mat")
+    store.create(a)
+    assert _fts_ids(store, "cat") == {a.id}
+
+    # Inject a write between reads — the second read sees it atomically.
+    b = _mem("cat by the window")
+    store.create(b)
+    assert _fts_ids(store, "cat") == {a.id, b.id}
+
+    # A deleted row is absent from the next read.
+    store.hard_delete(a.id)
+    assert _fts_ids(store, "cat") == {b.id}
+
+
+def test_c23_multi_term_query_ors_terms_on_search_fts_scored() -> None:
+    store = MemoryStore(":memory:")
+    m1 = _mem("henryk drinks coffee")
+    m2 = _mem("her preferences about tea")
+    store.create(m1)
+    store.create(m2)
+
+    # Disjoint terms (never co-occur) must return the UNION, not the empty
+    # AND-intersection a bare-term MATCH would give.
+    scored = store.search_fts_scored("henryk preferences")
+    ids = {m.id for m, _ in scored}
+    assert ids == {m1.id, m2.id}
+
+
+def test_c23_empty_query_returns_no_match() -> None:
+    store = MemoryStore(":memory:")
+    store.create(_mem("henryk drinks coffee"))
+    # All tokens dropped (too short) → no MATCH issued, empty result.
+    assert store.search_fts_scored("a an") == []

--- a/tests/unit/brain/memory/test_relevance_rank.py
+++ b/tests/unit/brain/memory/test_relevance_rank.py
@@ -1,0 +1,114 @@
+"""rank_memories — relevance ranking, normalization, exclusion (P2 — C3/C4/C5).
+
+Oracles are written to FAIL against the named known-bad:
+  - C3 fails against RELEVANCE_RANKING_ENABLED=False (recency order → newer weak
+    match first). Both orders are asserted so the discrimination is explicit.
+  - C4 pins the exact weighted sum + single-candidate no-divide-by-zero.
+  - C5 pins exclusion.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime, timedelta
+
+import brain.memory.relevance as rel
+from brain.memory.relevance import (
+    RECENCY_HALFLIFE_DAYS,
+    W_IMP,
+    W_MATCH,
+    W_REC,
+    rank_memories,
+)
+from brain.memory.store import Memory, MemoryStore
+
+
+def _mk(store: MemoryStore, content: str, *, importance: float, age_days: float) -> Memory:
+    m = Memory(
+        id=str(uuid.uuid4()),
+        content=content,
+        memory_type="event",
+        domain="d",
+        created_at=datetime.now(UTC) - timedelta(days=age_days),
+        importance=importance,
+    )
+    store.create(m)
+    return m
+
+
+def test_c3_ranking_is_relevance_not_recency(monkeypatch) -> None:
+    store = MemoryStore(":memory:")
+    # Older, strong text-match + high importance.
+    old_strong = _mk(store, "henryk henryk henryk", importance=9.0, age_days=60)
+    # Newer, weak text-match (one mention buried in filler) + low importance.
+    new_weak = _mk(
+        store,
+        "henryk mentioned only once amid a great many other unrelated filler words here",
+        importance=2.0,
+        age_days=0,
+    )
+
+    ranked = rank_memories(store, None, "henryk", limit=5)
+    order = [m.id for m, _ in ranked]
+    assert order[0] == old_strong.id, "blended relevance should rank the strong old match first"
+
+    # Known-bad: with ranking disabled the fallback is recency-only → newer first.
+    monkeypatch.setattr(rel, "RELEVANCE_RANKING_ENABLED", False)
+    ranked_off = rank_memories(store, None, "henryk", limit=5)
+    assert [m.id for m, _ in ranked_off][0] == new_weak.id
+
+
+def test_c4_normalization_exact_and_single_candidate_no_div0() -> None:
+    store = MemoryStore(":memory:")
+    _mk(store, "henryk", importance=7.0, age_days=0)
+
+    ranked = rank_memories(store, None, "henryk", limit=5)
+    assert len(ranked) == 1  # single candidate — bm25 min==max, must not raise
+    mem, score = ranked[0]
+    assert score is not None
+
+    # Single candidate → m_norm = 1.0; hebbian None → h = 0.
+    age_days = (datetime.now(UTC) - mem.created_at).total_seconds() / 86400.0
+    r_norm = 0.5 ** (age_days / RECENCY_HALFLIFE_DAYS)
+    expected = W_MATCH * 1.0 + W_IMP * (7.0 / 10.0) + W_REC * r_norm
+    assert abs(score - expected) < 1e-3
+
+
+def test_c5_exclusion_set_is_honored() -> None:
+    store = MemoryStore(":memory:")
+    m1 = _mk(store, "henryk one", importance=5.0, age_days=0)
+    m2 = _mk(store, "henryk two", importance=5.0, age_days=0)
+
+    ranked = rank_memories(store, None, "henryk", limit=5, exclude_ids={m1.id})
+    ids = {m.id for m, _ in ranked}
+    assert m1.id not in ids
+    assert m2.id in ids
+
+
+def test_disabled_ranking_returns_none_sentinel(monkeypatch) -> None:
+    store = MemoryStore(":memory:")
+    _mk(store, "henryk here", importance=5.0, age_days=0)
+    monkeypatch.setattr(rel, "RELEVANCE_RANKING_ENABLED", False)
+    ranked = rank_memories(store, None, "henryk", limit=5)
+    assert ranked and all(score is None for _, score in ranked)
+
+
+def test_disabled_ranking_excludes_before_limit_backfills(monkeypatch) -> None:
+    """Flag-off fallback applies exclude_ids BEFORE the limit slice, so an
+    excluded id inside the top-`limit` backfills from the next match instead of
+    shrinking the result (stage-6 minor). Known-bad: excluding then slicing
+    would return `limit - 1` items.
+    """
+    store = MemoryStore(":memory:")
+    # 3 matches; search_text orders by created_at DESC → newest first.
+    m_new = _mk(store, "henryk newest", importance=5.0, age_days=0)
+    m_mid = _mk(store, "henryk middle", importance=5.0, age_days=1)
+    m_old = _mk(store, "henryk oldest", importance=5.0, age_days=2)
+    monkeypatch.setattr(rel, "RELEVANCE_RANKING_ENABLED", False)
+
+    # limit=2, exclude the newest (which would occupy slot 1 of the top-2).
+    ranked = rank_memories(store, None, "henryk", limit=2, exclude_ids={m_new.id})
+    ids = [m.id for m, _ in ranked]
+    assert m_new.id not in ids
+    # Backfill: still 2 results (m_mid, m_old), not 1.
+    assert ids == [m_mid.id, m_old.id]

--- a/tests/unit/brain/memory/test_snippet_length.py
+++ b/tests/unit/brain/memory/test_snippet_length.py
@@ -1,0 +1,58 @@
+"""snippet_length — proportional snippet-length formula (recall-reinforcement,
+CHANGE 2 — G8/G9/G10/G11).
+
+``snippet_length(body_len) = min(max(SNIPPET_MIN_CHARS, body_len // 5), SNIPPET_MAX_CHARS)``.
+Table-driven over the load-bearing lengths named in the criteria: a short
+memory (12 chars, at/below the floor), a sub-140 memory (100 chars, the
+Defect-A case), a memory just over the cap boundary (200 chars), and a long
+memory (800 chars).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from brain.memory.relevance import SNIPPET_MAX_CHARS, SNIPPET_MIN_CHARS, snippet_length
+
+
+@pytest.mark.parametrize(
+    ("body_len", "expected"),
+    [
+        (12, SNIPPET_MIN_CHARS),  # G11: tiny body — floored, not ~3 useless chars
+        (100, 20),  # G9 (Defect-A fix): sub-140 body now truncates, 100 // 5 == 20
+        (200, 40),  # 200 // 5 == 40, still below the cap
+        (800, SNIPPET_MAX_CHARS),  # G10: long body still caps at 140
+    ],
+)
+def test_g8_snippet_length_formula(body_len: int, expected: int) -> None:
+    assert snippet_length(body_len) == expected
+
+
+def test_g9_sub_140_memory_now_truncates() -> None:
+    """Defect-A fix: a memory shorter than 140 but longer than the floor no
+    longer surfaces as its own full body — the snippet is strictly shorter,
+    so a follow-up read_full_memory always adds real text."""
+    body = "x" * 100
+    max_chars = snippet_length(len(body))
+    assert max_chars < len(body)
+    snippet = body[: max_chars - 1].rstrip() + "…"
+    assert snippet.endswith("…")
+    assert len(snippet) < len(body)
+
+
+def test_g10_long_memory_caps_at_snippet_max_chars() -> None:
+    body = "y" * 800
+    max_chars = snippet_length(len(body))
+    assert max_chars == SNIPPET_MAX_CHARS
+    snippet = body[: max_chars - 1].rstrip() + "…"
+    assert snippet.endswith("…")
+    assert len(snippet) == SNIPPET_MAX_CHARS
+
+
+def test_g11_tiny_memory_shows_whole_body() -> None:
+    """A body at/below the floor isn't reduced to a useless fragment: its
+    snippet_length is >= its own length, so the (len > max_chars) truncation
+    gate never fires and the whole tiny body renders."""
+    body = "z" * 12
+    max_chars = snippet_length(len(body))
+    assert max_chars >= len(body)

--- a/tests/unit/brain/memory/test_store.py
+++ b/tests/unit/brain/memory/test_store.py
@@ -881,6 +881,151 @@ def test_hard_delete_does_not_bump_recall_count_on_other_rows():
     store.close()
 
 
+# ---------------------------------------------------------------------------
+# ND-1 follow-up: update()/deactivate()'s internal existence-check must not
+# bump recall_count either (closes the last leak — only a genuine full-read
+# via get(bump=True, the default) counts as engagement).
+# ---------------------------------------------------------------------------
+
+
+def test_update_does_not_bump_recall_count():
+    """update()'s internal existence-check must not inflate recall_count."""
+    store = MemoryStore(":memory:")
+    m = Memory.create_new(content="x", memory_type="episodic", domain="chat", emotions={})
+    store.create(m)
+    row = store._conn.execute("SELECT recall_count FROM memories WHERE id = ?", (m.id,)).fetchone()
+    assert row["recall_count"] == 0
+    store.update(m.id, content="modified")
+    row = store._conn.execute("SELECT recall_count FROM memories WHERE id = ?", (m.id,)).fetchone()
+    assert row["recall_count"] == 0  # a maintenance write is NOT a recall
+    store.close()
+
+
+def test_deactivate_does_not_bump_recall_count():
+    """deactivate()'s internal existence-check must not inflate recall_count."""
+    store = MemoryStore(":memory:")
+    m = Memory.create_new(content="x", memory_type="episodic", domain="chat", emotions={})
+    store.create(m)
+    row = store._conn.execute("SELECT recall_count FROM memories WHERE id = ?", (m.id,)).fetchone()
+    assert row["recall_count"] == 0
+    store.deactivate(m.id)
+    row = store._conn.execute("SELECT recall_count FROM memories WHERE id = ?", (m.id,)).fetchone()
+    assert row["recall_count"] == 0  # deactivating is NOT a recall
+    store.close()
+
+
+def test_genuine_full_read_still_bumps_recall_count_after_nd1():
+    """Regression: get()'s default path (bump=True) is untouched by the ND-1 fix
+    — a deliberate full-read still bumps recall_count, even after update()/
+    deactivate() calls that themselves must not bump it."""
+    store = MemoryStore(":memory:")
+    m = Memory.create_new(content="x", memory_type="episodic", domain="chat", emotions={})
+    store.create(m)
+    store.update(m.id, content="modified")
+    store.deactivate(m.id)
+    row = store._conn.execute("SELECT recall_count FROM memories WHERE id = ?", (m.id,)).fetchone()
+    assert row["recall_count"] == 0  # confirm the maintenance writes above didn't bump it
+    restored = store.get(m.id)  # genuine full-read, default bump=True
+    assert restored is not None
+    row = store._conn.execute("SELECT recall_count FROM memories WHERE id = ?", (m.id,)).fetchone()
+    assert row["recall_count"] == 1  # only the full-read counted
+    store.close()
+
+
+# ---------------------------------------------------------------------------
+# recall-reinforcement: fractional recall_count bump (CHANGE 1, G4/G5/G14)
+# ---------------------------------------------------------------------------
+
+
+def test_bump_recall_accumulates_fractional_values():
+    """G4: bump_recall stores and accumulates fractional amounts — two 0.8
+    bumps read back as ~1.6 (float), not 1 or 2."""
+    store = MemoryStore(":memory:")
+    m = Memory.create_new(content="x", memory_type="episodic", domain="chat", emotions={})
+    store.create(m)
+
+    store.bump_recall(m.id, 0.8)
+    store.bump_recall(m.id, 0.8)
+
+    restored = store.get(m.id, bump=False)
+    row = store._conn.execute("SELECT recall_count FROM memories WHERE id = ?", (m.id,)).fetchone()
+    assert row["recall_count"] == pytest.approx(1.6)
+    assert restored.recall_count == pytest.approx(1.6)  # round-trips through _row_to_memory too
+    store.close()
+
+
+# Pre-REAL personas (e.g. the v0.0.33 schema in tests/recovery/test_source_reader.py)
+# declared recall_count with INTEGER column affinity. When such a DB is opened by
+# MemoryStore, `CREATE TABLE IF NOT EXISTS` leaves the existing table alone and the
+# column-migration only adds recall_count when absent, so the INTEGER affinity is
+# preserved on the live table. This helper reproduces that exact starting state so
+# G5 tests the real back-compat path, not a fresh REAL-affinity column.
+def _mk_integer_affinity_store(db_path, *, seed_recall_count=3):
+    conn = sqlite3.connect(str(db_path))
+    conn.execute(
+        "CREATE TABLE memories (id TEXT PRIMARY KEY, content TEXT NOT NULL,"
+        " memory_type TEXT NOT NULL, domain TEXT NOT NULL, emotions_json TEXT NOT NULL,"
+        " tags_json TEXT NOT NULL, importance REAL NOT NULL DEFAULT 0.0,"
+        " score REAL NOT NULL DEFAULT 0.0, created_at TEXT NOT NULL, last_accessed_at TEXT,"
+        " active INTEGER NOT NULL DEFAULT 1, protected INTEGER NOT NULL DEFAULT 0,"
+        " metadata_json TEXT NOT NULL DEFAULT '{}', state TEXT NOT NULL DEFAULT 'active',"
+        " content_snapshot TEXT, recall_count INTEGER NOT NULL DEFAULT 0)"
+    )
+    conn.execute(
+        "INSERT INTO memories (id, content, memory_type, domain, emotions_json, tags_json,"
+        " created_at, recall_count) VALUES ('m1','x','episodic','chat','{}','[]',"
+        " '2026-01-01T00:00:00+00:00', ?)",
+        (seed_recall_count,),
+    )
+    conn.commit()
+    conn.close()
+    return MemoryStore(str(db_path))
+
+
+def test_bump_recall_on_integer_affinity_column_accumulates_to_float(tmp_path):
+    """G5 (back-compat): a persona whose recall_count column genuinely has
+    INTEGER affinity (holding integer 3) accepts a subsequent fractional bump
+    through the store's real UPDATE path and reads back as 3.8 (float) — no
+    crash, no truncation to 3 or 4. Fails if SQLite were to truncate a
+    fractional bump on an integer-affinity column."""
+    store = _mk_integer_affinity_store(tmp_path / "memories.db")
+    # Confirm we are actually testing INTEGER affinity, not a REAL column.
+    affinity = {
+        row["name"]: row["type"]
+        for row in store._conn.execute("PRAGMA table_info(memories)")
+    }["recall_count"]
+    assert affinity == "INTEGER"
+
+    store.bump_recall("m1", 0.8)
+
+    row = store._conn.execute(
+        "SELECT recall_count, typeof(recall_count) AS t FROM memories WHERE id = 'm1'"
+    ).fetchone()
+    assert row["recall_count"] == pytest.approx(3.8)
+    assert row["t"] == "real"  # stored as a real, not truncated to an integer
+    store.close()
+
+
+def test_recall_count_bumps_from_different_sites_accumulate_additively():
+    """G14 (no-lost-update): a full-read bump (+1.0, via get()) and a passive-
+    recall fractional bump (+0.8, via bump_recall()) both land as a SUM — the
+    second write does not clobber the first. Each bump site issues a single
+    atomic `recall_count = recall_count + ?` UPDATE, so this must FAIL against
+    a non-additive/overwrite implementation (e.g. one that read-then-wrote a
+    computed total in Python)."""
+    store = MemoryStore(":memory:")
+    m = Memory.create_new(content="x", memory_type="episodic", domain="chat", emotions={})
+    store.create(m)
+
+    store.get(m.id)  # +1.0
+    store.bump_recall(m.id, 0.8)  # +0.8
+    store.get(m.id)  # +1.0
+
+    row = store._conn.execute("SELECT recall_count FROM memories WHERE id = ?", (m.id,)).fetchone()
+    assert row["recall_count"] == pytest.approx(2.8)
+    store.close()
+
+
 def test_double_fade_preserves_original_content_snapshot(caplog):
     """fade called twice must NOT overwrite the original snapshot."""
     import logging

--- a/tests/unit/brain/monologue/test_ambient.py
+++ b/tests/unit/brain/monologue/test_ambient.py
@@ -1,3 +1,5 @@
+import pytest
+
 from brain.memory.store import MemoryStore
 from brain.monologue.ambient import build_interior_continuity_block
 from brain.monologue.trace import write_trace_memory
@@ -16,6 +18,17 @@ def test_renders_active_verbatim(tmp_path):
     assert "interior continuity" in block.lower()
 
 
+@pytest.mark.xfail(
+    reason=(
+        "CATEGORY-B (memory-consolidation migration): monologue_trace is now a gated "
+        "pending-candidate, not a memories.db row. Ambient reads traces from the "
+        "queue and renders them VERBATIM (see test_renders_active_verbatim); a "
+        "candidate cannot fade — store.fade(mem_id) raises KeyError since there is no "
+        "DB row. The blurred-summary rendering is deferred to Phase 4 (Root 2 "
+        "stopgap)."
+    ),
+    strict=True,
+)
 def test_renders_faded_summary_not_original(tmp_path):
     store = MemoryStore(tmp_path / "memories.db")
     mem_id = write_trace_memory(store, "a long original verbatim thought")

--- a/tests/unit/brain/monologue/test_recall.py
+++ b/tests/unit/brain/monologue/test_recall.py
@@ -1,3 +1,5 @@
+import pytest
+
 from brain.memory.hebbian import HebbianMatrix
 from brain.memory.store import Memory, MemoryStore
 from brain.monologue.recall import recall_monologue
@@ -21,6 +23,16 @@ def test_recall_finds_matching_trace_only(tmp_path):
     assert "lighthouse facts" not in bodies
 
 
+@pytest.mark.xfail(
+    reason=(
+        "CATEGORY-B (memory-consolidation migration): monologue_trace is now a gated "
+        "pending-candidate, not a memories.db row, so recall reads it from the queue "
+        "and the keep-sharp recall_count bump is a NO-OP (there is no store row to "
+        "bump — list_by_type('monologue_trace') is empty). recall-bump deferred to "
+        "Phase 4 (Root 2 stopgap)."
+    ),
+    strict=True,
+)
 def test_recall_bumps_recall_count_keeping_it_sharp(tmp_path):
     store, hebbian = _ctx(tmp_path)
     write_trace_memory(store, "the harbour at dusk")

--- a/tests/unit/brain/monologue/test_trace.py
+++ b/tests/unit/brain/monologue/test_trace.py
@@ -1,15 +1,29 @@
 import json
 
 from brain.chat.monologue_capture import capture_monologue
+from brain.memory.pending import PendingQueue
 from brain.memory.store import Memory, MemoryStore
 from brain.monologue.trace import MONOLOGUE_TRACE_TYPE, write_trace_memory
+
+# memory-consolidation migration: monologue_trace is a GATED type. write_trace_memory
+# now enqueues a pending candidate instead of writing to memories.db. These tests
+# verify the produced trace's fields against the queue entry (read_recent yields
+# Memory objects with the same content/type/domain/emotions/state). The trace's
+# DB-fade lifecycle is a separate concern — see test_monologue_trace_lifecycle.
+
+
+def _trace_candidate(store):
+    """The single most-recent monologue_trace candidate in the pending queue."""
+    return PendingQueue(store.persona_dir).read_recent(MONOLOGUE_TRACE_TYPE, limit=1)[0]
 
 
 def test_write_trace_memory_persists_verbatim_as_active(tmp_path):
     store = MemoryStore(tmp_path / "memories.db")
     mem_id = write_trace_memory(store, "i kept thinking about the lighthouse")
-    mem = store.get(mem_id)
-    assert mem is not None
+    # Enqueued as a candidate, not a memories.db row.
+    assert store.get(mem_id) is None
+    mem = _trace_candidate(store)
+    assert mem.id == mem_id
     assert mem.content == "i kept thinking about the lighthouse"
     assert mem.memory_type == MONOLOGUE_TRACE_TYPE
     assert mem.domain == "monologue"
@@ -28,8 +42,8 @@ def test_write_trace_memory_seeds_current_emotion_aggregate(tmp_path):
             emotions={"love": 8.0},
         )
     )
-    mem_id = write_trace_memory(store, "drifting again")
-    mem = store.get(mem_id)
+    write_trace_memory(store, "drifting again")
+    mem = _trace_candidate(store)
     assert mem.emotions, "trace should inherit the current emotional aggregate"
     assert "love" in mem.emotions
 
@@ -44,8 +58,8 @@ def test_capture_writes_trace_memory_and_surfaced_digest(tmp_path):
         surface=True,
     )
     assert out == "the raw drift"
-    # Tier 2: a trace memory exists.
-    traces = store.list_by_type(MONOLOGUE_TRACE_TYPE)
+    # Tier 2: a trace candidate exists in the pending queue (gated type).
+    traces = PendingQueue(store.persona_dir).read_recent(MONOLOGUE_TRACE_TYPE, limit=10)
     assert len(traces) == 1
     assert traces[0].content == "the raw drift"
     # Tier 3: the digest line carries surfaced.

--- a/tests/unit/brain/self_model/test_reconcile.py
+++ b/tests/unit/brain/self_model/test_reconcile.py
@@ -53,16 +53,11 @@ def test_revise_writes_clamped_registered_emotion_memory(tmp_path: Path) -> None
     assert result.get("ok") is True
     assert result.get("delta_written") is True
 
-    # self_model_reconcile is a GATED type (Root-2 stopgap): the emotion-carrying memory
-    # enqueues to the pending queue and reaches memories.db only after a consolidation drain.
-    from brain.engines.consolidation import Decision, run_consolidation
-
+    # self_model_reconcile BYPASSES the consolidation gate (owner decision, see
+    # GATE_BYPASS_TYPES in brain/memory/pending.py): the emotion-carrying memory
+    # commits straight to memories.db, immediately visible via list_active.
     store = MemoryStore(tmp_path / "memories.db")
     try:
-        assert not [m for m in store.list_active() if m.memory_type == "self_model_reconcile"]
-        run_consolidation(
-            store, persona_dir=tmp_path, classifier=lambda _c, _ctx: Decision("new")
-        )
         mems = [m for m in store.list_active() if m.memory_type == "self_model_reconcile"]
     finally:
         store.close()

--- a/tests/unit/brain/self_model/test_reconcile.py
+++ b/tests/unit/brain/self_model/test_reconcile.py
@@ -53,8 +53,16 @@ def test_revise_writes_clamped_registered_emotion_memory(tmp_path: Path) -> None
     assert result.get("ok") is True
     assert result.get("delta_written") is True
 
+    # self_model_reconcile is a GATED type (Root-2 stopgap): the emotion-carrying memory
+    # enqueues to the pending queue and reaches memories.db only after a consolidation drain.
+    from brain.engines.consolidation import Decision, run_consolidation
+
     store = MemoryStore(tmp_path / "memories.db")
     try:
+        assert not [m for m in store.list_active() if m.memory_type == "self_model_reconcile"]
+        run_consolidation(
+            store, persona_dir=tmp_path, classifier=lambda _c, _ctx: Decision("new")
+        )
         mems = [m for m in store.list_active() if m.memory_type == "self_model_reconcile"]
     finally:
         store.close()

--- a/tests/unit/brain/tools/test_dispatch.py
+++ b/tests/unit/brain/tools/test_dispatch.py
@@ -265,6 +265,7 @@ def test_all_dispatched_tools_dispatch_without_crash(tmp_path: Path) -> None:
         "get_personality": {},
         "get_body_state": {},
         "search_memories": {"query": "test"},
+        "read_full_memory": {"memory_id": "zzzzzzzz-zzzz-zzzz-zzzz-zzzzzzzzzzzz"},
         "add_journal": {"content": "journal entry"},
         "add_memory": {
             "content": "significant moment",

--- a/tests/unit/brain/tools/test_read_full_memory.py
+++ b/tests/unit/brain/tools/test_read_full_memory.py
@@ -1,0 +1,60 @@
+"""read_full_memory tool — full body + deliberate-read bump + wiring (P2 — C7/C10)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from brain.chat.tool_inventory import build_tool_inventory
+from brain.chat.tool_recruit import REFLEXIVE_CORE
+from brain.memory.hebbian import HebbianMatrix
+from brain.memory.store import Memory, MemoryStore
+from brain.tools import NELL_TOOL_NAMES, SCHEMAS
+from brain.tools.dispatch import dispatch
+from brain.tools.impls.read_full_memory import read_full_memory
+
+
+def _recall_count(store: MemoryStore, mid: str) -> int:
+    return store._conn.execute(
+        "SELECT recall_count FROM memories WHERE id = ?", (mid,)
+    ).fetchone()[0]
+
+
+def test_c7_read_full_memory_returns_full_body_and_bumps_recall_count(tmp_path: Path) -> None:
+    store = MemoryStore(":memory:")
+    hebbian = HebbianMatrix(":memory:")
+    long_body = "Jordan " + ("mattered very much and here is a lot more detail. " * 20)
+    m = Memory.create_new(content=long_body, memory_type="event", domain="d")
+    store.create(m)
+
+    before = _recall_count(store, m.id)
+    res = read_full_memory(m.id, store=store, hebbian=hebbian, persona_dir=tmp_path)
+
+    assert res["content"] == long_body  # full, untruncated
+    assert _recall_count(store, m.id) - before == 1  # deliberate-read bump
+
+
+def test_c7_read_full_memory_not_found(tmp_path: Path) -> None:
+    store = MemoryStore(":memory:")
+    hebbian = HebbianMatrix(":memory:")
+    res = read_full_memory("no-such-id", store=store, hebbian=hebbian, persona_dir=tmp_path)
+    assert res == {"error": "not found", "id": "no-such-id"}
+
+
+def test_c10_read_full_memory_registered_and_reachable(tmp_path: Path) -> None:
+    assert "read_full_memory" in NELL_TOOL_NAMES
+    assert "read_full_memory" in SCHEMAS
+    assert set(SCHEMAS) == set(NELL_TOOL_NAMES)  # schema set-equality holds
+    assert "read_full_memory" in REFLEXIVE_CORE  # always-available tier
+    assert "`read_full_memory`" in build_tool_inventory("Nell")  # appears in inventory
+
+    # Dispatches without crashing (unknown id → soft error dict).
+    store = MemoryStore(":memory:")
+    hebbian = HebbianMatrix(":memory:")
+    out = dispatch(
+        "read_full_memory",
+        {"memory_id": "nope"},
+        store=store,
+        hebbian=hebbian,
+        persona_dir=tmp_path,
+    )
+    assert out["error"] == "not found"

--- a/tests/unit/brain/tools/test_search_memories_ranked.py
+++ b/tests/unit/brain/tools/test_search_memories_ranked.py
@@ -1,0 +1,90 @@
+"""search_memories on the ranked/snippet path, via real dispatch (P2 — C5/C23 + shape).
+
+Exercises the ASSEMBLED tool path (through `dispatch`), not the impl in isolation:
+  - C23: a disjoint multi-term query returns the UNION on the real tool.
+  - C5:  exclude_ids drops the excluded id on the real tool.
+  - shape: results are snippets (`snippet: true` + id), never full bodies.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from brain.memory.hebbian import HebbianMatrix
+from brain.memory.relevance import snippet_length
+from brain.memory.store import Memory, MemoryStore
+from brain.tools.dispatch import dispatch
+
+
+def _seed(store: MemoryStore, content: str) -> Memory:
+    m = Memory.create_new(content=content, memory_type="event", domain="d")
+    store.create(m)
+    return m
+
+
+def _ctx(tmp_path: Path) -> dict:
+    return {
+        "store": MemoryStore(":memory:"),
+        "hebbian": HebbianMatrix(":memory:"),
+        "persona_dir": tmp_path,
+    }
+
+
+def test_c23_dispatched_search_memories_ors_disjoint_terms(tmp_path: Path) -> None:
+    ctx = _ctx(tmp_path)
+    m1 = _seed(ctx["store"], "henryk drinks coffee")
+    m2 = _seed(ctx["store"], "her preferences about tea")
+
+    res = dispatch("search_memories", {"query": "henryk preferences"}, **ctx)
+    ids = {m["id"] for m in res["memories"]}
+    assert m1.id in ids and m2.id in ids, "disjoint multi-term query must union, not AND"
+
+
+def test_dispatched_search_memories_returns_snippet_shape(tmp_path: Path) -> None:
+    ctx = _ctx(tmp_path)
+    long_body = "henryk " + ("and a great deal of extra detail follows here. " * 20)
+    _seed(ctx["store"], long_body)
+    expected_max = snippet_length(len(long_body))  # G12: proportional bound, not flat 140
+
+    res = dispatch("search_memories", {"query": "henryk"}, **ctx)
+    assert res["memories"], "expected at least one hit"
+    for m in res["memories"]:
+        assert m.get("snippet") is True
+        assert "id" in m
+        assert len(m["content"]) <= expected_max  # truncated per the proportional formula
+
+
+def test_g7_search_memories_leaves_recall_count_and_last_accessed_untouched(
+    tmp_path: Path,
+) -> None:
+    """G7: the explicit search_memories tool path stays bump-free (CHANGE 1
+    scopes the fractional bump to passive recall only)."""
+    ctx = _ctx(tmp_path)
+    m = _seed(ctx["store"], "henryk untouched by search")
+    before = ctx["store"]._conn.execute(
+        "SELECT recall_count, last_accessed_at FROM memories WHERE id = ?", (m.id,)
+    ).fetchone()
+
+    res = dispatch("search_memories", {"query": "henryk"}, **ctx)
+    assert res["memories"], "expected at least one hit"
+
+    after = ctx["store"]._conn.execute(
+        "SELECT recall_count, last_accessed_at FROM memories WHERE id = ?", (m.id,)
+    ).fetchone()
+    assert after["recall_count"] == before["recall_count"]
+    assert after["last_accessed_at"] == before["last_accessed_at"]
+
+
+def test_c5_dispatched_search_memories_honors_exclude_ids(tmp_path: Path) -> None:
+    ctx = _ctx(tmp_path)
+    m1 = _seed(ctx["store"], "henryk one detail")
+    m2 = _seed(ctx["store"], "henryk two detail")
+
+    res = dispatch(
+        "search_memories",
+        {"query": "henryk", "exclude_ids": [m1.id]},
+        **ctx,
+    )
+    ids = {m["id"] for m in res["memories"]}
+    assert m1.id not in ids
+    assert m2.id in ids


### PR DESCRIPTION
 Temporary stopgap for the Root 2 "memory-generation flood" (self-generated content re-entering recall as if it were genuine memory). It is explicitly a v0 that the full dream/consolidation cycle replaces in a later phase; its removal is tracked as a dependency of the relevance-overhaul phase.

## What it does
Automatically-generated "firehose" memories (the monologue family, dream, research, heartbeat, and non-journal reflex/ingest output) are enqueued to a **separate pending queue** (`brain/memory/pending.py` — a JSONL store + file-lock, outside `memories.db`) instead of committing straight to the memory database. An idle-tick consolidation gate (`brain/engines/consolidation.py`) drains the queue and, per candidate: rejects exact duplicates, promotes survivors into `memories.db`, or merges a near-duplicate-that-adds-information into the existing memory (archive a pre-image, then a surgical edit). Recall reads `memories.db` unchanged.

- Deliberate writes (`journal_entry`, `initiate_outbound`) bypass the gate and commit directly.
- The Pass-1 salience drop is scoped to the monologue-episode types (the ones that carry a real importance signal), so emotionally-flat dreams/traces are never discarded.
- Corrections/continuations get a strong hebbian link on promotion.
- Interior-continuity reads recent traces from the queue; its limit/semantics are unchanged (that rework is deferred to a later phase).

## Why a separate queue
A rejected candidate is never a stored memory, so it never touches the graveyard/grief/forgetting machinery — the reject case is a trivial queue discard, and recall/forgetting are untouched by construction.

## Status / scope
- Built and independently cold-reviewed. Full non-live suite green: **4235 passed, 0 failed, 5 xfailed** (legitimate behavior-removals); `ruff` clean.
- **This proves the mechanism.** Actual flood-reduction depends on the consolidation classifier's keep/merge/reject quality — validated and tuned by a live sandbox run (pending). Without a live classifier the gate safely degrades to promote-everything (nothing lost).
- Kept **draft** pending that live validation and review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


**Design note (2026-08-28): emotion-influence memory types bypass the consolidation gate.** `monologue_emotion` and `self_model_reconcile` are added to `GATE_BYPASS_TYPES`, so per-turn emotional nudges affect felt state immediately instead of waiting for consolidation promotion (these types carry the emotion vectors that `aggregate_state` pools). Trade-off accepted for now: they are recallable, auto-generated memories, so they enter recall without gate review. If the memory-flood / low-value-recall problem resurfaces, this bypass is the first place to look. To be revisited when the dream cycle replaces this interim gate.

**Merge notes:** Based on the diagnosis branch with a stale recorded merge-base — a naive `git rebase main` throws spurious conflicts, so it's been reconstructed as a clean net-diff on current main (final-snapshot, not commit-by-commit). It predated main's emotion-delta cap (#94 / `_MAX_DELTA_INTENSITY`), which has been re-applied here. One unrelated CI test fails pre-existing: `test_review_tick_gate_blocks_send_records_hold` (hardcoded-date test #136; #142 fixes it).
