### PR TITLE
Make the attunement backfill respect the CLI concurrency cap

### DIFF
--- a/brain/attunement/backfill.py
+++ b/brain/attunement/backfill.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import json
 import logging
+import time
 from dataclasses import asdict, dataclass, replace
 from datetime import UTC
 from datetime import datetime as _datetime
@@ -179,6 +180,12 @@ def _cursor_index(windows: list[Window], cursor: str) -> int:
 
 _MIN_TURNS_FOR_BACKFILL = 10
 
+# Inter-call pacing between windows, so a backfill never bursts its whole daily
+# budget of `claude -p` spawns in one sitting. Mirrors _INTER_CALL_DELAY_S in
+# brain/ingest/emotion_backfill.py, the sibling backfill this loop is modelled
+# on. Tests pass delay_s=0 to skip the wait.
+_INTER_CALL_DELAY_S = 1.5
+
 # Categories added in schema v0.0.29 that need a supplementary bootstrap
 # when an existing persona's backfill completed at an older schema version.
 # tone + cadence are already learned and must NOT be double-counted.
@@ -224,6 +231,7 @@ def run_backfill(
     cap: int | None = None,
     only_categories: frozenset[str] | None = None,
     supplementary: bool = False,
+    delay_s: float = _INTER_CALL_DELAY_S,
 ):
     """Run (or resume) the one-time backfill migration.
 
@@ -247,6 +255,13 @@ def run_backfill(
         BackfillState,
     )
     from brain.attunement.store import merge_into_learned
+    from brain.body.session_hours import compute_active_session_hours
+    from brain.bridge import cli_throttle
+
+    # cli_throttle is imported locally: brain.bridge pulls in the supervisor, so
+    # a module-level import would be circular. compute_active_session_hours is
+    # the layer-neutral primitive (brain/body/session_hours.py) — the same
+    # signal emotion_backfill's _user_recently_active wraps.
 
     if cap is None:
         cap = DAILY_BUDGET_DEFAULT
@@ -330,34 +345,69 @@ def run_backfill(
 
     for i in range(start_idx, len(sampled)):
         window = sampled[i]
-        if not _attunement_consume_call(persona_dir, now=now_dt, cap=cap):
-            state = replace(state, status="deferred_to_next_day")
-            _save_state(persona_dir, state)
+
+        # Yield gate (disk-based, restart-robust): stand down while the user is
+        # actively chatting so the CLI is free for the interactive turn. The
+        # cursor is already persisted, so the next pass resumes right here.
+        if compute_active_session_hours(persona_dir, now=now_dt) > 0.0:
+            _log.info(
+                "attunement backfill: yielding — user actively chatting; "
+                "will resume when idle (cursor=%s)",
+                state.last_cursor,
+            )
             return state
 
-        try:
-            output = detector_fn(buffer_slice=list(window.turns), reply_text="")
-        except Exception as exc:  # noqa: BLE001
-            _log.warning(
-                "attunement backfill: detector error on %s: %s", window.id, exc
-            )
-            continue
+        # Global concurrency cap: one background CLI consumer at a time. Each
+        # detector_fn call is a fresh `claude -p` spawn, and without this the
+        # loop could issue up to `cap` of them while another engine held the
+        # single slot — invisibly, since _inflight_background never saw them.
+        # The slot wraps budget-check + detector + write-back so it covers the
+        # whole per-window unit of work, and is released before the pacing sleep.
+        with cli_throttle.background_slot() as slot:
+            if not slot:
+                # Return rather than break: falling through would run the
+                # completion tail below and mark a partially-processed backfill
+                # 'complete', which should_run_backfill treats as done forever.
+                _log.info(
+                    "attunement backfill: throttle slot unavailable — deferring; "
+                    "cursor preserved (cursor=%s)",
+                    state.last_cursor,
+                )
+                return state
 
-        merge_into_learned(
-            persona_dir,
-            output.pattern_candidates,
-            list(window.turns),
-            now_iso=now_iso,
-        )
-        patterns_emitted_so_far += len(output.pattern_candidates)
-        processed_so_far += 1
-        state = replace(
-            state,
-            processed_windows=processed_so_far,
-            patterns_emitted=patterns_emitted_so_far,
-            last_cursor=window.id,
-        )
-        _save_state(persona_dir, state)
+            if not _attunement_consume_call(persona_dir, now=now_dt, cap=cap):
+                state = replace(state, status="deferred_to_next_day")
+                _save_state(persona_dir, state)
+                return state
+
+            try:
+                output = detector_fn(buffer_slice=list(window.turns), reply_text="")
+            except Exception as exc:  # noqa: BLE001
+                _log.warning(
+                    "attunement backfill: detector error on %s: %s", window.id, exc
+                )
+                continue
+
+            merge_into_learned(
+                persona_dir,
+                output.pattern_candidates,
+                list(window.turns),
+                now_iso=now_iso,
+            )
+            patterns_emitted_so_far += len(output.pattern_candidates)
+            processed_so_far += 1
+            state = replace(
+                state,
+                processed_windows=processed_so_far,
+                patterns_emitted=patterns_emitted_so_far,
+                last_cursor=window.id,
+            )
+            _save_state(persona_dir, state)
+
+        # Outside the slot: another background consumer can acquire while we pace.
+        # Tests pass delay_s=0 to skip the wait (matches emotion_backfill).
+        if delay_s > 0:
+            time.sleep(delay_s)
 
     check_crystallisations(persona_dir, now_iso=now_iso)
     state = replace(state, status="complete")
@@ -371,6 +421,7 @@ def run_supplementary_backfill(
     detector_fn=None,
     now_dt: _datetime | None = None,
     cap: int | None = None,
+    delay_s: float = _INTER_CALL_DELAY_S,
 ):
     """One-time supplementary pass after a schema upgrade.
 
@@ -386,6 +437,7 @@ def run_supplementary_backfill(
         cap=cap,
         only_categories=_NEW_CATEGORIES,
         supplementary=True,
+        delay_s=delay_s,
     )
 
 

--- a/tests/unit/brain/attunement/test_backfill_state.py
+++ b/tests/unit/brain/attunement/test_backfill_state.py
@@ -59,6 +59,7 @@ def test_run_backfill_completes_status_when_all_windows_processed(tmp_path: Path
         tmp_path,
         detector_fn=fake_detector,
         now_dt=datetime(2026, 5, 31, 12, 0, tzinfo=UTC),
+        delay_s=0,
     )
     assert state.status == "complete"
     assert state.processed_windows == state.sampled_windows
@@ -73,7 +74,8 @@ def test_run_backfill_respects_daily_cap_splits_across_days(tmp_path: Path):
         tmp_path,
         detector_fn=fake_detector,
         now_dt=datetime(2026, 5, 31, 12, 0, tzinfo=UTC),
-        cap=2,  # tiny cap forces split
+        cap=2,  # tiny cap forces split,
+        delay_s=0,
     )
     assert state.status == "deferred_to_next_day"
     assert state.last_cursor != ""
@@ -89,6 +91,7 @@ def test_run_backfill_resumes_from_last_cursor(tmp_path: Path):
         detector_fn=fake_detector,
         now_dt=datetime(2026, 5, 31, 12, 0, tzinfo=UTC),
         cap=2,
+        delay_s=0,
     )
     assert first.status == "deferred_to_next_day"
     first_processed = first.processed_windows
@@ -99,6 +102,7 @@ def test_run_backfill_resumes_from_last_cursor(tmp_path: Path):
         detector_fn=fake_detector,
         now_dt=datetime(2026, 6, 1, 12, 0, tzinfo=UTC),
         cap=100,
+        delay_s=0,
     )
     assert second.status == "complete"
     assert second.processed_windows > first_processed
@@ -111,6 +115,7 @@ def test_run_backfill_returns_existing_when_complete(tmp_path: Path):
         tmp_path,
         detector_fn=fake_detector,
         now_dt=datetime(2026, 5, 31, 12, 0, tzinfo=UTC),
+        delay_s=0,
     )
     assert first.status == "complete"
     # Second call: short-circuit before window_buffer is reached
@@ -119,6 +124,7 @@ def test_run_backfill_returns_existing_when_complete(tmp_path: Path):
             tmp_path,
             detector_fn=fake_detector,
             now_dt=datetime(2026, 6, 1, 12, 0, tzinfo=UTC),
+            delay_s=0,
         )
     assert second.status == "complete"
     mock_window.assert_not_called()
@@ -130,6 +136,7 @@ def test_run_backfill_skips_when_no_active_conversations(tmp_path: Path):
         tmp_path,
         detector_fn=fake_detector,
         now_dt=datetime(2026, 5, 31, 12, 0, tzinfo=UTC),
+        delay_s=0,
     )
     assert state.status == "complete"
     assert state.processed_windows == 0
@@ -143,6 +150,7 @@ def test_run_backfill_persists_state_after_each_window(tmp_path: Path):
         tmp_path,
         detector_fn=fake_detector,
         now_dt=datetime(2026, 5, 31, 12, 0, tzinfo=UTC),
+        delay_s=0,
     )
     state_path = tmp_path / "attunement" / "backfill_state.json"
     assert state_path.exists()
@@ -164,7 +172,7 @@ def test_run_backfill_default_detector_threads_identity(tmp_path: Path):
         return _fake_detector_output()
 
     with patch("brain.attunement.detector.run_detector", side_effect=_capture):
-        run_backfill(tmp_path, now_dt=datetime(2026, 5, 31, 12, 0, tzinfo=UTC))
+        run_backfill(tmp_path, now_dt=datetime(2026, 5, 31, 12, 0, tzinfo=UTC), delay_s=0)
 
     assert captured, "expected the default detector closure to be invoked"
     assert captured[0]["companion_name"] == tmp_path.name

--- a/tests/unit/brain/attunement/test_backfill_throttle.py
+++ b/tests/unit/brain/attunement/test_backfill_throttle.py
@@ -1,0 +1,116 @@
+"""#133 — the attunement backfill must respect the global CLI concurrency cap.
+
+`run_backfill` loops `detector_fn` once per sampled window, and each call is a
+fresh `claude -p` subprocess. It took no `cli_throttle` slot, so it could issue
+up to `DAILY_BUDGET_DEFAULT = 150` back-to-back spawns while another background
+engine held the single slot — and `_inflight_background` never saw it, so
+nothing backed off for it either.
+
+Its sibling `brain/ingest/emotion_backfill.py` already does this correctly
+(per-iteration slot, idle yield, inter-call pacing); this is the port.
+
+The subtle half is the *state*: the loop falls through to `status="complete"`.
+A naive port that simply `break`s on a denied slot would mark the backfill
+complete having skipped windows — permanently, since `should_run_backfill`
+returns False once a completed state exists. Yielding must leave the state
+resumable.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+from brain.attunement.backfill import run_backfill
+from brain.attunement.schemas import SCHEMA_VERSION, CurrentRead, DetectorOutput
+
+
+def _make_buffer_file(persona_dir: Path, n_turns: int) -> None:
+    """Seed active_conversations/main.jsonl with n_turns user messages."""
+    convs = persona_dir / "active_conversations"
+    convs.mkdir(parents=True, exist_ok=True)
+    lines = [
+        json.dumps({
+            "id": f"m-{i}",
+            "role": "user",
+            "ts": f"2026-05-{(i % 28) + 1:02d}T12:00:00Z",
+            "content": f"this is message number {i} in the conversation",
+        })
+        for i in range(n_turns)
+    ]
+    (convs / "main.jsonl").write_text("\n".join(lines) + "\n")
+
+
+def _fake_detector_output() -> DetectorOutput:
+    return DetectorOutput(
+        current_read=CurrentRead(
+            ts="2026-05-31T12:00:00Z",
+            source_turn_id="m-0",
+            tone_label="warm",
+            tone_justification="x",
+            cadence_label="measured",
+            cadence_justification="y",
+            mood_valence=0.0,
+            mood_intensity=0.0,
+            predicted_arc_shape="z",
+            schema_version=SCHEMA_VERSION,
+        ),
+        pattern_candidates=[],
+    )
+
+
+def test_denied_throttle_slot_stops_the_loop_without_marking_it_complete(
+    tmp_path: Path,
+):
+    """No slot -> no `claude -p` spawn, and the backfill stays resumable."""
+    _make_buffer_file(tmp_path, n_turns=25)
+
+    calls: list[object] = []
+
+    def counting_detector(buffer_slice, reply_text):  # noqa: ANN001
+        calls.append(buffer_slice)
+        return _fake_detector_output()
+
+    # The single background slot is already held by another engine.
+    with patch("brain.bridge.cli_throttle.acquire_background", return_value=False):
+        state = run_backfill(tmp_path, detector_fn=counting_detector, delay_s=0)
+
+    assert calls == [], (
+        f"backfill spawned {len(calls)} claude -p call(s) with no throttle slot"
+    )
+    assert state.status != "complete", (
+        "backfill marked itself complete while yielding — the skipped windows "
+        "would never be revisited, because should_run_backfill returns False "
+        f"once a completed state exists (status={state.status!r})"
+    )
+
+
+def test_an_active_chat_turn_makes_the_backfill_stand_down(tmp_path: Path):
+    """The second guard: yield to interactive chat, disk-based and restart-robust.
+
+    `cli_throttle` keeps its state in a module global on a monotonic clock, so it
+    resets on every supervisor restart. `compute_active_session_hours` reads the
+    conversation buffer off disk and survives one. Belt and braces, same as
+    emotion_backfill — a restart mid-conversation must not hand the backfill a
+    clean slate to burst from.
+    """
+    _make_buffer_file(tmp_path, n_turns=25)
+
+    calls: list[object] = []
+
+    def counting_detector(buffer_slice, reply_text):  # noqa: ANN001
+        calls.append(buffer_slice)
+        return _fake_detector_output()
+
+    # Throttle would allow it; the user being mid-turn is what must stop it.
+    with patch(
+        "brain.body.session_hours.compute_active_session_hours", return_value=0.4
+    ):
+        state = run_backfill(tmp_path, detector_fn=counting_detector, delay_s=0)
+
+    assert calls == [], (
+        f"backfill spawned {len(calls)} claude -p call(s) during an active chat turn"
+    )
+    assert state.status != "complete", (
+        f"backfill marked itself complete while yielding (status={state.status!r})"
+    )

--- a/tests/unit/brain/attunement/test_supplementary_backfill.py
+++ b/tests/unit/brain/attunement/test_supplementary_backfill.py
@@ -98,6 +98,7 @@ def test_run_supplementary_backfill_completes_at_current_schema_version(tmp_path
         tmp_path,
         detector_fn=stub_detector,
         now_dt=datetime(2026, 6, 1, 12, 0, tzinfo=UTC),
+        delay_s=0,
     )
 
     assert state.schema_version == SCHEMA_VERSION
@@ -137,6 +138,7 @@ def test_supplementary_resets_cursor_not_inheriting_stale_completed_cursor(tmp_p
         detector_fn=lambda *, buffer_slice, reply_text: None,  # never called (cap=0)
         now_dt=datetime(2026, 6, 1, 12, 0, tzinfo=UTC),
         cap=0,
+        delay_s=0,
     )
 
     assert state.status == "deferred_to_next_day"
@@ -191,6 +193,7 @@ def test_supplementary_preserves_prior_completion_record(tmp_path):
     state = run_supplementary_backfill(
         tmp_path, detector_fn=stub_detector,
         now_dt=datetime(2026, 6, 1, 12, 0, tzinfo=UTC),
+        delay_s=0,
     )
 
     # Original journey-start preserved (not reset to now); new patterns accumulate.


### PR DESCRIPTION
Fixes #133.

`run_backfill` loops `detector_fn` once per sampled window, and every call is a fresh `claude -p` subprocess. It took **no `cli_throttle` slot**, so it could issue up to `DAILY_BUDGET_DEFAULT = 150` back-to-back spawns while another background engine held the single slot — and `_inflight_background` never saw them, so nothing backed off for it either. The bypass cut both ways.

Its sibling `brain/ingest/emotion_backfill.py` already had this right, so this is a **port**, not a design.

## What the port had to get right beyond copying

**The completion tail.** The loop falls through to `status="complete"`. A naive `break` on a denied slot would mark a partially-processed backfill complete — and *permanently*, since `should_run_backfill` returns False once a completed state exists. Both yield paths `return` instead, leaving the state resumable at its cursor. This is the assertion the first test actually guards.

**No duplicated helper.** `compute_active_session_hours` is called directly rather than copying `emotion_backfill`'s private `_user_recently_active`. It is already the layer-neutral primitive (`brain/body/session_hours.py`) and is the same signal that wrapper reads.

Both guards are load-bearing for a different reason each: `cli_throttle` keeps state in a module global on a **monotonic** clock and resets on supervisor restart; the session-hours read comes **off disk** and survives one.

## The pacing default, and what it cost

`delay_s` defaults to 1.5s rather than 0. An unpaced burst is the bug being fixed, so the safe value is the default and tests opt out — matching `emotion_backfill`'s documented convention.

That default made the attunement suite **120× slower (0.23s → 27.5s)** until the 12 existing call sites opted out. I measured the baseline rather than assuming the slowdown was mine to shrug at; it is back to **0.24s**.

## Tests

Two, both **toggled to prove they discriminate** rather than merely pass:

- throttle denied → no spawn, not marked complete (fails on `main`)
- active chat turn → stands down (disabling the yield gate makes it fail; re-enabling restores it)

The "throttle grants" path needed no new test — the 157 existing attunement tests already exercise it.

## Verification

`4304 passed`, ruff clean. The single failure is the known agent-shell artefact (`test_generic_live_run` — `Not logged in · Please run /login`), present identically on `main`.

One caveat recorded rather than glossed: I edited the file (import order + a moved comment) after that full-suite run started, so I re-ran the attunement subset against the final tree — 159 passed. No frontend files touched; `pnpm build` left to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)