### PR TITLE
Guard the last two paths that returned a CLI error as content

### DIFF
--- a/brain/bridge/provider.py
+++ b/brain/bridge/provider.py
@@ -587,6 +587,14 @@ class ClaudeCliProvider(LLMProvider):
         try:
             payload = json.loads(result.stdout)
             log_usage(persona_dir, call_type="generate", model=self._model, frame=payload)
+            # #119: the CLI can exit 0 and report the failure inside the frame,
+            # so the returncode guard above never sees it. Without this the error
+            # string was returned as the generation itself — and this is the
+            # Haiku path, so the attunement detector then parsed "Not logged in
+            # · Please run /login" as if it were its classification JSON.
+            cli_err = _cli_error_detail(payload)
+            if cli_err is not None:
+                raise RuntimeError(f"ClaudeCliProvider: {cli_err}")
             return str(payload["result"])
         except (json.JSONDecodeError, KeyError, TypeError) as exc:
             raise RuntimeError(
@@ -1861,6 +1869,14 @@ def _parse_stream_json_result(stdout: str) -> str:
         )
     ):
         raise ProviderError("error_max_budget_usd", result_text or "")
+    # #119: any OTHER is_error frame is a failure, not a reply. Checked after
+    # the over-budget branch above so that frame keeps its dedicated graceful
+    # path — it carries real partial work. Without this the error text was
+    # returned as the assistant reply and persisted as a companion turn.
+    if result_frame is not None:
+        cli_err = _cli_error_detail(result_frame)
+        if cli_err is not None:
+            raise ProviderError("claude_cli_error", cli_err)
     if result_text is not None:
         return result_text
     if assistant_chunks:

--- a/tests/unit/brain/bridge/test_provider_cli_error.py
+++ b/tests/unit/brain/bridge/test_provider_cli_error.py
@@ -1,0 +1,76 @@
+"""#119 — a CLI failure reported *inside* a result frame is not a reply.
+
+The Claude CLI can exit 0 and report the failure in the JSON payload:
+
+    {"is_error": true, "result": "Not logged in · Please run /login"}
+
+The non-zero-exit guard never sees those. `_cli_error_detail` was added for #92
+and wired into `chat()`, `_run_chat_stream()` and `_chat_with_mcp_tools()` — but
+two paths were missed, and each turns a system error into content:
+
+* `generate()` — the Haiku path (attunement detector, emotion backfill). The
+  error string is handed back as the call's output and parsed as if it were the
+  detector's classification JSON.
+* `_parse_stream_json_result()` — the image path's parser, and the single route
+  `_chat_with_images()` takes. It special-cases only the over-budget frame; any
+  other `is_error` frame falls through and is returned as the assistant reply,
+  which the engine then persists as a turn the companion supposedly said.
+
+The over-budget frame stays excluded on purpose: it carries real partial work
+and has its own graceful path at each call site.
+"""
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from brain.bridge.provider import ClaudeCliProvider
+
+
+def test_generate_raises_on_an_is_error_frame_instead_of_returning_it():
+    """The Haiku path must not hand an auth error back as its output."""
+    mock_result = MagicMock()
+    mock_result.returncode = 0  # the CLI exits 0 and reports failure in-band
+    mock_result.stdout = json.dumps({
+        "is_error": True,
+        "result": "Not logged in · Please run /login",
+    })
+    mock_result.stderr = ""
+
+    with patch("subprocess.run", return_value=mock_result):
+        p = ClaudeCliProvider(model="claude-haiku-4-5-20251001")
+        with pytest.raises(Exception) as exc_info:  # noqa: PT011 — see assert below
+            p.generate("classify this", system="you are a detector")
+
+    assert "Not logged in" in str(exc_info.value), (
+        "the CLI error text must surface as a raised failure, not be returned "
+        f"as the generation: {exc_info.value!r}"
+    )
+
+
+def test_stream_json_parser_raises_on_an_is_error_result_frame():
+    """The image path's parser must not return an error frame as the reply.
+
+    `_chat_with_images` routes its whole output through this function, so the
+    check belongs here rather than at the call site — one guard covers the path.
+    """
+    from brain.bridge.provider import _parse_stream_json_result
+
+    stdout = "\n".join([
+        json.dumps({"type": "system", "subtype": "init"}),
+        json.dumps({
+            "type": "result",
+            "is_error": True,
+            "result": "API Error: 529 overloaded_error",
+        }),
+    ])
+
+    with pytest.raises(Exception) as exc_info:  # noqa: PT011 — see assert below
+        _parse_stream_json_result(stdout)
+
+    assert "529" in str(exc_info.value), (
+        "an is_error result frame was returned as the assistant reply, which "
+        f"the engine then persists as a companion turn: {exc_info.value!r}"
+    )


### PR DESCRIPTION
Fixes #119.

`_cli_error_detail` was added for #92 and wired into `chat()`, `_run_chat_stream()` and `_chat_with_mcp_tools()`. **Two paths were missed**, and each turns a system error into something the companion appears to have produced.

| path | before |
|---|---|
| `chat()` :743 | ✅ guarded |
| `_run_chat_stream()` :1055 | ✅ guarded |
| `_chat_with_mcp_tools()` :1423 | ✅ guarded |
| **`generate()`** :589 | ❌ bare `return str(payload["result"])` |
| **`_parse_stream_json_result()`** | ❌ over-budget only |

## Why each one matters

**`generate()` is the Haiku path** — the attunement detector and emotion backfill. An `is_error` frame came back as the call's output, so the detector then tried to parse `"Not logged in · Please run /login"` as its classification JSON.

**`_parse_stream_json_result()` is the image path's parser**, and the only route `_chat_with_images()` takes — which is why the guard belongs there rather than at the call site. It special-cased the over-budget frame and let every other `is_error` frame fall through as the assistant reply, which the engine persists as a turn the companion supposedly said.

## Notes on the shape of the fix

**Each site raises in its own function's idiom.** `generate()` already raises `RuntimeError` on non-zero exit and on unparseable output; the stream parser already raises `ProviderError`. I checked all ~20 `generate()` callers: this adds an instance of a contract they already have to handle, not a new one. (The 31 `haiku_call_failed` rows on the live persona are a caller catching exactly this.)

**The over-budget frame stays excluded, deliberately.** The general check sits *after* that branch so it cannot swallow it — that frame carries real partial work and has a graceful cut-off path at each call site. `test_chat_with_images_path_budget_flag_and_graceful` already covers that route through this parser and stays green, so I did not add a redundant test for it.

## Tests

Two, both verified RED first — each failed with `DID NOT RAISE`, i.e. the error text really was being returned as content.

## Verification

`4304 passed`, ruff clean. The single failure is the known agent-shell artefact (`test_generic_live_run` — `Not logged in · Please run /login`), which is fittingly the exact error string this PR stops from reaching a user as dialogue. No frontend files touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)