### PR TITLE
fix(initiate): make the review-tick blackout test timezone-independent (#136)

### DIFF
--- a/tests/unit/brain/initiate/test_review.py
+++ b/tests/unit/brain/initiate/test_review.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from datetime import UTC, datetime
 from pathlib import Path
 from unittest.mock import MagicMock, patch
+from zoneinfo import ZoneInfo
 
 from brain.initiate.emit import emit_initiate_candidate, read_candidates
 from brain.initiate.review import run_initiate_review_tick
@@ -144,7 +145,15 @@ def test_review_tick_gate_blocks_send_records_hold(tmp_path: Path, monkeypatch) 
         semantic_context=_ctx(),
     )
     provider = _fake_provider("send_notify")
-    blackout_time = datetime(2026, 5, 11, 1, 30, tzinfo=UTC)
+    # A fixed non-UTC offset (not the host's OS timezone) so the gate takes
+    # its "already user-local" branch deterministically — see
+    # `check_send_allowed`'s tzinfo/utcoffset() branch in brain/initiate/gates.py
+    # and the same pattern in test_gates.py::test_check_send_allowed_blocks_notify_in_blackout.
+    # A tzinfo=UTC value here would be re-converted via `.astimezone()` to
+    # whatever local timezone the test happens to run in, making the
+    # blackout check (and thus this test) pass or fail depending on the
+    # host machine's configured timezone/DST offset for this date.
+    blackout_time = datetime(2026, 5, 11, 1, 30, tzinfo=ZoneInfo("America/Los_Angeles"))
     with patch("brain.initiate.review.datetime") as mock_dt:
         mock_dt.now = MagicMock(return_value=blackout_time)
         mock_dt.fromisoformat = datetime.fromisoformat


### PR DESCRIPTION
## What
`test_review_tick_gate_blocks_send_records_hold` failed intermittently depending on the machine's wall-clock timezone. It built its blackout instant with `tzinfo=UTC` (zero offset), which routes through `check_send_allowed`'s `now.astimezone()` branch — reinterpreting the instant in the *runner's* local timezone. In many timezones that shifted the time outside the 23:00–07:00 blackout window, so the gate allowed the send instead of holding it and the assertion failed.

This is a test-determinism issue, not a production bug: `check_send_allowed` treating a zero-offset `now` as needing conversion to local is intended (the OS is the source of truth, per the module docstring).

## Fix
Pin the test's blackout time to a fixed non-UTC `ZoneInfo` so it deterministically takes the already-local branch — matching the existing pattern in `test_gates.py::test_check_send_allowed_blocks_notify_in_blackout`. Added a comment so it isn't reverted. No production code changed.

## Verification
Passes deterministically across a wide timezone spread (UTC, US east/west, Sydney, Kiritimati, Etc/GMT+12). `tests/unit/brain/initiate/` — 247 passed; ruff clean.

## Note (follow-up, not in this PR)
A neighboring "daytime" test in the same file uses the same `tzinfo=UTC` pattern and is theoretically exposed to the same class in extreme timezones (currently passing). A small sweep for other blackout-adjacent UTC fixtures could preempt future flakes.

Fixes #136.
