### PR TITLE
docs: out-of-scope follow-ups get their own issue, not a PR-body note

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,6 +51,7 @@ Do not create `WIP.md`, `CLAIMS.md`, `TODO.md`, or similar files intended to tra
 - Commit messages: imperative mood, present tense ("fix provider path resolution," not "fixed" or "fixes").
 - If a commit or PR resolves an issue, include `Fixes #N` in the PR description so it auto-closes.
 - Don't squash unrelated changes into one commit. If the user is fixing two different things, suggest two branches.
+- **Out-of-scope follow-ups → a new issue, not a PR-body note.** When you spot follow-up work during a PR that's outside that PR's scope, file it as its own issue rather than leaving a "follow-up" note in the PR description — PR-body notes get lost on merge; issues stay tracked. (Human-facing version in `CONTRIBUTING.md`.)
 
 ## When in doubt
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,6 +23,7 @@ Every bug, feature, or chunk of work gets an issue in the Issues tab.
 - **If an issue is assigned to the other person, don't start work on it** without talking first. They might be mid-thought on it even if there's no PR yet.
 - **Labels are optional** but `bug`, `enhancement`, and `question` are worth using so we can filter.
 - **Closing:** if your PR fixes an issue, put `Fixes #12` in the PR description. GitHub auto-closes the issue when the PR merges.
+- **Out-of-scope follow-ups get their own issue, not a PR note.** If you notice separate follow-up work while doing a PR (a related bug, a deferred cleanup, a "should also do X later"), open an issue for it. A note buried in a PR description disappears once the PR merges; an issue stays on the board.
 
 ## Branches: never commit to main
 


### PR DESCRIPTION
## What
Adds a workflow guideline to both `CONTRIBUTING.md` (human-facing, under "Issues") and `CLAUDE.md` (AI-facing, under "Commits and PRs"): out-of-scope follow-up work spotted during a PR should be filed as its own issue, not left as a "follow-up" note in the PR description — PR-body notes get lost on merge, issues stay tracked.

Two-line docs change, no code.
