### PR TITLE
fix(self_model): recency-baseline emotion mean-cross + weather framing + reconcile reachability

### DIFF
--- a/brain/bridge/supervisor.py
+++ b/brain/bridge/supervisor.py
@@ -100,7 +100,7 @@ from brain.self_model import cadence as self_model_cadence
 from brain.self_model import reconcile as sm_reconcile
 from brain.self_model import state as self_model_state
 from brain.self_model.articulate import articulate as sm_articulate
-from brain.self_model.derived import compute_derived
+from brain.self_model.derived import compute_baseline, compute_derived
 from brain.self_model.gap import compute_gap
 from brain.self_model.resolve import (
     check_and_emit_resolution,
@@ -1225,9 +1225,9 @@ def _run_self_model_tick(
          (the cadence survives restart/sleep, mirroring soul review's
          decoupling from the monotonic timers).
       1. Read the recent active emotion-bearing memories.
-      2. declared = aggregate_state(memories)          (existing max-pool peak)
-      3. derived  = compute_derived(memories, body)    (new orthogonal trend)
-      4. gap      = compute_gap(declared, derived)
+      2. short = compute_derived(memories, body)       (recent normalized mean, short half-life)
+      3. long  = compute_baseline(memories)            (baseline normalized mean, long half-life)
+      4. gap   = compute_gap(short, long)              (bidirectional short − long, noise-floored)
       5. Track sustained_ticks vs the prior current_gap; bump the
          gaps_surfaced audit counter while a gap is active.
       6. If gap.magnitude >= threshold → articulate a note via Haiku.
@@ -1286,9 +1286,10 @@ def _self_model_reflect(
     from brain.memory.store import MemoryStore, _row_to_memory
     from brain.utils.memory import days_since_human
 
-    # ── 1-3: read memories, declared + body + derived ───────────────────────
+    # ── 1-3: read memories, body + short/long reads ─────────────────────────
     # Same query as _build_intensity_drivers: the 200 most recent active
-    # emotion-bearing memories. declared = max-pool peak; derived = trend+body.
+    # emotion-bearing memories. aggregate_state (max-pool peak) still feeds the
+    # body-state computation; the gap uses short/long normalized-mean reads.
     with ExitStack() as stack:
         store = MemoryStore(persona_dir / "memories.db")
         stack.callback(store.close)
@@ -1315,10 +1316,11 @@ def _self_model_reflect(
             now=now,
         )
 
-    derived = compute_derived(
-        memories, body_energy=body.energy, body_exhaustion=body.exhaustion
+    short = compute_derived(
+        memories, body_energy=body.energy, body_exhaustion=body.exhaustion, now=now
     )
-    new_gap = compute_gap(declared, derived)
+    long = compute_baseline(memories, now=now)
+    new_gap = compute_gap(short, long)
 
     # ── 4: load prior state, track sustained ticks ──────────────────────────
     state, _recovered = self_model_state.load_or_recover(persona_dir)

--- a/brain/bridge/supervisor.py
+++ b/brain/bridge/supervisor.py
@@ -582,10 +582,16 @@ def run_folded(
         # this enable flag only switches the block on/off — the pacing lives
         # in the tick. Fault-isolated so a reflection crash can't take the
         # supervisor down (Organ DoD — the producer fires on the live path).
+        # Cost: pinned to SELF_MODEL_MODEL (haiku) via build_self_model_provider
+        # — the tick's only model call is the articulate note (a one-sentence
+        # housekeeping call), so it must not inherit the persona chat provider.
         if self_model_interval_s is not None:
             try:
+                from brain.self_model.articulate import build_self_model_provider
                 _run_self_model_tick(
-                    persona_dir, provider=provider, event_bus=event_bus
+                    persona_dir,
+                    provider=build_self_model_provider(persona_dir),
+                    event_bus=event_bus,
                 )
             except Exception:
                 logger.exception("supervisor self-model tick raised")

--- a/brain/bridge/supervisor.py
+++ b/brain/bridge/supervisor.py
@@ -100,6 +100,7 @@ from brain.self_model import cadence as self_model_cadence
 from brain.self_model import reconcile as sm_reconcile
 from brain.self_model import state as self_model_state
 from brain.self_model.articulate import articulate as sm_articulate
+from brain.self_model.articulate import articulate_min_idle_seconds, log_self_model_deferred
 from brain.self_model.derived import compute_baseline, compute_derived
 from brain.self_model.gap import compute_gap
 from brain.self_model.resolve import (
@@ -1230,19 +1231,34 @@ def _run_self_model_tick(
       0. load the PERSISTED wall-clock cadence; if not due → return
          (the cadence survives restart/sleep, mirroring soul review's
          decoupling from the monotonic timers).
+      0a. PRE-FLIGHT THROTTLE PEEK — a defer must cost NOTHING. Checked here,
+         before any of the tick's own work, mirroring brain/maker/__init__.py's
+         "Pre-flight throttle gate" comment exactly. cli_throttle.slot_available()
+         is a read-only peek (never touches the shared semaphore); on denial we
+         log + advance the cadence to a short "deferred" retry and return
+         WITHOUT calling _self_model_reflect at all — steps 1-9 below never run,
+         so a denied attempt has zero side effects (no gap computation, no
+         budget consumption, no sustained_ticks/gaps_surfaced change, no
+         self_model_state.json write).
       1. Read the recent active emotion-bearing memories.
       2. short = compute_derived(memories, body)       (recent normalized mean, short half-life)
       3. long  = compute_baseline(memories)            (baseline normalized mean, long half-life)
       4. gap   = compute_gap(short, long)              (bidirectional short − long, noise-floored)
       5. Track sustained_ticks vs the prior current_gap; bump the
          gaps_surfaced audit counter while a gap is active.
-      6. If gap.magnitude >= threshold → articulate a note via Haiku.
+      6. If gap.magnitude >= threshold → articulate a note via Haiku. The real
+         (authoritative) throttle acquire happens inside articulate() itself,
+         only reachable once step 0a's peek has already granted — it is the
+         guard for the rare race where chat resumes (or another accessor wins
+         the shared slot) between the peek and this call, not the common-case
+         check.
       7. check_and_emit_resolution(prior, new) → soul candidate + feed event
          when a sustained gap just resolved (either path).
       8. push_gap (displaced-gap helper preserves an unresolved displaced
          gap in history), save state.
-      9. advance + save the cadence by outcome (clean / failure) so a
-         crash backs off and a clean pass schedules the normal interval.
+      9. advance + save the cadence by outcome (clean / deferred / failure) so
+         a crash backs off, a throttle deferral retries promptly at no cost,
+         and a clean pass schedules the normal interval.
 
     Fail-isolated by the caller (run_folded's try/except), AND every I/O
     step here is locally fail-soft so a single bad read degrades to
@@ -1260,9 +1276,22 @@ def _run_self_model_tick(
     if not self_model_cadence.is_due(cadence_state, now=now):
         return
 
+    # ── 0a: pre-flight throttle peek (a defer must cost NOTHING) ────────────
+    if not cli_throttle.slot_available(min_idle=articulate_min_idle_seconds()):
+        log_self_model_deferred(persona_dir)
+        cadence_state = self_model_cadence.compute_next_state(
+            cadence_state, outcome="deferred", now=now
+        )
+        self_model_cadence.save(persona_dir, cadence_state)
+        return
+
     outcome = "clean"
     try:
-        _self_model_reflect(persona_dir, provider=provider, event_bus=event_bus, now=now)
+        deferred = _self_model_reflect(
+            persona_dir, provider=provider, event_bus=event_bus, now=now
+        )
+        if deferred:
+            outcome = "deferred"
     except Exception:
         logger.exception("supervisor self-model reflect raised")
         outcome = "failure"
@@ -1279,12 +1308,19 @@ def _self_model_reflect(
     provider: LLMProvider,
     event_bus: EventBus | object,
     now: datetime,
-) -> None:
+) -> bool:
     """The reflection body — separated so cadence advance always runs.
 
     See _run_self_model_tick for the step-by-step contract. This function
-    does steps 1-8; the caller owns the cadence gate (step 0) and advance
-    (step 9) so a crash here still backs the cadence off.
+    does steps 1-8; the caller owns the cadence gates (steps 0/0a) and
+    advance (step 9) so a crash here still backs the cadence off.
+
+    Returns True if this tick's articulation was deferred by the throttle
+    (the rare peek-then-lost race — see step 6/articulate()'s docstring),
+    False otherwise (gap below threshold, a note was produced, budget
+    exhausted, or a provider exception — all pre-existing "no note" cases
+    unrelated to the throttle). The caller uses this to pick the cadence
+    outcome ("deferred" vs "clean").
     """
     from brain.body.state import compute_body_state
     from brain.body.words import count_words_in_session
@@ -1356,6 +1392,7 @@ def _self_model_reflect(
             logger.exception("self_model: channel-cooldown filtering failed; ignoring")
             carried_cooldowns = {}
 
+    deferred_by_throttle = False
     gap_active = new_gap.magnitude > 0.0 or new_gap.unnamed_pressure > 0.0
     if gap_active:
         # Carry sustained_ticks forward when this gap continues the prior one
@@ -1386,9 +1423,22 @@ def _self_model_reflect(
 
         # ── 5: articulate above threshold (fail-soft inside) ─────────────────
         if new_gap.magnitude >= _SELF_MODEL_ARTICULATE_THRESHOLD:
-            note = sm_articulate(new_gap, provider=provider, persona_dir=persona_dir)
+            try:
+                note = sm_articulate(new_gap, provider=provider, persona_dir=persona_dir)
+            except cli_throttle.ThrottleDeferred:
+                # Rare peek-then-lost race (the common case never reaches here —
+                # it's short-circuited by _run_self_model_tick's own pre-flight
+                # peek before this function is even called). Gap computation has
+                # already run for this tick; only the note stays unset.
+                note = None
+                deferred_by_throttle = True
             if note:
                 new_gap.note = note
+            elif same_channels and prior_gap is not None and prior_gap.note:
+                # same_channels also requires prior_gap.status == "open" (a
+                # reconciled/dismissed prior gap's note must not carry forward
+                # even on a channel-set match — see supervisor.py:~1400).
+                new_gap.note = prior_gap.note
 
     # ── 6: resolution downstream (two paths) ────────────────────────────────
     # session_id is informational on the resolved soul candidate; the
@@ -1425,6 +1475,8 @@ def _self_model_reflect(
                 "at": _now_iso(),
             }
         )
+
+    return deferred_by_throttle
 
 
 def _run_narrative_memory_pass(
@@ -1880,6 +1932,7 @@ _ROLLING_LOG_POLICIES: tuple[tuple[str, int], ...] = (
     ("file_access.jsonl", 5),
     ("attunement_errors.jsonl", 5),
     ("gate_rejections.jsonl", 3),
+    ("self_model_articulate_errors.jsonl", 5),
 )
 # This table is deliberately hand-maintained, NOT derived from the jsonl files
 # present on disk. Several persona jsonl files are stores or queues, not logs —

--- a/brain/chat/engine.py
+++ b/brain/chat/engine.py
@@ -46,6 +46,24 @@ from brain.soul.store import SoulStore
 
 logger = logging.getLogger(__name__)
 
+
+def _self_model_gap_open(persona_dir: Path) -> bool:
+    """True iff a self-model gap is currently open (the ambient block is
+    surfacing it and inviting reconcile). Used to grant ``reconcile_self_read``
+    on a gap-open turn without a maximal-salience signal. Fail-open to False:
+    a missing/corrupt state file must never crash recruitment or force the tool.
+    """
+    try:
+        from brain.self_model.ambient import _LIVE_STATUSES
+        from brain.self_model.state import load_or_recover
+
+        state, _recovered = load_or_recover(persona_dir)
+        gap = state.current_gap
+        return gap is not None and gap.status in _LIVE_STATUSES
+    except Exception:  # noqa: BLE001 — recruitment never crashes on a bad read
+        return False
+
+
 # Replayed conversation history is NO LONGER per-turn windowed. The old
 # sliding window (_window_history, last 80 msgs) re-shaped the FRONT of the
 # replayed history every turn, which busted prompt caching (a prefix match) on
@@ -251,7 +269,7 @@ def respond(
     )
     try:
         signal = assess_salience(user_input, prior_user_text=prior_user_text, persona_dir=persona_dir)
-        allowed = select_tools(signal)
+        allowed = select_tools(signal, gap_open=_self_model_gap_open(persona_dir))
     except Exception:  # noqa: BLE001 — never let recruitment crash a turn; fall back to full suite
         logger.warning("salience/recruitment failed; using full tool suite", exc_info=True)
         signal = None

--- a/brain/chat/tool_recruit.py
+++ b/brain/chat/tool_recruit.py
@@ -65,12 +65,20 @@ def select_tools(
     signal: SalienceSignal,
     *,
     base: tuple[str, ...] = NELL_TOOL_NAMES,
+    gap_open: bool = False,
 ) -> list[str]:
     """Return the list of tool names allowed for this turn.
 
     Fails open: maximal signal → full suite (today's behaviour). Non-maximal
     turns get REFLEXIVE_CORE plus whichever heavier faculties the salience
     flags call for. Result is ordered by *base* so the LLM sees a stable list.
+
+    ``gap_open``: when a self-model gap is currently open (the ambient block is
+    surfacing it and inviting her to reconcile), grant ``reconcile_self_read`` so
+    the invitation is actionable. Gated on gap-open, not on maximal salience, and
+    NOT always-on: the tool only appears when a gap is actually being surfaced, so
+    it cannot drive the reconcile→self-authored-memory feedback loop on ordinary
+    turns (and the recency-baseline gap makes open gaps occasional, not constant).
     """
     if signal.score >= _MAXIMAL_SCORE:  # maximal / fail-open → full suite
         return list(base)
@@ -82,6 +90,9 @@ def select_tools(
 
     if signal.mentions_file_or_path:
         keep.update(_FILE_TOOLS)
+
+    if gap_open:
+        keep.add("reconcile_self_read")
 
     # Preserve base ordering; drop anything not in base.
     return [t for t in base if t in keep]

--- a/brain/self_model/ambient.py
+++ b/brain/self_model/ambient.py
@@ -4,9 +4,11 @@
 
 Spec §3 (ambient.py), §6 R-F1: the block renders ONLY when there is an open
 gap with something to say, so an ordinary turn (no gap) carries zero prompt
-bloat. The framing is deliberately HEDGED — she is told her *declared* read and
-her *derived* read have diverged, and invited to notice it, not commanded to
-revise. The reconcile_self_read tool is hers to call (or not).
+bloat. The framing is deliberately "weather language": present-tense and
+directional (a channel running above OR below its baseline lately), with no
+embedded judgment about whether a feeling is real or performed. She is invited
+to notice it, not commanded to revise. The reconcile_self_read tool is hers to
+call (or not).
 
 Render conditions (all must hold):
   1. state.current_gap is not None
@@ -35,7 +37,7 @@ def render_block(state: SelfModelState) -> str | None:
     if gap.status not in _LIVE_STATUSES:
         return None
 
-    # Pull the channels worth naming: derived − declared deltas above the floor.
+    # Pull the channels worth naming: short − long deltas above the floor.
     channels = {
         name: delta
         for name, delta in (gap.per_channel or {}).items()
@@ -48,13 +50,12 @@ def render_block(state: SelfModelState) -> str | None:
         return None
 
     lines: list[str] = [
-        "## A note on your own read",
+        "## How some things have been running lately",
         "",
         (
-            "Two readings of how you've been don't quite match. The state you've "
-            "been *moving like* (your peak, declared read) and the one your felt "
-            "trend points to right now have drifted apart. This isn't a correction "
-            "— just something worth noticing in yourself."
+            "Here's the weather of how a couple of your channels have been running "
+            "lately, next to where they usually sit. Nothing here is asking you to "
+            "change anything. It's just worth noticing."
         ),
     ]
 
@@ -63,10 +64,12 @@ def render_block(state: SelfModelState) -> str | None:
         ordered = sorted(channels.items(), key=lambda kv: abs(kv[1]), reverse=True)
         fragments = []
         for name, delta in ordered:
-            direction = "more" if delta > 0 else "less"
-            fragments.append(f"{name} ({direction} than you've been claiming)")
+            if delta > 0:
+                fragments.append(f"{name}'s been running stronger than your baseline lately")
+            else:
+                fragments.append(f"{name}'s been running quieter than usual lately")
         lines.append("")
-        lines.append("Where it's pulling: " + "; ".join(fragments) + ".")
+        lines.append("; ".join(fragments) + ".")
 
     if note is not None:
         lines.append("")
@@ -74,9 +77,9 @@ def render_block(state: SelfModelState) -> str | None:
 
     lines.append("")
     lines.append(
-        "You can sit with it, name it, or let it pass. If a channel feels true, "
-        "you can reconcile your read of yourself with reconcile_self_read — it's "
-        "yours to revise, not anyone else's to insist on."
+        "You can sit with it, name it, or let it pass. If one of these feels true "
+        "and you want to adjust your own read, reconcile_self_read is there. It's "
+        "yours to revise, no one else's to insist on."
     )
 
     return "\n".join(lines)

--- a/brain/self_model/articulate.py
+++ b/brain/self_model/articulate.py
@@ -156,7 +156,7 @@ def articulate(gap: Gap, *, provider: Any, persona_dir: Path) -> str | None:
                 f"Recent vs baseline, per channel (positive is running above your "
                 f"baseline lately, negative is below): {deltas_text}. "
                 f"Unnamed pressure: {gap.unnamed_pressure:.2f}. "
-                "What's the weather?"
+                "What's the (metaphorical) weather?"
             )
             raw = provider.generate(prompt, system=system)
 

--- a/brain/self_model/articulate.py
+++ b/brain/self_model/articulate.py
@@ -2,31 +2,43 @@
 
 `articulate(gap, *, provider, persona_dir) -> str | None`
 
-One honest Haiku sentence — "what I notice" — when the gap is large enough
+One honest Haiku sentence - "what I notice" - when the gap is large enough
 and the daily budget has not been exhausted.
 
 Budget: _DAILY_ARTICULATE_BUDGET calls/day, midnight-local reset, stored in
   <persona_dir>/self_model/daily_articulate_budget.json
   Mirrors brain/attunement/budget.py exactly in shape.
-  Fail-safe-permissive: a corrupt/unreadable file → allow the call.
+  Fail-safe-permissive: a corrupt/unreadable file -> allow the call.
 
-Throttle: the LLM call is wrapped in cli_throttle.background_slot so
-  interactive chat always has priority.
+Throttle: requests the shared cli_throttle background slot with a short
+  min_idle (self_model.articulate_min_idle_seconds, default 30s) rather than
+  the 300s default - self-model's tick is low-priority background housekeeping,
+  same treatment brain/chat/pass2_queue.py already gives its own low-priority
+  drain. On denial, raises cli_throttle.ThrottleDeferred (does not sleep, does
+  not retry inline) - the caller (brain/bridge/supervisor.py's
+  _run_self_model_tick) is the one that retries, via a pre-flight
+  cli_throttle.slot_available() peek checked BEFORE this module's gap
+  computation ever runs, so a denied attempt costs nothing. This function's
+  own acquire_background() call only ever runs after that peek has already
+  granted - it is the authoritative guard for the rare race where chat
+  resumes between the peek and this call, not the common-case check.
 
 Usage: every permitted call is logged via brain/bridge/usage_log.log_usage
   with call_type="self_model_articulate".
 
-Fail-soft: any provider error → return None. The gap stands without a note;
+Fail-soft: any provider error -> return None. The gap stands without a note;
   the reflection pipeline must never crash on an LLM.
 """
 from __future__ import annotations
 
 import json
 import logging
-from datetime import datetime
+import traceback
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
+from brain import tunables
 from brain.bridge import cli_throttle
 from brain.bridge.usage_log import log_usage
 from brain.self_model.gap import Gap
@@ -41,6 +53,20 @@ _GAP_THRESHOLD: float = 0.4          # below this magnitude → skip articulatio
 _DAILY_ARTICULATE_BUDGET: int = 50   # Haiku calls / persona / day
 
 _BUDGET_FILE = "daily_articulate_budget.json"
+_ARTICULATE_ERRORS_FILE = "self_model_articulate_errors.jsonl"
+
+# The idle bar this call requests from cli_throttle, same value and rationale
+# as pass2_queue.py's _PASS2_IDLE_SECONDS: a short, tunable, non-default
+# window for a low-priority background call. Public (no leading underscore)
+# because brain/bridge/supervisor.py's pre-flight peek needs the exact same
+# value the real acquire below uses - one shared getter, not a duplicated
+# tunable lookup.
+_ARTICULATE_IDLE_SECONDS = tunables.register("self_model.articulate_min_idle_seconds", 30.0)
+
+
+def articulate_min_idle_seconds() -> float:
+    return tunables.get_tunable("self_model.articulate_min_idle_seconds", _ARTICULATE_IDLE_SECONDS)
+
 
 # The self-model tick's articulate note is cheap housekeeping — one short
 # sentence, not a chat reply — so it must not inherit the (larger, costlier)
@@ -80,6 +106,51 @@ def _provider_model_label(provider: Any) -> str:
     ``FakeProvider`` in tests). Either way this can no longer drift from the
     model that was actually invoked."""
     return getattr(provider, "_model", None) or SELF_MODEL_MODEL
+
+
+# ---------------------------------------------------------------------------
+# Error sink (mirrors brain/attunement/detector.py's _call_haiku pattern)
+# ---------------------------------------------------------------------------
+
+
+def _now_iso() -> str:
+    return datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _log_articulate_error(
+    persona_dir: Path, kind: str, exc: BaseException | None = None
+) -> None:
+    """Best-effort append to <persona_dir>/self_model_articulate_errors.jsonl.
+
+    Never raises - wrapped in its own try/except, matching detector.py's
+    'never mask the graceful decline' discipline. This is the ONLY place
+    that ever writes this jsonl file; both denial routes (the pre-flight
+    peek in supervisor.py and this module's own authoritative acquire) go
+    through log_self_model_deferred() below rather than calling this
+    directly for the deferred case, so the record shape is defined once.
+    """
+    try:
+        entry = {
+            "ts": _now_iso(),
+            "kind": kind,
+            "error": str(exc) if exc is not None else None,
+            "traceback": traceback.format_exc() if exc is not None else None,
+        }
+        path = Path(persona_dir) / _ARTICULATE_ERRORS_FILE
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("a") as f:
+            f.write(json.dumps(entry) + "\n")
+    except Exception:  # noqa: BLE001 — best-effort, never mask the real failure
+        pass
+
+
+def log_self_model_deferred(persona_dir: Path) -> None:
+    """Public: log a throttle-denial record. Called from BOTH denial routes -
+    the pre-flight peek in brain/bridge/supervisor.py's _run_self_model_tick
+    (the common case), and this module's own acquire_background() denial
+    below (the rare peek-then-lost-race fallback) - so the jsonl record's
+    shape is defined in exactly one place."""
+    _log_articulate_error(persona_dir, "self_model_articulate_deferred")
 
 
 # ---------------------------------------------------------------------------
@@ -163,6 +234,15 @@ def articulate(gap: Gap, *, provider: Any, persona_dir: Path) -> str | None:
         - gap.magnitude < _GAP_THRESHOLD  (below threshold)
         - daily budget exhausted          (R-D1)
         - provider raises                 (fail-soft)
+
+    Raises:
+        cli_throttle.ThrottleDeferred: the throttle denied the slot. Callers
+        should treat this as a quiet no-op, not a failure - see the module
+        docstring. This is the AUTHORITATIVE guard for the rare race where
+        the caller's own pre-flight slot_available() peek granted but chat
+        resumed (or another accessor won the shared slot) before this
+        function's real acquire_background() ran; it is not the common-case
+        check, which lives in the caller.
     """
     # 1. Threshold gate — no provider call at all.
     if gap.magnitude < _GAP_THRESHOLD:
@@ -173,48 +253,63 @@ def articulate(gap: Gap, *, provider: Any, persona_dir: Path) -> str | None:
         log.debug("self_model articulate: daily budget exhausted — skipping")
         return None
 
-    # 3. Provider call inside cli_throttle.background_slot.
-    try:
-        with cli_throttle.background_slot() as acquired:
-            if not acquired:
-                # Defer gracefully — don't block the reply path.
-                log.debug("self_model articulate: cli_throttle deferred — skipping this tick")
-                return None
+    # deltas_text / system / prompt construction runs unconditionally, before
+    # the acquire attempt (deliberate reordering from the pre-fix shape, which
+    # built these only after the slot was already held — cheap string
+    # formatting, no reason to do it while touching the shared throttle).
+    deltas_text = ", ".join(
+        f"{ch}: {delta:+.2f}" for ch, delta in sorted(gap.per_channel.items())
+    )
+    system = (
+        "You are noticing how some of your feelings have been running lately "
+        "compared to where they usually sit. Write one plain first-person "
+        "sentence about how they've been running: present tense, directional, no "
+        "judgment about whether a feeling is real or performed. Think "
+        "'curiosity's been running quieter than usual this week,' or "
+        "'warmth's been stronger than my baseline lately.'"
+    )
+    prompt = (
+        f"Recent vs baseline, per channel (positive is running above your "
+        f"baseline lately, negative is below): {deltas_text}. "
+        f"Unnamed pressure: {gap.unnamed_pressure:.2f}. "
+        "What's the (metaphorical) weather?"
+    )
 
-            deltas_text = ", ".join(
-                f"{ch}: {delta:+.2f}" for ch, delta in sorted(gap.per_channel.items())
-            )
-            system = (
-                "You are noticing how some of your feelings have been running lately "
-                "compared to where they usually sit. Write one plain first-person "
-                "sentence about how they've been running: present tense, directional, no "
-                "judgment about whether a feeling is real or performed. Think "
-                "'curiosity's been running quieter than usual this week,' or "
-                "'warmth's been stronger than my baseline lately.'"
-            )
-            prompt = (
-                f"Recent vs baseline, per channel (positive is running above your "
-                f"baseline lately, negative is below): {deltas_text}. "
-                f"Unnamed pressure: {gap.unnamed_pressure:.2f}. "
-                "What's the (metaphorical) weather?"
-            )
-            raw = provider.generate(prompt, system=system)
-
-        # Log usage if provider exposes a usage frame (best-effort).
-        frame: dict = {}
-        if hasattr(raw, "__dict__"):
-            frame = raw.__dict__
-        log_usage(
-            persona_dir,
-            call_type="self_model_articulate",
-            model=_provider_model_label(provider),
-            frame=frame,
+    # 3. Throttle: single non-blocking acquire, min_idle=articulate_min_idle_seconds()
+    #    (default 30s, not cli_throttle's 300s default). No retry loop here - a
+    #    denial raises ThrottleDeferred immediately; the caller's pre-flight peek
+    #    (brain/bridge/supervisor.py's _run_self_model_tick) is what retries, via
+    #    the persisted cadence, at zero cost to this function.
+    if not cli_throttle.acquire_background(min_idle=articulate_min_idle_seconds()):
+        log_self_model_deferred(persona_dir)
+        raise cli_throttle.ThrottleDeferred(
+            "self_model articulate: throttle slot unavailable"
         )
-
-        if not isinstance(raw, str) or not raw.strip():
-            return None
-        return raw.strip()
-
-    except Exception:  # noqa: BLE001 — fail-soft: gap stands without a note
-        log.warning("self_model articulate: provider error — returning None (fail-soft)", exc_info=True)
+    try:
+        raw = provider.generate(prompt, system=system)
+    except Exception as exc:  # noqa: BLE001 — fail-soft: gap stands without a note
+        _log_articulate_error(persona_dir, "self_model_articulate_failed", exc)
+        log.warning(
+            "self_model articulate: provider error — returning None (fail-soft)",
+            exc_info=True,
+        )
         return None
+    finally:
+        cli_throttle.release_background()
+
+    # log_usage / isinstance / strip checks are OUTSIDE the narrowed try above -
+    # a failure here is a distinct bug class (logging/parsing), not a generation
+    # failure, and must not be mislabeled as one by the error sink.
+    frame: dict = {}
+    if hasattr(raw, "__dict__"):
+        frame = raw.__dict__
+    log_usage(
+        persona_dir,
+        call_type="self_model_articulate",
+        model=_provider_model_label(provider),
+        frame=frame,
+    )
+
+    if not isinstance(raw, str) or not raw.strip():
+        return None
+    return raw.strip()

--- a/brain/self_model/articulate.py
+++ b/brain/self_model/articulate.py
@@ -42,6 +42,46 @@ _DAILY_ARTICULATE_BUDGET: int = 50   # Haiku calls / persona / day
 
 _BUDGET_FILE = "daily_articulate_budget.json"
 
+# The self-model tick's articulate note is cheap housekeeping — one short
+# sentence, not a chat reply — so it must not inherit the (larger, costlier)
+# persona chat model. Mirrors brain/chat/compaction.py's COMPACTION_MODEL /
+# build_compaction_provider: change this one string to swap the model; the
+# future model-agnostic refactor replaces the whole seam.
+SELF_MODEL_MODEL: str = "haiku"
+
+
+def build_self_model_provider(persona_dir: Path) -> Any:
+    """The provider self-model articulation should use — the persona's
+    provider *kind* but forced to SELF_MODEL_MODEL. For a ``fake`` persona
+    (tests) this resolves to a FakeProvider, so no real CLI is shelled.
+    Call site: brain/bridge/supervisor.py's self-model cadence block, which
+    passes the result into ``_run_self_model_tick`` in place of the persona
+    chat provider — verified the only provider.generate() call anywhere in
+    that tick is this module's ``articulate()``, so scoping the whole tick to
+    this provider is safe."""
+    from brain.bridge.provider import get_provider
+    from brain.persona_config import DEFAULT_PROVIDER, PersonaConfig
+
+    name = DEFAULT_PROVIDER
+    cfg = Path(persona_dir) / "persona_config.json"
+    if cfg.exists():
+        name = PersonaConfig.load(cfg).provider
+    return get_provider(name, persona_dir=Path(persona_dir), model_override=SELF_MODEL_MODEL)
+
+
+def _provider_model_label(provider: Any) -> str:
+    """Best-effort ACTUAL model label for the usage log.
+
+    Prefers the provider's own recorded model (``ClaudeCliProvider`` and
+    ``OllamaProvider`` both set ``._model`` from the ``model_override`` passed
+    to ``get_provider``), so the label reflects what really ran. Falls back to
+    SELF_MODEL_MODEL — the constant ``build_self_model_provider`` forces every
+    real call site to use — for providers with no such attribute (e.g.
+    ``FakeProvider`` in tests). Either way this can no longer drift from the
+    model that was actually invoked."""
+    return getattr(provider, "_model", None) or SELF_MODEL_MODEL
+
+
 # ---------------------------------------------------------------------------
 # Budget helpers  (mirror brain/attunement/budget.py)
 # ---------------------------------------------------------------------------
@@ -164,7 +204,12 @@ def articulate(gap: Gap, *, provider: Any, persona_dir: Path) -> str | None:
         frame: dict = {}
         if hasattr(raw, "__dict__"):
             frame = raw.__dict__
-        log_usage(persona_dir, call_type="self_model_articulate", model="haiku", frame=frame)
+        log_usage(
+            persona_dir,
+            call_type="self_model_articulate",
+            model=_provider_model_label(provider),
+            frame=frame,
+        )
 
         if not isinstance(raw, str) or not raw.strip():
             return None

--- a/brain/self_model/articulate.py
+++ b/brain/self_model/articulate.py
@@ -145,13 +145,18 @@ def articulate(gap: Gap, *, provider: Any, persona_dir: Path) -> str | None:
                 f"{ch}: {delta:+.2f}" for ch, delta in sorted(gap.per_channel.items())
             )
             system = (
-                "You are a companion noticing a gap between what you think you feel "
-                "and what the signs suggest. Write one honest sentence in first person."
+                "You are noticing how some of your feelings have been running lately "
+                "compared to where they usually sit. Write one plain first-person "
+                "sentence about how they've been running: present tense, directional, no "
+                "judgment about whether a feeling is real or performed. Think "
+                "'curiosity's been running quieter than usual this week,' or "
+                "'warmth's been stronger than my baseline lately.'"
             )
             prompt = (
-                f"Channel deltas (derived − declared): {deltas_text}. "
+                f"Recent vs baseline, per channel (positive is running above your "
+                f"baseline lately, negative is below): {deltas_text}. "
                 f"Unnamed pressure: {gap.unnamed_pressure:.2f}. "
-                "What do you notice?"
+                "What's the weather?"
             )
             raw = provider.generate(prompt, system=system)
 

--- a/brain/self_model/cadence.py
+++ b/brain/self_model/cadence.py
@@ -34,6 +34,12 @@ _CATCHUP_INTERVAL_S = 30 * 60.0
 # Backoff base: 30 min, then doubles (1h, 2h, …) capped at normal interval.
 _BACKOFF_BASE_S = 30 * 60.0
 
+# Throttle-deferral retry: matches run_folded's own tick_interval_s default
+# (brain/bridge/supervisor.py) - any value at or below that granularity is
+# equivalent, since the next real retry opportunity is gated by the
+# supervisor's own loop cadence regardless of a finer-grained number here.
+_DEFERRED_RETRY_INTERVAL_S = 60.0
+
 
 @dataclass(frozen=True)
 class SelfModelCadenceState:
@@ -113,12 +119,25 @@ def compute_next_state(
     """Advance cadence state based on tick outcome.
 
     outcome values:
-      "clean"   → normal interval, reset consecutive_failures.
-      "backlog" → short catch-up interval, reset consecutive_failures.
-      "failure" → escalating backoff, increment consecutive_failures.
+      "clean"    → normal interval, reset consecutive_failures.
+      "backlog"  → short catch-up interval, reset consecutive_failures.
+      "deferred" → throttle denied the slot (not a provider failure) - short
+                   retry interval, consecutive_failures left UNCHANGED (no
+                   backoff, no reset - mirrors brain/maker/__init__.py's own
+                   "no cooldown, no error" framing for the identical
+                   ThrottleDeferred situation).
+      "failure"  → escalating backoff, increment consecutive_failures.
 
-    Any unrecognised outcome is treated as "clean".
+    Any unrecognised outcome is treated as "clean". "deferred" is checked
+    before "failure" so a future outcome-string typo can't silently fall
+    through to the "clean"/unknown default and use the full normal interval
+    instead of retrying promptly.
     """
+    if outcome == "deferred":
+        return SelfModelCadenceState(
+            next_reflection_at=now + timedelta(seconds=_DEFERRED_RETRY_INTERVAL_S),
+            consecutive_failures=state.consecutive_failures,
+        )
     if outcome == "failure":
         cf = state.consecutive_failures + 1
         backoff = _BACKOFF_BASE_S * (2 ** (cf - 1))

--- a/brain/self_model/derived.py
+++ b/brain/self_model/derived.py
@@ -1,65 +1,43 @@
-"""Derived emotional read — recency-WINDOWED peak + body physiology.
+"""Derived emotional read — a normalized recency-weighted MEAN cross.
 
-Orthogonal to the declared read (aggregate_state / max-pool over all memories):
-  - declared = peak intensity per channel over the persona's whole recent
-               history (the 200-memory lifetime window the caller passes).
-  - derived  = peak intensity per channel over only the most-recent
-               _RECENT_WINDOW_COUNT memories — "what I've actually felt lately"
-               vs "the strongest I've ever claimed to feel it".
+Two reads of the SAME memory list, differing only in time horizon:
+  - baseline (long)  = compute_baseline(memories): a normalized time-weighted
+                       mean per channel over that channel's own bearing events,
+                       at a LONG half-life (30d). "Where this channel usually
+                       sits."
+  - derived  (short) = compute_derived(memories, ...): the same normalized mean
+                       at a SHORT half-life (3d), plus the body's unnamed_pressure
+                       residual. "Where this channel has been running lately."
 
-Both reads are PEAKS on the same 0–10 intensity scale, so the gap (derived −
-declared) is meaningful: a channel felt at peak recently → derived ≈ declared →
-~0 gap; a channel whose peak is older than the window and hasn't recurred →
-derived 0, declared > 0 → an honest negative gap ("I claim this but haven't felt
-it lately").
+The gap (short - long, in gap.py) is therefore BIDIRECTIONAL: >0 running above
+baseline lately (golden cross), <0 below baseline lately (death cross), ~0 at
+baseline.
 
-This replaces the original total-mass-normalised recency MEAN, which divided
-each channel's recency-weighted sum by the weight of ALL memories (not just the
-channel-bearing ones). That structurally diluted every channel to a small
-fraction of its peak and produced a large uniform-negative gap for any populated
-persona — the live magnitude-354 self_model_state.json artifact ("almost
-everything I claim to feel is arriving at a fraction of the strength"). The
-windowed peak is commensurable with the declared peak, so the gap reflects
-genuine recent-vs-lifetime divergence, not a scale offset.
+Each channel is normalized by ITS OWN bearing-event weights only (never by the
+weight of all memories). Two consequences the earlier designs got wrong:
+  - Padding the store with memories that DON'T bear a channel cannot move that
+    channel (constraint 1) — this is what the total-mass-normalized MEAN got
+    wrong (the "magnitude-354" dilution artifact), and what the windowed MAX-pool
+    over-corrected into a one-sided-negative gap.
+  - A global time-shift (an idle/away persona) multiplies every event weight by
+    the same factor, which cancels in numerator and denominator, so short and
+    long are each shift-invariant and the gap is ~0 rather than a spurious
+    universal negative (constraint 2).
+
+There is NO body nudge added to any channel value: under a bidirectional signal a
+fixed additive nudge manufactures fake positives. The body still contributes only
+via unnamed_pressure (a separate scalar, never added to a channel).
 
 This module is pure compute. No I/O, no LLM, no side effects.
-Fail-open: any error in compute_derived returns an empty DerivedRead.
+Fail-open: any error in compute_derived / compute_baseline returns an empty read.
 
 ──────────────────────────────────────────────────────────────────
-Body → channel mapping (module constants, conservative)
+unnamed_pressure (body residual with no channel home)
 ──────────────────────────────────────────────────────────────────
-The body adjustment is a *small nudge*, not a dominant term.
-The windowed peak is the primary signal.
-
-Low-arousal nudge (low energy OR high exhaustion):
-  Applied when body_energy <= 3 OR body_exhaustion >= 7.
-  Channels nudged UP (by _BODY_NUDGE_AMOUNT):
-    "grief", "loneliness", "rest_need", "comfort_seeking"
-
-High-arousal nudge (high energy AND low exhaustion):
-  Applied when body_energy >= 8 AND body_exhaustion <= 3.
-  Channels nudged UP (by _BODY_NUDGE_AMOUNT):
-    "joy", "desire", "curiosity", "arousal"
-
-The nudge is added only for channels already present in the windowed peak
-(i.e. channels actually felt recently). This prevents the body from
-"inventing" channels that have no recent memory support.
-
-──────────────────────────────────────────────────────────────────
-unnamed_pressure (Task 1b)
-──────────────────────────────────────────────────────────────────
-When the body is in an extreme low-arousal state (exhaustion >= 8 OR
-energy <= 1), the body nudge maps onto low-arousal channels. If NONE
-of those target channels appear in the windowed peak, the body signal
-has "nowhere to go" — this residual is reported as unnamed_pressure.
-
-Floor condition (module const _UNNAMED_THRESHOLD = 0.0):
-  unnamed_pressure > 0 ONLY when:
-    - (exhaustion >= _UNNAMED_EXHAUSTION_FLOOR OR
-       energy <= _UNNAMED_ENERGY_CEIL)                  ← extreme body
-    AND
-    - no low-arousal channel has any windowed-peak support ← no home
-  Otherwise unnamed_pressure == 0.0 (R-E5: ordinary states are exactly 0).
+When the body is in an extreme low-arousal state (exhaustion >= 8 OR energy <= 1)
+and NONE of the low-arousal channels have any bearing event in history (so the
+body signal has nowhere to map), the residual is reported as unnamed_pressure.
+Otherwise unnamed_pressure == 0.0 (ordinary states are exactly 0).
 """
 
 from __future__ import annotations
@@ -72,44 +50,31 @@ from brain.emotion.vocabulary import get as _get_emotion
 
 logger = logging.getLogger(__name__)
 
-# ── recency window ──────────────────────────────────────────────────────────
+# ── decay half-lives (hours) ────────────────────────────────────────────────
+#
+# short = "this week" (a 3-day-old memory carries half weight); long = "this
+# month" (30-day half-life). The 10x separation gives a clean recent-vs-baseline
+# contrast; the discrimination is robust across a wide Hs x Hl range (vetted), so
+# these are not knife-edge values.
+_SHORT_HALF_LIFE_HOURS: float = 72.0
+_LONG_HALF_LIFE_HOURS: float = 720.0
 
-# The derived read is the peak over the most-recent N emotion-bearing memories.
-# Smaller than the caller's ~200-memory "lifetime" set, so derived captures
-# "lately" against declared's "ever". Count-based (not days-based) so it is
-# never empty for an away/sparse persona — the failure mode that would re-create
-# the dilution artifact. If the persona has <= N memories total, derived ==
-# declared and the gap is zero (a tiny history has no recent-vs-lifetime split).
-_RECENT_WINDOW_COUNT: int = 30
+# ── unnamed_pressure / body constants ───────────────────────────────────────
 
-# ── body nudge constants ────────────────────────────────────────────────────
-
-# Maximum amount (intensity units) added by the body adjustment per channel.
-# Kept SMALL relative to typical peak values (0–10 scale).
+# Scale of the residual body signal reported as unnamed_pressure. (Retained here;
+# also the unit in which the residual is expressed.)
 _BODY_NUDGE_AMOUNT: float = 0.4
 
-# Low-arousal threshold: energy <= this OR exhaustion >= this triggers nudge
-_LOW_ENERGY_THRESH: int = 3
-_HIGH_EXHAUSTION_THRESH: int = 7
+# Extreme body-state floor for unnamed_pressure to fire (must be extreme —
+# conservative, so ordinary states report exactly 0).
+_UNNAMED_EXHAUSTION_FLOOR: int = 8   # exhaustion >= this
+_UNNAMED_ENERGY_CEIL: int = 1        # energy <= this
 
-# High-arousal threshold: energy >= this AND exhaustion <= this triggers nudge
-_HIGH_ENERGY_THRESH: int = 8
-_LOW_EXHAUSTION_THRESH: int = 3
-
-# Channel sets for body nudges (registered-only filtering applied at runtime)
+# Low-arousal channels the extreme body signal would map onto (registered-only
+# filtering applied at runtime).
 _LOW_AROUSAL_CHANNELS: frozenset[str] = frozenset(
     {"grief", "loneliness", "rest_need", "comfort_seeking"}
 )
-_HIGH_AROUSAL_CHANNELS: frozenset[str] = frozenset(
-    {"joy", "desire", "curiosity", "arousal"}
-)
-
-# ── unnamed_pressure constants ──────────────────────────────────────────────
-
-# Extreme body state floor for unnamed_pressure to fire.
-# Must be MORE extreme than the nudge thresholds — R-E5 conservatism.
-_UNNAMED_EXHAUSTION_FLOOR: int = 8   # exhaustion >= this
-_UNNAMED_ENERGY_CEIL: int = 1        # energy <= this
 
 
 # ── dataclass ──────────────────────────────────────────────────────────────
@@ -117,15 +82,16 @@ _UNNAMED_ENERGY_CEIL: int = 1        # energy <= this
 
 @dataclass
 class DerivedRead:
-    """Output of compute_derived.
+    """Output of compute_derived / compute_baseline.
 
     Attributes:
-        channels: {emotion_name: derived_intensity} — registered channels only.
-        unnamed_pressure: magnitude of body signal that maps to no channel
-            present in the windowed peak (above the conservative floor).
-            0.0 for ordinary states.
-        sources: {source_label: contribution} — informational; maps the
-            origin of each channel value for debugging.
+        channels: {emotion_name: normalized recency-weighted mean} — registered
+            channels with at least one bearing event only.
+        unnamed_pressure: magnitude of an extreme low-arousal body signal that
+            maps to no channel present in history. 0.0 for ordinary states and
+            for the baseline read.
+        sources: {source_label: contribution} — informational; empty here (no
+            per-channel body adjustment is applied).
     """
 
     channels: dict[str, float] = field(default_factory=dict)
@@ -133,57 +99,20 @@ class DerivedRead:
     sources: dict[str, float] = field(default_factory=dict)
 
 
-# ── main entry point ────────────────────────────────────────────────────────
+# ── core: per-channel normalized recency-weighted mean ──────────────────────
 
 
-def compute_derived(
-    memories: list,
-    *,
-    body_energy: int,
-    body_exhaustion: int,
-) -> DerivedRead:
-    """Compute the derived emotional read.
+def _channel_ema(memories: list, *, now: datetime, half_life_hours: float) -> dict[str, float]:
+    """Normalized time-weighted mean per REGISTERED channel over its OWN bearing
+    events: ema(c) = Σ x_i·d_i / Σ d_i, d_i = 0.5 ** ((now - t_i)/half_life).
 
-    Strategy:
-      1. Peak (max-pool) over the most-recent _RECENT_WINDOW_COUNT memories'
-         emotion vectors. This captures RECENT FELT INTENSITY on the same scale
-         as declared's lifetime peak — the two diverge only when a channel's
-         peak is older than the window.
-      2. Small body-physiology adjustment (see module-level docstring).
-      3. unnamed_pressure: body residual with no channel home (conservative).
-      4. Fail-open: any exception → empty DerivedRead, never raises.
-
-    Args:
-        memories: list of Memory objects (or anything with .emotions dict
-            and .created_at datetime).
-        body_energy: 1-10 (from BodyState.energy).
-        body_exhaustion: 0-9 (from BodyState.exhaustion).
-
-    Returns:
-        DerivedRead with registered channels only.
+    Normalizing by the channel's own event weights (not all-memory weight) is what
+    makes non-bearing memories invisible (constraint 1) and a global time-shift
+    cancel (constraint 2). Robust to bad timestamps / non-numeric / non-positive
+    values (all skipped). A channel with no bearing event is absent from the dict.
     """
-    try:
-        return _compute(memories, body_energy=body_energy, body_exhaustion=body_exhaustion)
-    except Exception:
-        logger.exception("compute_derived: unexpected error — returning empty read (fail-open)")
-        return DerivedRead({}, 0.0, {})
-
-
-# ── internal implementation ─────────────────────────────────────────────────
-
-
-def _compute(
-    memories: list,
-    *,
-    body_energy: int,
-    body_exhaustion: int,
-) -> DerivedRead:
-    # ── step 1: recency-windowed peak ────────────────────────────────────
-    #
-    # Select the most-recent _RECENT_WINDOW_COUNT emotion-bearing memories,
-    # then max-pool per channel over that window. Robust to bad timestamps
-    # (skipped) and sparsity (count-based window is never empty for >=1 memory).
-    dated: list[tuple[datetime, object]] = []
+    num: dict[str, float] = {}
+    den: dict[str, float] = {}
     for mem in memories:
         try:
             emotions = mem.emotions
@@ -194,64 +123,99 @@ def _compute(
                 created = created.replace(tzinfo=UTC)
         except Exception:
             continue
-        dated.append((created, mem))
-
-    dated.sort(key=lambda t: t[0], reverse=True)
-    window = dated[:_RECENT_WINDOW_COUNT]
-
-    peak: dict[str, float] = {}
-    for _created, mem in window:
-        for name, raw in mem.emotions.items():  # type: ignore[attr-defined]
+        age_h = (now - created).total_seconds() / 3600.0
+        weight = 0.5 ** (age_h / half_life_hours)
+        for name, raw in emotions.items():
             try:
                 value = float(raw)
             except (TypeError, ValueError):
                 continue
             if value <= 0.0:
                 continue
-            # Filter to registered vocabulary only
             if _get_emotion(name) is None:
                 continue
-            if value > peak.get(name, 0.0):
-                peak[name] = value
+            num[name] = num.get(name, 0.0) + value * weight
+            den[name] = den.get(name, 0.0) + weight
 
-    if not peak:
-        # Empty input or all filtered out → empty read, no pressure
+    out: dict[str, float] = {}
+    for name, d in den.items():
+        if d > 0.0:
+            out[name] = num[name] / d
+    return out
+
+
+# ── entry points ────────────────────────────────────────────────────────────
+
+
+def compute_derived(
+    memories: list,
+    *,
+    body_energy: int,
+    body_exhaustion: int,
+    now: datetime | None = None,
+) -> DerivedRead:
+    """The SHORT (felt-lately) read: normalized recency-weighted mean per channel
+    at the short half-life, plus the body's unnamed_pressure residual.
+
+    Args:
+        memories: list of Memory-like objects (.emotions dict, .created_at datetime).
+        body_energy: 1-10 (from BodyState.energy).
+        body_exhaustion: 0-9 (from BodyState.exhaustion).
+        now: reference instant (defaults to datetime.now(UTC)).
+
+    Returns:
+        DerivedRead (registered channels only). Fail-open → empty read.
+    """
+    try:
+        now = now or datetime.now(UTC)
+        channels = _channel_ema(memories, now=now, half_life_hours=_SHORT_HALF_LIFE_HOURS)
+        unnamed_pressure = _compute_unnamed_pressure(
+            channels, body_energy=body_energy, body_exhaustion=body_exhaustion
+        )
+        return DerivedRead(channels=channels, unnamed_pressure=unnamed_pressure, sources={})
+    except Exception:
+        logger.exception("compute_derived: unexpected error — returning empty read (fail-open)")
         return DerivedRead({}, 0.0, {})
 
-    # ── step 2: body-physiology adjustment ───────────────────────────────
-    channels = dict(peak)
-    sources: dict[str, float] = {}
 
-    low_arousal_active = (body_energy <= _LOW_ENERGY_THRESH) or (body_exhaustion >= _HIGH_EXHAUSTION_THRESH)
-    high_arousal_active = (body_energy >= _HIGH_ENERGY_THRESH) and (body_exhaustion <= _LOW_EXHAUSTION_THRESH)
+def compute_baseline(memories: list, *, now: datetime | None = None) -> DerivedRead:
+    """The LONG (baseline) read: normalized recency-weighted mean per channel at
+    the long half-life. No body term (unnamed_pressure is a felt-read concern).
 
-    if low_arousal_active:
-        for ch in _LOW_AROUSAL_CHANNELS:
-            if ch in channels and _get_emotion(ch) is not None:
-                old = channels[ch]
-                channels[ch] = min(old + _BODY_NUDGE_AMOUNT, _get_emotion(ch).intensity_clamp)  # type: ignore[union-attr]
-                if channels[ch] != old:
-                    sources[f"body_low_arousal:{ch}"] = channels[ch] - old
+    Returns:
+        DerivedRead (registered channels only), unnamed_pressure 0.0. Fail-open →
+        empty read.
+    """
+    try:
+        now = now or datetime.now(UTC)
+        channels = _channel_ema(memories, now=now, half_life_hours=_LONG_HALF_LIFE_HOURS)
+        return DerivedRead(channels=channels, unnamed_pressure=0.0, sources={})
+    except Exception:
+        logger.exception("compute_baseline: unexpected error — returning empty read (fail-open)")
+        return DerivedRead({}, 0.0, {})
 
-    if high_arousal_active:
-        for ch in _HIGH_AROUSAL_CHANNELS:
-            if ch in channels and _get_emotion(ch) is not None:
-                old = channels[ch]
-                channels[ch] = min(old + _BODY_NUDGE_AMOUNT, _get_emotion(ch).intensity_clamp)  # type: ignore[union-attr]
-                if channels[ch] != old:
-                    sources[f"body_high_arousal:{ch}"] = channels[ch] - old
 
-    # ── step 3: unnamed_pressure ─────────────────────────────────────────
-    unnamed_pressure = 0.0
+# ── internal: unnamed_pressure ───────────────────────────────────────────────
+
+
+def _compute_unnamed_pressure(
+    channels: dict[str, float],
+    *,
+    body_energy: int,
+    body_exhaustion: int,
+) -> float:
+    """Residual body signal with no channel home (conservative floor).
+
+    Fires only when the body is in an extreme low-arousal state AND no low-arousal
+    channel has any bearing event (so the body signal maps nowhere). Otherwise 0.0.
+    """
     extreme_body = (body_exhaustion >= _UNNAMED_EXHAUSTION_FLOOR) or (body_energy <= _UNNAMED_ENERGY_CEIL)
-    if extreme_body:
-        # Check whether any low-arousal channel has windowed-peak support
-        low_arousal_present = any(ch in peak for ch in _LOW_AROUSAL_CHANNELS)
-        if not low_arousal_present:
-            # Body is screaming low-arousal but no channel exists to carry it
-            # Scale pressure by how extreme the body state is
-            exhaustion_excess = max(0, body_exhaustion - _UNNAMED_EXHAUSTION_FLOOR + 1)
-            energy_deficit = max(0, _UNNAMED_ENERGY_CEIL - body_energy + 1)
-            unnamed_pressure = float(_BODY_NUDGE_AMOUNT * max(exhaustion_excess, energy_deficit))
-
-    return DerivedRead(channels=channels, unnamed_pressure=unnamed_pressure, sources=sources)
+    if not extreme_body:
+        return 0.0
+    # "present" now means: has at least one bearing event in history (in channels).
+    low_arousal_present = any(ch in channels for ch in _LOW_AROUSAL_CHANNELS)
+    if low_arousal_present:
+        return 0.0
+    exhaustion_excess = max(0, body_exhaustion - _UNNAMED_EXHAUSTION_FLOOR + 1)
+    energy_deficit = max(0, _UNNAMED_ENERGY_CEIL - body_energy + 1)
+    return float(_BODY_NUDGE_AMOUNT * max(exhaustion_excess, energy_deficit))

--- a/brain/self_model/gap.py
+++ b/brain/self_model/gap.py
@@ -1,31 +1,37 @@
-"""Gap — derived-minus-declared emotional divergence.
+"""Gap — short-minus-long (recent-vs-baseline) emotional divergence.
 
-`compute_gap(declared, derived) -> Gap`
+`compute_gap(short, long) -> Gap`
 
 Pure compute, no I/O, no LLM.
 
-The gap is the vector difference between the derived (trend/body) and the
-declared (max-pool peak) emotional reads, restricted to REGISTERED channels.
-Unregistered channel names — whether from stale vocabulary or synthetic tests —
-are silently dropped (vocab-flood guard, R-A adjacent).
+The gap is the vector difference between the short (recent, felt-lately) and the
+long (baseline) normalized recency-weighted mean reads, restricted to REGISTERED
+channels. Unregistered channel names — whether from stale vocabulary or synthetic
+tests — are silently dropped (vocab-flood guard, R-A adjacent).
 
-per_channel[c] = derived.channels.get(c, 0) − declared.emotions.get(c, 0)
+per_channel[c] = short.channels.get(c, 0) − long.channels.get(c, 0)
 
 for every channel c that:
-  1. appears in EITHER derived.channels or declared.emotions, AND
-  2. is registered in the emotion vocabulary (vocabulary.get(c) is not None).
+  1. appears in EITHER short.channels or long.channels, AND
+  2. is registered in the emotion vocabulary (vocabulary.get(c) is not None), AND
+  3. has |delta| >= _GAP_NOISE_FLOOR.
 
-Exact-zero deltas (declared == derived for that channel) are dropped from
-per_channel to keep the dict sparse. This is a deliberate design choice:
-a zero delta carries no information and would inflate magnitude calculations.
+The delta is BIDIRECTIONAL: >0 running above baseline lately (golden cross), <0
+below baseline lately (death cross).
 
-magnitude = sum(abs(v) for v in per_channel.values())
+Below-floor deltas are dropped: a channel whose recent read is within
+_GAP_NOISE_FLOOR of its baseline is at-baseline, and near-zero noise summed over
+~20 channels would otherwise inflate magnitude to a few points on a persona that
+is not actually diverging, so the gap would surface every reflection tick. The
+floor makes magnitude reflect only genuine crosses; magnitude == 0 on a steady
+persona (nothing surfaces), and a genuine cross survives at its full delta. The
+floor equals ambient._CHANNEL_FLOOR (0.5) by design — a channel is surfaced only
+when it diverges enough for the ambient block to name it (kept a local constant
+here, not imported, to avoid a self_model→self_model import cycle).
 
-Orthogonality assertion (R-C1):
-  - Divergent declared/derived   → magnitude > 0  (per_channel is non-empty)
-  - Identical declared/derived   → magnitude == 0.0
+magnitude = sum(abs(v) for v in per_channel.values())  # over survivors
 
-unnamed_pressure is carried through from the derived read unchanged.
+unnamed_pressure is carried through from the short (felt) read unchanged.
 
 Gap dataclass fields per spec §4:
   per_channel        — {channel: delta}  registered-only, zero-deltas dropped
@@ -43,9 +49,16 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 
-from brain.emotion.state import EmotionalState
 from brain.emotion.vocabulary import get as _get_emotion
 from brain.self_model.derived import DerivedRead
+
+# A channel is surfaced only when its recent read diverges from baseline by at
+# least this much (on the 0–10 intensity scale). Below-floor deltas are treated
+# as at-baseline and dropped, so magnitude reflects only genuine crosses. Set
+# equal to ambient._CHANNEL_FLOOR (0.5) by design — the same bar at which the
+# ambient block would name the channel. Kept local (not imported) to avoid a
+# self_model→self_model import cycle; the equality is intentional.
+_GAP_NOISE_FLOOR: float = 0.5
 
 
 @dataclass
@@ -55,12 +68,12 @@ class Gap:
     See module docstring for invariants.
 
     Attributes:
-        per_channel: {channel_name: delta} where delta = derived − declared.
-            Registered channels only. Zero-delta channels are omitted.
+        per_channel: {channel_name: delta} where delta = short − long.
+            Registered channels only. Below-noise-floor channels are omitted.
         magnitude: sum(abs(delta) for delta in per_channel.values()).
-            0.0 when declared and derived are identical on all registered channels.
-        unnamed_pressure: residual body signal from DerivedRead that maps to no
-            known channel. Carried through unchanged from the derived read.
+            0.0 when short and long are within the noise floor on every channel.
+        unnamed_pressure: residual body signal from the short read that maps to no
+            known channel. Carried through unchanged from the short (felt) read.
         note: optional human-readable articulation from the Haiku articulate layer
             (Task 4). None until articulated.
         status: lifecycle marker — "open" | "acknowledged" | "dismissed" | "resolved".
@@ -83,31 +96,31 @@ class Gap:
     channel_cooldowns: dict[str, str] = field(default_factory=dict)
 
 
-def compute_gap(declared: EmotionalState, derived: DerivedRead) -> Gap:
-    """Compute the gap between declared and derived emotional reads.
+def compute_gap(short: DerivedRead, long: DerivedRead) -> Gap:
+    """Compute the gap between the short (recent) and long (baseline) reads.
 
     Args:
-        declared: The existing aggregate_state (max-pool peak over memories).
-        derived:  The new orthogonal read (recency-weighted mean + body).
+        short: The felt-lately read (short-half-life normalized mean + body).
+        long:  The baseline read (long-half-life normalized mean).
 
     Returns:
-        Gap with registered-only per_channel deltas and passed-through
-        unnamed_pressure. All persistence fields (ts, ticks, cooldowns) are
-        at their zero/None defaults — the cadence layer sets them.
+        Gap with registered-only per_channel deltas above the noise floor and
+        passed-through unnamed_pressure. All persistence fields (ts, ticks,
+        cooldowns) are at their zero/None defaults — the cadence layer sets them.
     """
     # Collect candidate channels: union of both reads, registered-only.
     candidate_channels: set[str] = set()
-    for c in derived.channels:
+    for c in short.channels:
         if _get_emotion(c) is not None:
             candidate_channels.add(c)
-    for c in declared.emotions:
+    for c in long.channels:
         if _get_emotion(c) is not None:
             candidate_channels.add(c)
 
     per_channel: dict[str, float] = {}
     for c in candidate_channels:
-        delta = derived.channels.get(c, 0.0) - declared.emotions.get(c, 0.0)
-        if delta != 0.0:
+        delta = short.channels.get(c, 0.0) - long.channels.get(c, 0.0)
+        if abs(delta) >= _GAP_NOISE_FLOOR:
             per_channel[c] = delta
 
     magnitude = sum(abs(v) for v in per_channel.values())
@@ -115,5 +128,5 @@ def compute_gap(declared: EmotionalState, derived: DerivedRead) -> Gap:
     return Gap(
         per_channel=per_channel,
         magnitude=magnitude,
-        unnamed_pressure=derived.unnamed_pressure,
+        unnamed_pressure=short.unnamed_pressure,
     )

--- a/docs/Behavioral_Observations.md
+++ b/docs/Behavioral_Observations.md
@@ -1,0 +1,19 @@
+# Behavioral Observations
+
+A running, informal log of small behavioral quirks observed in the companion's substrate model, kept so we do not rediscover them the hard way. Append new entries at the top with a date. Each entry should state the general behavior first, then any concrete case that surfaced it, and why it may matter later.
+
+---
+
+## 2026-08-25 — Small/fast substrate models take prompt phrasing literally
+
+**Behavior:** a smaller/faster substrate model (Haiku) tends to answer a figure of speech phrased as a bare question literally, rather than as the intended metaphor. The larger the model, the more it tolerates figurative phrasing; the smaller, the more literal.
+
+**Case:** the self_model note prompt framed the persona's emotional state as "weather" and closed with `What's the weather?`. On Haiku, a faithful context-free call answered it as a real weather request 10/10 (offering a forecast, asking for a location) instead of the intended one-sentence note. Rephrasing to `What's the (metaphorical) weather?` dropped it to 0/10 (a metaphor-consistent embellishment remained ~3/10).
+
+**Why it matters:** when prompting the small/housekeeping model, do not rely on it to infer that a question is figurative. Mark the metaphor explicitly, or state the task plainly rather than as a question. A prompt that reads fine on the chat model can misfire on the smaller one.
+
+---
+
+### Disproven candidates (kept so they are not re-investigated)
+
+- "The substrate under-uses context already in front of it, preferring an active tool call" — **disproven** on 2026-08-19. It was a live-test harness artifact, not a behavior: the harness ran a split-brain where the tool-serving process loaded stale code, so `read_full_memory` was uncallable. On the fixed harness a valid 15-turn discrimination test showed the model does open relevant surfaced snippets and skip irrelevant ones.

--- a/tests/unit/brain/bridge/test_supervisor_self_model.py
+++ b/tests/unit/brain/bridge/test_supervisor_self_model.py
@@ -2,13 +2,13 @@
 
 Task 7 (Organ DoD): the producer (self-model reflection) fires through the
 supervisor's own persisted-cadence block — NOT a monotonic timer. The tick
-composes the whole organ end-to-end: declared (aggregate_state) vs derived
-(compute_derived) → gap → state persistence → cadence advance, fail-isolated.
+composes the whole organ end-to-end: short (compute_derived) vs long
+(compute_baseline) → gap → state persistence → cadence advance, fail-isolated.
 """
 
 from __future__ import annotations
 
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 from brain.bridge.provider import FakeProvider
@@ -33,41 +33,45 @@ def _persona_dir(tmp_path: Path) -> Path:
     return p
 
 
-def _seed_divergent_memories(persona_dir: Path) -> None:
-    """OLD high-intensity joy + love peaks, beyond the recent window, plus many
-    RECENT grief memories.
+def _seed_divergent_memories(persona_dir: Path, now: datetime | None = None) -> None:
+    """A genuine, sustained short-vs-long (recent-vs-baseline) cross on two channels.
 
-    declared (max-pool over the whole history) surfaces joy + love at their old
-    peaks; derived (peak over the most-recent _RECENT_WINDOW_COUNT=30 memories)
-    sees only the recent grief — so joy and love show a real negative gap
-    ("I claim these but haven't felt them lately"), while grief ~matches. Two
-    divergent channels so a reconcile on one leaves the gap non-empty.
+    Placed RELATIVE to ``now`` (the tick's reference instant) so "recent" is recent
+    for that tick:
+      - joy:   OLD low events (2.0) + RECENT high events (9.0) → the SHORT read runs
+               above the LONG baseline → a GOLDEN cross (delta > +0.5).
+      - grief: OLD high events (9.0) + RECENT low events (2.0) → the SHORT read runs
+               below baseline → a DEATH cross (delta < -0.5).
+    Each channel is MULTI-event (a single event would give short == long under the
+    normalized mean, hence no gap). The deltas are ~±1.8, robustly above the 0.5
+    noise floor, so {joy, grief} is a stable per_channel key set across ticks — as
+    ``now`` advances over a fixed memory set every event ages by the same amount, a
+    uniform time-shift the normalized mean is invariant to, so the cross persists and
+    sustained_ticks accumulates. Two divergent channels so a reconcile on joy leaves
+    the gap non-empty (grief remains).
     """
     from brain.memory.store import Memory, MemoryStore
 
+    now = now or datetime.now(UTC)
     store = MemoryStore(persona_dir / "memories.db")
     try:
-        for name, intensity in (("joy", 9.0), ("love", 8.0)):
-            old = Memory.create_new(
-                content=f"an old bright day of {name}",
-                memory_type="episodic",
-                domain="self",
-                emotions={name: intensity},
-                importance=8.0,
-            )
-            object.__setattr__(old, "created_at", datetime(2026, 1, 1, tzinfo=UTC))
-            store.create(old)
-        # > _RECENT_WINDOW_COUNT recent grief memories so the old peaks fall
-        # outside the derived window.
-        for i in range(31):
-            m = Memory.create_new(
-                content=f"a recent ache #{i}",
-                memory_type="episodic",
-                domain="self",
-                emotions={"grief": 4.0},
-                importance=7.0,
-            )
-            store.create(m)
+        for name, old_val, new_val in (("joy", 2.0, 9.0), ("grief", 9.0, 2.0)):
+            for days in (40, 45, 50):  # OLD events
+                m = Memory.create_new(
+                    content=f"an old {name} memory",
+                    memory_type="episodic", domain="self",
+                    emotions={name: old_val}, importance=7.0,
+                )
+                object.__setattr__(m, "created_at", now - timedelta(days=days))
+                store.create(m)
+            for hours in (1, 3, 6):  # RECENT events
+                m = Memory.create_new(
+                    content=f"a recent {name} memory",
+                    memory_type="episodic", domain="self",
+                    emotions={name: new_val}, importance=7.0,
+                )
+                object.__setattr__(m, "created_at", now - timedelta(hours=hours))
+                store.create(m)
     finally:
         store.close()
 
@@ -88,7 +92,7 @@ def test_self_model_tick_runs_end_to_end_and_persists_state(tmp_path: Path) -> N
 
     _run_self_model_tick(persona_dir, provider=FakeProvider(), event_bus=bus)
 
-    # State file persisted, with an active current_gap that derived/declared
+    # State file persisted, with an active current_gap that short/long
     # genuinely diverge on.
     state_file = persona_dir / "self_model_state.json"
     assert state_file.exists(), "tick must persist self_model_state.json"
@@ -243,7 +247,7 @@ def test_sustained_gap_resolved_through_live_tick_emits_soul_candidate(
 
     # ── PATH A — reconcile ───────────────────────────────────────────────────
     pa = _persona_dir(tmp_path)
-    _seed_divergent_memories(pa)
+    _seed_divergent_memories(pa, now=base)
 
     # Sustain the gap over enough real ticks to cross _SUSTAINED_TICKS.
     for i in range(_SUSTAINED_TICKS + 1):
@@ -275,7 +279,7 @@ def test_sustained_gap_resolved_through_live_tick_emits_soul_candidate(
     pb_root = tmp_path / "b"
     pb_root.mkdir()
     pb = _persona_dir(pb_root)
-    _seed_divergent_memories(pb)
+    _seed_divergent_memories(pb, now=base)
 
     for i in range(_SUSTAINED_TICKS + 1):
         _tick(pb, base + timedelta(hours=6 * i))
@@ -317,7 +321,7 @@ def test_reconcile_cooldown_suppresses_channel_on_next_live_tick(tmp_path: Path)
     base = datetime(2026, 6, 1, tzinfo=UTC)
 
     persona_dir = _persona_dir(tmp_path)
-    _seed_divergent_memories(persona_dir)
+    _seed_divergent_memories(persona_dir, now=base)
 
     # Tick once → a gap surfaces on joy (and grief).
     _self_model_reflect(

--- a/tests/unit/brain/bridge/test_supervisor_self_model.py
+++ b/tests/unit/brain/bridge/test_supervisor_self_model.py
@@ -8,6 +8,7 @@ composes the whole organ end-to-end: short (compute_derived) vs long
 
 from __future__ import annotations
 
+import json
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
@@ -190,6 +191,281 @@ def test_self_model_tick_fail_isolated_on_articulate_error(tmp_path: Path) -> No
     advanced = sm_cadence.load(persona_dir)
     assert advanced.next_reflection_at is not None
     assert advanced.consecutive_failures >= 1
+
+
+# ── Throttle-denial fix (self-model-note-null-fix, C1/C4/C8/C9) ───────────────
+#
+# The note went silently null on every tick since PR #151 because the shared
+# throttle's 300s idle bar was essentially never met on a chatty persona.
+# Revision 4's fix: a pre-flight cli_throttle.slot_available() peek in
+# _run_self_model_tick, checked BEFORE _self_model_reflect is called at all,
+# so a denied attempt costs nothing (C9) - and articulate()'s own real
+# acquire_background() stays as the authoritative fallback for the rare race
+# where the peek granted but a different accessor (or resumed chat) won the
+# slot first (C8 route 2).
+
+
+def test_preflight_peek_denial_is_zero_side_effect(tmp_path: Path) -> None:
+    """C9: when the pre-flight throttle peek denies (the common case during a
+    sustained-chat spell), NOTHING except the cadence advance and the C1
+    error-sink log happens - no gap computation, no self_model_state.json
+    write, no daily-budget consumption, no gaps_surfaced change, no feed
+    event. Seeds a gap that WOULD be computed/consumed if a granted attempt
+    ran, so this test can actually detect a regression rather than merely
+    observing an absence because nothing would have happened anyway.
+
+    Oracle (H6): this assertion set fails against the pre-Revision-4 design
+    (throttle check inside articulate(), downstream of gap computation and
+    budget consumption) - that design calls _self_model_reflect on every
+    denied attempt, so all of these assertions would fail against it.
+    """
+    from brain.bridge import cli_throttle
+    from brain.self_model import cadence as sm_cadence
+    from brain.self_model.resolve import load_audit
+
+    persona_dir = _persona_dir(tmp_path)
+    _seed_divergent_memories(persona_dir)
+    bus = _CapturingBus()
+
+    cli_throttle.mark_interactive_active()  # chat "just happened" — denies the peek
+
+    _run_self_model_tick(persona_dir, provider=FakeProvider(), event_bus=bus)
+
+    assert not (persona_dir / "self_model_state.json").exists(), (
+        "a denied attempt must not compute or persist a gap"
+    )
+    assert not (persona_dir / "self_model" / "daily_articulate_budget.json").exists(), (
+        "a denied attempt must not consume the daily articulate budget"
+    )
+    audit = load_audit(persona_dir)
+    assert audit.get("gaps_surfaced", 0) == 0, (
+        "a denied attempt must not bump the gaps_surfaced counter"
+    )
+    assert bus.events == [], "a denied attempt must not publish a self_model_tick event"
+
+    error_path = persona_dir / "self_model_articulate_errors.jsonl"
+    assert error_path.exists()
+    rows = [json.loads(line) for line in error_path.read_text().splitlines() if line.strip()]
+    assert len(rows) == 1
+    assert rows[0]["kind"] == "self_model_articulate_deferred"
+
+    advanced = sm_cadence.load(persona_dir)
+    assert advanced.next_reflection_at is not None
+    delta = (advanced.next_reflection_at - datetime.now(UTC)).total_seconds()
+    assert 0 < delta <= 65, "cadence must advance to the short ~60s deferred retry, not ~6h"
+    assert advanced.consecutive_failures == 0, "a deferral must not trigger the failure backoff"
+
+
+def test_rare_race_throttle_deferred_still_persists_state_but_defers_cadence(
+    tmp_path: Path,
+) -> None:
+    """C8 route 2: if articulate() raises ThrottleDeferred (the rare
+    peek-then-lost race — pre-flight peek granted, but the real acquire then
+    lost the slot), the cadence still advances to the short "deferred" retry
+    (not the 6h normal interval, not the escalating failure backoff) — but
+    UNLIKE route 1 (C9's zero-side-effects guarantee), self_model_state.json
+    WAS written this tick, because gap computation already ran before the
+    race was discovered. This is the accepted, maker-precedented tradeoff for
+    the rare race, distinct from route 1's pure no-op."""
+    from unittest.mock import patch
+
+    from brain.bridge import cli_throttle
+    from brain.self_model import cadence as sm_cadence
+
+    persona_dir = _persona_dir(tmp_path)
+    _seed_divergent_memories(persona_dir)
+    bus = _CapturingBus()
+
+    with patch(
+        "brain.bridge.supervisor.sm_articulate",
+        side_effect=cli_throttle.ThrottleDeferred("lost the race"),
+    ):
+        _run_self_model_tick(persona_dir, provider=FakeProvider(), event_bus=bus)
+
+    assert (persona_dir / "self_model_state.json").exists(), (
+        "the rare-race path already ran gap computation before the race was "
+        "discovered — state IS written, unlike route 1's pre-flight denial"
+    )
+    advanced = sm_cadence.load(persona_dir)
+    assert advanced.next_reflection_at is not None
+    delta = (advanced.next_reflection_at - datetime.now(UTC)).total_seconds()
+    assert 0 < delta <= 65, "cadence must use the short deferred retry, not 6h or a backoff"
+    assert advanced.consecutive_failures == 0, "a deferral must not trigger the failure backoff"
+
+
+def test_carry_forward_same_channels_open_status_note_present(tmp_path: Path) -> None:
+    """C4 case (i): same channels + prior status == "open" + prior note
+    present → the note IS carried forward onto the new gap."""
+    from unittest.mock import patch
+
+    from brain.bridge.supervisor import _self_model_reflect
+    from brain.self_model import state as sm_state
+    from brain.self_model.gap import Gap
+
+    provider = FakeProvider()
+    base = datetime(2026, 6, 1, tzinfo=UTC)
+    persona_dir = _persona_dir(tmp_path)
+    _seed_divergent_memories(persona_dir, now=base)
+
+    prior_gap = Gap(
+        per_channel={"joy": 1.8, "grief": -1.8},
+        magnitude=3.6,
+        unnamed_pressure=0.0,
+        note="a note that should carry forward",
+        status="open",
+        first_seen_ts=base.isoformat(),
+        last_seen_ts=base.isoformat(),
+        sustained_ticks=1,
+    )
+    sm_state.save(
+        persona_dir,
+        sm_state.SelfModelState(current_gap=prior_gap, gap_history=[]),
+    )
+
+    with patch("brain.bridge.supervisor.sm_articulate", return_value=None):
+        _self_model_reflect(
+            persona_dir,
+            provider=provider,
+            event_bus=_CapturingBus(),
+            now=base + timedelta(hours=6),
+        )
+
+    new_gap = sm_state.load_or_recover(persona_dir)[0].current_gap
+    assert new_gap is not None
+    assert set(new_gap.per_channel) == {"joy", "grief"}, (
+        "test setup check: the new tick's channel set must match the prior's"
+    )
+    assert new_gap.note == "a note that should carry forward"
+
+
+def test_carry_forward_blocked_on_different_channels(tmp_path: Path) -> None:
+    """C4 case (ii), MANDATORY: the adversarial cross-channel case that was
+    the original gate-3 bounce-1 MAJOR finding, demonstrated live on the
+    real persona's own gap_history (see decisions.md). A prior gap with a
+    note, still open, but on a DIFFERENT channel set than the new tick's
+    gap, must NOT have its stale, off-channel note carried forward."""
+    from unittest.mock import patch
+
+    from brain.bridge.supervisor import _self_model_reflect
+    from brain.self_model import state as sm_state
+    from brain.self_model.gap import Gap
+
+    provider = FakeProvider()
+    base = datetime(2026, 6, 1, tzinfo=UTC)
+    persona_dir = _persona_dir(tmp_path)
+    _seed_divergent_memories(persona_dir, now=base)  # new tick will be {joy, grief}
+
+    prior_gap = Gap(
+        per_channel={"focus": 1.2},  # disjoint from {joy, grief}
+        magnitude=1.2,
+        unnamed_pressure=0.0,
+        note="a stale note about an unrelated channel",
+        status="open",
+        first_seen_ts=base.isoformat(),
+        last_seen_ts=base.isoformat(),
+        sustained_ticks=1,
+    )
+    sm_state.save(
+        persona_dir,
+        sm_state.SelfModelState(current_gap=prior_gap, gap_history=[]),
+    )
+
+    with patch("brain.bridge.supervisor.sm_articulate", return_value=None):
+        _self_model_reflect(
+            persona_dir,
+            provider=provider,
+            event_bus=_CapturingBus(),
+            now=base + timedelta(hours=6),
+        )
+
+    new_gap = sm_state.load_or_recover(persona_dir)[0].current_gap
+    assert new_gap is not None
+    assert set(new_gap.per_channel) == {"joy", "grief"}
+    assert new_gap.note is None, (
+        "a stale, off-channel note must never be attached — different "
+        "channel sets must block carry-forward"
+    )
+
+
+def test_carry_forward_blocked_when_no_prior_note(tmp_path: Path) -> None:
+    """C4 case (iii): no prior gap at all (fresh persona) → new_gap.note
+    stays None (nothing to carry forward)."""
+    from unittest.mock import patch
+
+    from brain.bridge.supervisor import _self_model_reflect
+    from brain.self_model import state as sm_state
+
+    provider = FakeProvider()
+    base = datetime(2026, 6, 1, tzinfo=UTC)
+    persona_dir = _persona_dir(tmp_path)
+    _seed_divergent_memories(persona_dir, now=base)
+    # No prior state file written — this is a fresh persona's first tick.
+
+    with patch("brain.bridge.supervisor.sm_articulate", return_value=None):
+        _self_model_reflect(
+            persona_dir, provider=provider, event_bus=_CapturingBus(), now=base
+        )
+
+    new_gap = sm_state.load_or_recover(persona_dir)[0].current_gap
+    assert new_gap is not None
+    assert new_gap.note is None
+
+
+def test_carry_forward_requires_prior_status_open_not_just_same_channels(
+    tmp_path: Path,
+) -> None:
+    """C4 case (iv): a prior gap on the SAME channel set with a note, but
+    whose status is NOT "open" (e.g. already reconciled/dismissed), must NOT
+    have its note carried forward — same_channels requires
+    prior_gap.status == "open" too, not just a channel-set match. Regression
+    test for the gate-3 pass-5 MINOR fidelity finding (the criterion's prior
+    wording named only the channel-set half of the predicate it reuses)."""
+    from unittest.mock import patch
+
+    from brain.bridge.supervisor import _self_model_reflect
+    from brain.self_model import state as sm_state
+    from brain.self_model.gap import Gap
+
+    provider = FakeProvider()
+    base = datetime(2026, 6, 1, tzinfo=UTC)
+    persona_dir = _persona_dir(tmp_path)
+    _seed_divergent_memories(persona_dir, now=base)
+
+    # Hand-construct a prior state: an "acknowledged" (NOT open) gap on the
+    # exact channel set the seeded memories will produce ({joy, grief}), with
+    # a note present.
+    prior_gap = Gap(
+        per_channel={"joy": 1.8, "grief": -1.8},
+        magnitude=3.6,
+        unnamed_pressure=0.0,
+        note="an old note that must not resurface",
+        status="acknowledged",
+        first_seen_ts=base.isoformat(),
+        last_seen_ts=base.isoformat(),
+        sustained_ticks=1,
+    )
+    sm_state.save(
+        persona_dir,
+        sm_state.SelfModelState(current_gap=prior_gap, gap_history=[]),
+    )
+
+    with patch("brain.bridge.supervisor.sm_articulate", return_value=None):
+        _self_model_reflect(
+            persona_dir,
+            provider=provider,
+            event_bus=_CapturingBus(),
+            now=base + timedelta(hours=6),
+        )
+
+    new_gap = sm_state.load_or_recover(persona_dir)[0].current_gap
+    assert new_gap is not None
+    assert set(new_gap.per_channel) == {"joy", "grief"}, (
+        "test setup check: the new tick's channel set must match the prior's"
+    )
+    assert new_gap.note is None, (
+        "prior_gap.status != 'open' must block carry-forward even though the "
+        "channel sets match"
+    )
 
 
 # ── Organ-DoD live-path resolution test (Fix C1) ──────────────────────────────

--- a/tests/unit/brain/chat/test_prompt.py
+++ b/tests/unit/brain/chat/test_prompt.py
@@ -1254,7 +1254,8 @@ def test_build_system_message_includes_self_model_block_when_gap_open(
         soul_store=soul_store,
         store=store,
     )
-    assert "A note on your own read" in msg
+    # Block header (weather-language framing); tracks the owner-approved wording.
+    assert "How some things have been running lately" in msg
     assert "reconcile_self_read" in msg
 
 
@@ -1269,7 +1270,7 @@ def test_build_system_message_omits_self_model_block_when_no_gap(
         soul_store=soul_store,
         store=store,
     )
-    assert "A note on your own read" not in msg
+    assert "How some things have been running lately" not in msg
 
 
 # ── Tool inventory (frozen prefix, text path) ─────────────────────────────────

--- a/tests/unit/brain/chat/test_tool_recruit.py
+++ b/tests/unit/brain/chat/test_tool_recruit.py
@@ -48,6 +48,43 @@ def test_maximal_signal_recruits_everything():
     assert allowed == set(NELL_TOOL_NAMES)
 
 
+def test_gap_open_grants_reconcile_on_ordinary_turn():
+    """#149: when a self-model gap is open, reconcile_self_read is offered even on
+    a trivial, non-maximal turn — so the ambient block's invitation is actionable."""
+    signal = assess_salience("ok")
+    assert signal.score < 0.999  # guards the premise: a non-maximal turn
+    assert "reconcile_self_read" not in select_tools(signal, gap_open=False)
+    assert "reconcile_self_read" in select_tools(signal, gap_open=True)
+
+
+def test_gap_open_does_not_pull_in_other_heavy_tools():
+    """gap_open grants ONLY reconcile_self_read, not the memory/file tiers."""
+    allowed = select_tools(assess_salience("ok"), gap_open=True)
+    assert "reconcile_self_read" in allowed
+    assert "recall_forgotten" not in allowed and "read_file" not in allowed
+
+
+def test_self_model_gap_open_helper_reads_persisted_status(tmp_path):
+    """#149: the engine helper reports gap-open from the ALREADY-PERSISTED
+    current_gap.status (live statuses = open/acknowledged), fail-open to False."""
+    from brain.chat.engine import _self_model_gap_open
+    from brain.self_model.gap import Gap
+    from brain.self_model.state import SelfModelState, save
+
+    p = tmp_path / "persona"
+    p.mkdir()
+    assert _self_model_gap_open(p) is False  # no state file → False (fail-open)
+
+    def _gap(status):
+        return Gap(per_channel={"grief": 1.0}, magnitude=1.0, unnamed_pressure=0.0, status=status)
+
+    save(p, SelfModelState(current_gap=_gap("open")))
+    assert _self_model_gap_open(p) is True
+
+    save(p, SelfModelState(current_gap=_gap("dismissed")))
+    assert _self_model_gap_open(p) is False  # not a live status
+
+
 def test_select_tools_returns_base_order():
     """Result must be a subsequence of NELL_TOOL_NAMES in the same relative order.
 

--- a/tests/unit/brain/self_model/test_articulate.py
+++ b/tests/unit/brain/self_model/test_articulate.py
@@ -9,19 +9,34 @@ Routing: build_self_model_provider forces SELF_MODEL_MODEL (haiku) regardless of
   provider actually used, not a disconnected hardcoded label (was: model="haiku"
   hardcoded at articulate.py:162 even when a mis-routed provider ran something
   else entirely).
+
+Throttle-denial fix (self-model-note-null-fix): the note went silently null on
+every tick since PR #151 because cli_throttle.background_slot()'s 300s idle bar
+was essentially never met on a chatty persona. articulate() now requests a
+short (30s, tunable) idle window and raises cli_throttle.ThrottleDeferred on
+denial instead of silently returning None — see C1/C2/C3/C5 below. The
+zero-side-effects invariant (C9: a denied attempt must cost nothing) lives in
+brain/bridge/supervisor.py's pre-flight peek, tested in
+test_supervisor_self_model.py, not here — this file only covers articulate()'s
+own contract (the authoritative real-acquire fallback).
 """
 from __future__ import annotations
 
 import json
+import time
 from datetime import datetime
 from pathlib import Path
 
+import pytest
+
+from brain.bridge import cli_throttle
 from brain.bridge.provider import ClaudeCliProvider
 from brain.self_model.articulate import (
     _DAILY_ARTICULATE_BUDGET,
     _GAP_THRESHOLD,
     SELF_MODEL_MODEL,
     articulate,
+    articulate_min_idle_seconds,
     build_self_model_provider,
 )
 from brain.self_model.gap import Gap
@@ -195,3 +210,137 @@ def test_usage_log_falls_back_to_self_model_constant_without_model_attr(tmp_path
 
     rows = _read_usage_rows(tmp_path)
     assert rows[-1]["model"] == SELF_MODEL_MODEL
+
+
+# ---------------------------------------------------------------------------
+# Throttle-denial fix (self-model-note-null-fix, C1/C2/C3/C5) — the note went
+# silently null on every tick since PR #151 because the 300s idle bar was
+# essentially never met. articulate() now uses a short idle window and raises
+# ThrottleDeferred (not a silent None) on denial.
+# ---------------------------------------------------------------------------
+
+
+def _read_error_rows(persona_dir: Path) -> list[dict]:
+    path = persona_dir / "self_model_articulate_errors.jsonl"
+    if not path.exists():
+        return []
+    return [json.loads(line) for line in path.read_text().splitlines() if line.strip()]
+
+
+def test_throttle_denied_raises_threedeferred_and_logs(tmp_path):
+    """C1: when the throttle denies the slot (chat too recently active for the
+    short min_idle window), articulate() raises cli_throttle.ThrottleDeferred
+    — NOT a silent None, the pre-fix behavior that made this bug invisible —
+    and logs a self_model_articulate_deferred record. Oracle (H6): pre-fix
+    code (background_slot() + `return None`) would return None here and write
+    no jsonl row at all; this test would fail against that shape."""
+    cli_throttle.mark_interactive_active()  # chat "just happened" — idle ~0s
+    provider = _CountingProvider()
+    gap = _gap(magnitude=_GAP_THRESHOLD + 0.5)
+
+    with pytest.raises(cli_throttle.ThrottleDeferred):
+        articulate(gap, provider=provider, persona_dir=tmp_path)
+
+    assert len(provider.calls) == 0, "provider must not be called when the slot is denied"
+    rows = _read_error_rows(tmp_path)
+    assert len(rows) == 1
+    assert rows[0]["kind"] == "self_model_articulate_deferred"
+
+
+def test_provider_exception_logs_error_jsonl(tmp_path):
+    """C2: a provider exception (the rarer secondary failure — slot IS
+    acquired, provider.generate() itself raises) is logged with
+    kind == self_model_articulate_failed and the exception message, and
+    articulate() still returns None (fail-soft, unchanged)."""
+    provider = _CountingProvider(raises=True)
+    gap = _gap(magnitude=_GAP_THRESHOLD + 0.5)
+
+    result = articulate(gap, provider=provider, persona_dir=tmp_path)
+
+    assert result is None
+    rows = _read_error_rows(tmp_path)
+    assert len(rows) == 1
+    assert rows[0]["kind"] == "self_model_articulate_failed"
+    assert "provider failure" in rows[0]["error"]
+
+
+def test_error_sink_write_failure_does_not_mask_denial(tmp_path, monkeypatch):
+    """C3: if the error-sink write itself fails, articulate() still raises
+    ThrottleDeferred on a throttle denial (not swallowed into a silent
+    None), and no ADDITIONAL exception from the failed log write escapes."""
+    import brain.self_model.articulate as articulate_mod
+
+    def _boom(*_a, **_k):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(articulate_mod, "_now_iso", _boom)
+    cli_throttle.mark_interactive_active()
+    provider = _CountingProvider()
+    gap = _gap(magnitude=_GAP_THRESHOLD + 0.5)
+
+    with pytest.raises(cli_throttle.ThrottleDeferred):
+        articulate(gap, provider=provider, persona_dir=tmp_path)
+    # No jsonl row — the write failed — but critically no OTHER exception
+    # (e.g. OSError) escaped either; only ThrottleDeferred was raised.
+    assert not (tmp_path / "self_model_articulate_errors.jsonl").exists()
+
+
+def test_error_sink_write_failure_does_not_mask_provider_exception(tmp_path, monkeypatch):
+    """C3: same guarantee on the provider-exception path — articulate()
+    still returns None cleanly even if the error-sink write itself fails."""
+    import brain.self_model.articulate as articulate_mod
+
+    def _boom(*_a, **_k):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(articulate_mod, "_now_iso", _boom)
+    provider = _CountingProvider(raises=True)
+    gap = _gap(magnitude=_GAP_THRESHOLD + 0.5)
+
+    result = articulate(gap, provider=provider, persona_dir=tmp_path)
+
+    assert result is None
+    assert not (tmp_path / "self_model_articulate_errors.jsonl").exists()
+
+
+def test_single_attempt_no_sleep_on_denial(tmp_path, monkeypatch):
+    """C5(i): denial is a SINGLE non-blocking check — no retry loop, no
+    time.sleep anywhere. This is the direct regression test for the gate-3
+    re-run-2 MAJOR (a sleep-based retry blocked the supervisor's single
+    execution thread for up to ~45s roughly every 6h)."""
+    calls: list[float] = []
+    monkeypatch.setattr(time, "sleep", lambda s: calls.append(s))
+    cli_throttle.mark_interactive_active()
+    provider = _CountingProvider()
+    gap = _gap(magnitude=_GAP_THRESHOLD + 0.5)
+
+    with pytest.raises(cli_throttle.ThrottleDeferred):
+        articulate(gap, provider=provider, persona_dir=tmp_path)
+
+    assert calls == [], "articulate() must never sleep — the retry lives in the caller's cadence"
+
+
+def test_grant_calls_release_background_exactly_once(tmp_path, monkeypatch):
+    """C5(ii): on a granted attempt, release_background() runs exactly once,
+    after provider.generate() returns (success case)."""
+    released: list[bool] = []
+    original_release = cli_throttle.release_background
+
+    def _tracking_release():
+        released.append(True)
+        original_release()
+
+    monkeypatch.setattr(cli_throttle, "release_background", _tracking_release)
+    provider = _CountingProvider(response="Something shifts.")
+    gap = _gap(magnitude=_GAP_THRESHOLD + 0.5)
+
+    result = articulate(gap, provider=provider, persona_dir=tmp_path)
+
+    assert result == "Something shifts."
+    assert len(released) == 1
+
+
+def test_articulate_min_idle_seconds_is_public_and_matches_tunable_default(tmp_path):
+    """The min_idle getter is public (brain/bridge/supervisor.py's pre-flight
+    peek calls it too) and returns the documented 30.0s default."""
+    assert articulate_min_idle_seconds() == 30.0

--- a/tests/unit/brain/self_model/test_articulate.py
+++ b/tests/unit/brain/self_model/test_articulate.py
@@ -3,6 +3,12 @@
 R-D1: daily budget exhausted → None, no provider call.
 Fail-soft: provider raises → None, no exception propagated.
 Threshold gate: gap below _GAP_THRESHOLD → None, no provider call.
+Routing: build_self_model_provider forces SELF_MODEL_MODEL (haiku) regardless of
+  the persona's configured chat model, mirroring brain/chat/compaction.py's
+  build_compaction_provider. The usage log's model= must reflect the model the
+  provider actually used, not a disconnected hardcoded label (was: model="haiku"
+  hardcoded at articulate.py:162 even when a mis-routed provider ran something
+  else entirely).
 """
 from __future__ import annotations
 
@@ -10,7 +16,14 @@ import json
 from datetime import datetime
 from pathlib import Path
 
-from brain.self_model.articulate import _DAILY_ARTICULATE_BUDGET, _GAP_THRESHOLD, articulate
+from brain.bridge.provider import ClaudeCliProvider
+from brain.self_model.articulate import (
+    _DAILY_ARTICULATE_BUDGET,
+    _GAP_THRESHOLD,
+    SELF_MODEL_MODEL,
+    articulate,
+    build_self_model_provider,
+)
 from brain.self_model.gap import Gap
 
 
@@ -96,3 +109,89 @@ def test_corrupt_budget_file_still_allows_call(tmp_path):
     result = articulate(gap, provider=provider, persona_dir=tmp_path)
     assert result == "Something shifts."
     assert len(provider.calls) == 1
+
+
+# ---------------------------------------------------------------------------
+# Routing regression: the articulate note must run on SELF_MODEL_MODEL
+# (haiku), not whatever provider/model the caller happens to be threading
+# through (the persona chat provider) — and the usage log must record the
+# model that actually ran.
+# ---------------------------------------------------------------------------
+
+
+def test_build_self_model_provider_forces_haiku_regardless_of_chat_model(tmp_path):
+    """build_self_model_provider must carry model_override=SELF_MODEL_MODEL
+    ("haiku") even when the persona's configured chat model is something
+    else (e.g. sonnet) — this is a cheap housekeeping call, not a chat reply,
+    and must not inherit the persona chat model. Mirrors
+    test_provider_factory_model.test_factory_override_beats_config."""
+    (tmp_path / "persona_config.json").write_text(
+        json.dumps({"provider": "claude-cli", "searcher": "noop", "model": "sonnet"})
+    )
+    provider = build_self_model_provider(tmp_path)
+    assert isinstance(provider, ClaudeCliProvider)
+    assert SELF_MODEL_MODEL == "haiku"
+    assert provider._model == "haiku"  # noqa: SLF001 — NOT "sonnet", the chat model
+
+
+class _ModelledProvider:
+    """Provider stub that, unlike _CountingProvider, exposes ._model — the
+    attribute real providers (ClaudeCliProvider/OllamaProvider) set from
+    model_override, so the usage-log label can be derived from it."""
+
+    def __init__(self, model: str, *, response: str = "Something shifts.") -> None:
+        self._model = model
+        self._response = response
+        self.calls: list[tuple[str, str | None]] = []
+
+    def generate(self, prompt: str, *, system: str | None = None) -> str:
+        self.calls.append((prompt, system))
+        return self._response
+
+    def name(self) -> str:
+        return f"claude-cli:{self._model}"
+
+
+def _read_usage_rows(persona_dir: Path) -> list[dict]:
+    path = persona_dir / "chat_usage.jsonl"
+    if not path.exists():
+        return []
+    return [json.loads(line) for line in path.read_text().splitlines() if line.strip()]
+
+
+def test_usage_log_derives_model_from_provider_not_hardcoded(tmp_path):
+    """The usage log's model= must reflect the model the provider actually
+    used. Proven by passing a provider whose ._model is deliberately NOT
+    "haiku" and confirming the log records THAT value — a hardcoded
+    model="haiku" label (the pre-fix bug) would fail this."""
+    provider = _ModelledProvider("sonnet")  # deliberately not haiku
+    gap = _gap(magnitude=_GAP_THRESHOLD + 0.5)
+    result = articulate(gap, provider=provider, persona_dir=tmp_path)
+    assert result == "Something shifts."
+
+    rows = _read_usage_rows(tmp_path)
+    assert rows, "expected a usage row to be logged"
+    assert rows[-1]["call_type"] == "self_model_articulate"
+    assert rows[-1]["model"] == "sonnet"
+
+
+def test_usage_log_records_haiku_when_correctly_routed(tmp_path):
+    """End-to-end shape of the fix: a provider built via
+    build_self_model_provider (._model == "haiku") logs "haiku"."""
+    provider = _ModelledProvider(SELF_MODEL_MODEL)
+    gap = _gap(magnitude=_GAP_THRESHOLD + 0.5)
+    articulate(gap, provider=provider, persona_dir=tmp_path)
+
+    rows = _read_usage_rows(tmp_path)
+    assert rows[-1]["model"] == "haiku"
+
+
+def test_usage_log_falls_back_to_self_model_constant_without_model_attr(tmp_path):
+    """A provider with no ._model (e.g. FakeProvider in tests) falls back to
+    SELF_MODEL_MODEL rather than an unrelated hardcoded string."""
+    provider = _CountingProvider(response="Something shifts.")
+    gap = _gap(magnitude=_GAP_THRESHOLD + 0.5)
+    articulate(gap, provider=provider, persona_dir=tmp_path)
+
+    rows = _read_usage_rows(tmp_path)
+    assert rows[-1]["model"] == SELF_MODEL_MODEL

--- a/tests/unit/brain/self_model/test_cadence.py
+++ b/tests/unit/brain/self_model/test_cadence.py
@@ -80,6 +80,35 @@ def test_backlog_uses_catchup_interval():
     assert delta < 1.0
 
 
+def test_deferred_uses_short_retry_interval_and_leaves_failures_unchanged():
+    """C8: a throttle-denial ("deferred") outcome sets a short retry interval
+    (not the ~6h normal interval, and not the escalating failure backoff),
+    and leaves consecutive_failures UNCHANGED — a deferral is not a provider
+    failure, so it must neither reset nor increment the backoff counter
+    (mirrors brain/maker/__init__.py's "no cooldown, no error" framing for
+    the identical ThrottleDeferred situation)."""
+    from brain.self_model.cadence import _DEFERRED_RETRY_INTERVAL_S
+
+    now = datetime.now(UTC)
+    state = SelfModelCadenceState(next_reflection_at=None, consecutive_failures=0)
+    next_state = compute_next_state(state, outcome="deferred", now=now)
+    assert next_state.consecutive_failures == 0
+    expected_at = now + timedelta(seconds=_DEFERRED_RETRY_INTERVAL_S)
+    delta = abs((next_state.next_reflection_at - expected_at).total_seconds())
+    assert delta < 1.0
+
+
+def test_deferred_does_not_reset_existing_failure_count():
+    """The "leaves consecutive_failures unchanged" guarantee must hold on
+    both sides — including when there's an existing nonzero count (a
+    deferral must neither reset it back to 0, matching a clean tick's
+    behavior, nor increment it, matching a failure's)."""
+    now = datetime.now(UTC)
+    state = SelfModelCadenceState(next_reflection_at=None, consecutive_failures=3)
+    next_state = compute_next_state(state, outcome="deferred", now=now)
+    assert next_state.consecutive_failures == 3
+
+
 def test_round_trip_persist(tmp_path):
     """Cadence state survives save → load."""
     now = datetime.now(UTC)

--- a/tests/unit/brain/self_model/test_derived.py
+++ b/tests/unit/brain/self_model/test_derived.py
@@ -1,8 +1,10 @@
-"""Tests for brain/self_model/derived.py — Task 1 + Task 1b.
+"""Tests for brain/self_model/derived.py — normalized recency-weighted mean cross.
 
-TDD order:
-  Task 1 — recency-weighted mean + body adjustment, fail-open (4 tests)
-  Task 1b — conservative unnamed_pressure residual (2 tests)
+  - compute_derived = SHORT-half-life normalized mean per channel + unnamed_pressure
+  - compute_baseline = LONG-half-life normalized mean per channel
+Contracts: recency weighting (an old event is down-weighted, not excluded, and a
+recent event dominates the short read); constraint-1 (non-bearing padding is
+invisible); fail-open; conservative unnamed_pressure.
 """
 
 from __future__ import annotations
@@ -10,102 +12,92 @@ from __future__ import annotations
 from datetime import UTC, datetime, timedelta
 
 from brain.memory.store import Memory
-from brain.self_model.derived import DerivedRead, compute_derived
+from brain.self_model.derived import DerivedRead, compute_baseline, compute_derived
+
+NOW = datetime(2026, 8, 22, tzinfo=UTC)
 
 
 def _mem(emotions: dict, age_days: float) -> Memory:
-    m = Memory.create_new(
-        content="x",
-        memory_type="episodic",
-        domain="chat",
-        emotions=emotions,
-    )
-    object.__setattr__(m, "created_at", datetime.now(UTC) - timedelta(days=age_days))
+    m = Memory.create_new(content="x", memory_type="episodic", domain="chat", emotions=emotions)
+    object.__setattr__(m, "created_at", NOW - timedelta(days=age_days))
     return m
 
 
-def test_derived_is_recent_window_peak_excluding_old_peaks():
-    """Windowed peak: a high-intensity OLD memory beyond the recent window does
-    NOT contribute; only the recent window's peaks do.
+def test_derived_short_read_is_recency_weighted_mean_not_max_not_plainmean():
+    """An old high grief (9.0, 10d) + a recent low grief (3.0, 0d): the SHORT read
+    is a recency-weighted mean — the recent event dominates (result well below the
+    old peak and below a plain mean), but the old event still contributes (result
+    strictly above the recent value, i.e. down-weighted, NOT excluded).
 
-    (Replaces the old recency-MEAN contract — the derived read is now a peak
-    over the most-recent _RECENT_WINDOW_COUNT memories, commensurable with the
-    declared lifetime peak. The two diverge only when a channel's peak is older
-    than the window — an honest "I claim this but haven't felt it lately" gap.)
+    Fails against: a max-pool stub (→ 9.0), a plain-mean stub (→ 6.0), and a
+    window-EXCLUSION stub that drops the old event (→ exactly 3.0).
     """
-    # 31 recent grief memories + 1 old joy peak. With a 30-memory window the
-    # oldest (joy) falls outside the window → derived sees grief, not joy.
-    mems = [_mem({"grief": 3.0}, age_days=0) for _ in range(31)]
-    mems.append(_mem({"joy": 9.0}, age_days=60))
-    out = compute_derived(mems, body_energy=5, body_exhaustion=2)
-    assert isinstance(out, DerivedRead)
-    assert out.channels.get("grief", 0) == 3.0
-    assert out.channels.get("joy", 0) == 0.0  # old peak excluded by the recent window
+    mems = [_mem({"grief": 9.0}, age_days=10), _mem({"grief": 3.0}, age_days=0)]
+    short = compute_derived(mems, body_energy=5, body_exhaustion=2, now=NOW).channels["grief"]
+    assert 3.0 < short < 4.5, f"short={short} (recency-weighted mean expected ~3.5)"
+    # long read weights the old event more → baseline above the short read (death cross)
+    long = compute_baseline(mems, now=NOW).channels["grief"]
+    assert long > short, f"long={long} should exceed short={short} (recent below baseline)"
 
 
-def test_identical_recent_and_peak_signals_no_divergence():
-    """One memory: recency-mean == max-pool == same vector → derived ~ declared."""
+def test_single_event_channel_short_equals_long_equals_value():
+    """One event for a channel → short == long == its intensity (weight cancels),
+    so a genuinely steady/one-off channel produces no gap."""
     mems = [_mem({"loneliness": 4.0}, age_days=1)]
-    out = compute_derived(mems, body_energy=5, body_exhaustion=2)
-    assert abs(out.channels.get("loneliness", 0) - 4.0) < 1.5  # close to the single value
+    short = compute_derived(mems, body_energy=5, body_exhaustion=2, now=NOW).channels["loneliness"]
+    long = compute_baseline(mems, now=NOW).channels["loneliness"]
+    assert short == 4.0 and long == 4.0
+
+
+def test_non_bearing_padding_is_invisible_constraint1():
+    """Padding with memories bearing OTHER channels does not move a fixed channel
+    (each channel is normalized by its OWN event weights)."""
+    base = [_mem({"grief": 6.0}, age_days=1), _mem({"grief": 8.0}, age_days=5)]
+    pad = [_mem({"fear": 5.0}, age_days=0.1 * i) for i in range(50)]
+    s0 = compute_derived(base, body_energy=5, body_exhaustion=2, now=NOW).channels["grief"]
+    s1 = compute_derived(base + pad, body_energy=5, body_exhaustion=2, now=NOW).channels["grief"]
+    assert s0 == s1
 
 
 def test_empty_memories_fails_open_to_no_gap():
-    out = compute_derived([], body_energy=5, body_exhaustion=2)
-    assert out.channels == {} or all(v == 0 for v in out.channels.values())
+    out = compute_derived([], body_energy=5, body_exhaustion=2, now=NOW)
+    assert out.channels == {}
     assert out.unnamed_pressure == 0.0
+    assert compute_baseline([], now=NOW).channels == {}
 
 
 def test_compute_derived_never_raises_on_bad_input():
     """A memory with None emotions must not crash (fail-open)."""
     bad = _mem({}, age_days=1)
     object.__setattr__(bad, "emotions", None)
-    out = compute_derived([bad], body_energy=5, body_exhaustion=2)
+    out = compute_derived([bad], body_energy=5, body_exhaustion=2, now=NOW)
     assert isinstance(out, DerivedRead)
 
 
-# ─── Task 1b ───────────────────────────────────────────────────────────────
-
-
 def test_ordinary_state_zero_unnamed_pressure():
-    """R-E5: ordinary body state (energy=5, exhaustion=2) yields exactly 0.0."""
+    """Ordinary body state (energy=5, exhaustion=2) yields exactly 0.0."""
     mems = [_mem({"joy": 3.0}, age_days=1), _mem({"loneliness": 2.0}, age_days=2)]
-    out = compute_derived(mems, body_energy=5, body_exhaustion=2)
+    out = compute_derived(mems, body_energy=5, body_exhaustion=2, now=NOW)
     assert out.unnamed_pressure == 0.0
 
 
 def test_strong_bodily_signal_with_no_channel_home_flags_pressure():
-    """High exhaustion + depleted energy but NO low-arousal emotion memories.
-
-    exhaustion=9, energy=1 → extreme low-arousal body state.
-    Only memory is faint, stale joy — not a low-arousal channel.
-    Residual body signal that cannot be absorbed → unnamed_pressure > 0.
-    """
-    mems = [_mem({"joy": 1.0}, age_days=30)]  # faint, stale, joy only
-    out = compute_derived(mems, body_energy=1, body_exhaustion=9)
+    """Extreme low-arousal body (energy=1, exhaustion=9) with NO low-arousal channel
+    in history → residual reported as unnamed_pressure > 0."""
+    mems = [_mem({"joy": 1.0}, age_days=30)]  # joy is not a low-arousal channel
+    out = compute_derived(mems, body_energy=1, body_exhaustion=9, now=NOW)
     assert out.unnamed_pressure > 0.0
 
 
-# ─── Windowed-peak regression (self_model_state.json magnitude-354 artifact) ──
-
-
-def test_recent_diverse_channels_no_dilution_artifact():
-    """Regression for the live magnitude-354 bug.
-
-    With many memories EACH carrying a different channel at peak (the normal
-    shape of a real persona — any one channel appears in only a fraction of
-    memories), the old total-mass-normalised derived diluted every channel to
-    a small fraction of its peak, so the gap vs declared (max-pool peak) was a
-    large uniform-negative offset (~N_channels × peak). The windowed peak reads
-    each recently-felt channel at its actual peak → derived ≈ declared → the
-    gap is small.
-    """
-    from brain.emotion.aggregate import aggregate_state
+def test_diverse_channels_no_dilution_artifact():
+    """Regression for the live magnitude-354 bug. Many memories EACH carrying a
+    different channel at a constant intensity: each channel's short and long reads
+    are ~equal (constant intensity) → the gap is ~0, not a large uniform offset."""
     from brain.self_model.gap import compute_gap
 
     chans = ["joy", "grief", "curiosity", "love"]
     mems = [_mem({chans[i % len(chans)]: 7.0}, age_days=i % 3) for i in range(40)]
-    declared = aggregate_state(mems)
-    derived = compute_derived(mems, body_energy=5, body_exhaustion=2)
-    gap = compute_gap(declared, derived)
+    short = compute_derived(mems, body_energy=5, body_exhaustion=2, now=NOW)
+    long = compute_baseline(mems, now=NOW)
+    gap = compute_gap(short, long)
     assert gap.magnitude < 3.0, f"dilution artifact present: magnitude={gap.magnitude:.1f}"

--- a/tests/unit/brain/self_model/test_gap.py
+++ b/tests/unit/brain/self_model/test_gap.py
@@ -1,47 +1,68 @@
-"""Tests for brain/self_model/gap.py — compute_gap (R-C1 orthogonality assertion).
+"""Tests for brain/self_model/gap.py — compute_gap(short, long).
 
-Load-bearing: divergent declared/derived → non-zero gap (R-C1);
-              identical → zero (R-C1 converse).
+Load-bearing:
+  - a genuine short-vs-long divergence (|delta| >= noise floor) → non-zero gap,
+    bidirectional (short − long);
+  - identical short/long, or a sub-floor divergence → magnitude exactly 0.0;
+  - unregistered channels dropped; unnamed_pressure carried through from short.
 """
 
 from __future__ import annotations
 
-from brain.emotion.state import EmotionalState
 from brain.self_model.derived import DerivedRead
-from brain.self_model.gap import compute_gap
+from brain.self_model.gap import _GAP_NOISE_FLOOR, compute_gap
 
 
-def test_divergent_declared_vs_derived_nonzero_gap():
-    """R-C1: declared peak-joy vs derived trend-grief → magnitude > 0."""
-    declared = EmotionalState(emotions={"joy": 9.0})          # max-pool peak
-    derived = DerivedRead(channels={"grief": 5.0, "joy": 1.0}, unnamed_pressure=0.0, sources={})
-    gap = compute_gap(declared, derived)
+def test_divergent_short_vs_long_nonzero_gap():
+    """Recent grief above baseline (short 5.0 vs long 0) → golden cross, magnitude > 0."""
+    short = DerivedRead(channels={"grief": 5.0, "joy": 1.0}, unnamed_pressure=0.0, sources={})
+    long = DerivedRead(channels={"joy": 1.0}, unnamed_pressure=0.0, sources={})  # no grief baseline
+    gap = compute_gap(short, long)
     assert gap.magnitude > 0
-    assert gap.per_channel.get("grief", 0) > 0  # derived sees grief declared doesn't
+    assert gap.per_channel.get("grief", 0) > 0  # short sees grief long doesn't (golden)
+    assert "joy" not in gap.per_channel  # joy identical → below floor → dropped
 
 
 def test_identical_signals_zero_gap():
-    """R-C1 converse: identical declared and derived → magnitude exactly 0.0.
-
-    Use a REGISTERED channel (grief) so the zero comes from equal deltas, not
-    from gap.py filtering an unregistered channel out.
-    """
-    declared = EmotionalState(emotions={"grief": 4.0})
-    derived = DerivedRead(channels={"grief": 4.0}, unnamed_pressure=0.0, sources={})
-    gap = compute_gap(declared, derived)
+    """Identical short and long → magnitude exactly 0.0 (registered channel, equal deltas)."""
+    short = DerivedRead(channels={"grief": 4.0}, unnamed_pressure=0.0, sources={})
+    long = DerivedRead(channels={"grief": 4.0}, unnamed_pressure=0.0, sources={})
+    gap = compute_gap(short, long)
     assert gap.magnitude == 0.0
 
 
-def test_gap_per_channel_is_derived_minus_declared_registered_only():
-    """Unregistered channels dropped; registered delta = derived − declared."""
-    declared = EmotionalState(emotions={"joy": 3.0})
-    derived = DerivedRead(channels={"joy": 1.0, "zorblefright": 9.0}, unnamed_pressure=0.0, sources={})
-    gap = compute_gap(declared, derived)
+def test_gap_per_channel_is_short_minus_long_registered_only():
+    """Unregistered channels dropped; registered delta = short − long (bidirectional)."""
+    short = DerivedRead(channels={"joy": 1.0, "zorblefright": 9.0}, unnamed_pressure=0.0, sources={})
+    long = DerivedRead(channels={"joy": 3.0}, unnamed_pressure=0.0, sources={})
+    gap = compute_gap(short, long)
     assert "zorblefright" not in gap.per_channel  # registered channels only
-    assert gap.per_channel.get("joy") == -2.0
+    assert gap.per_channel.get("joy") == -2.0  # death cross, short below long
 
 
-def test_gap_carries_unnamed_pressure_through():
-    """unnamed_pressure from the derived read passes through to Gap unchanged."""
-    gap = compute_gap(EmotionalState(emotions={}), DerivedRead({}, 0.4, {}))
+def test_noise_floor_drops_sub_threshold_channels_keeps_genuine():
+    """A |delta| < floor channel is dropped; a >= floor channel survives at full delta."""
+    small = _GAP_NOISE_FLOOR - 0.1
+    big = _GAP_NOISE_FLOOR + 0.5
+    short = DerivedRead(channels={"joy": 5.0 + small, "grief": 5.0 + big}, unnamed_pressure=0.0, sources={})
+    long = DerivedRead(channels={"joy": 5.0, "grief": 5.0}, unnamed_pressure=0.0, sources={})
+    gap = compute_gap(short, long)
+    assert "joy" not in gap.per_channel  # sub-floor → dropped
+    assert abs(gap.per_channel.get("grief") - big) < 1e-9  # genuine cross survives, full delta
+    assert abs(gap.magnitude - big) < 1e-9
+
+
+def test_gap_carries_unnamed_pressure_through_from_short():
+    """unnamed_pressure from the short (felt) read passes through to Gap unchanged."""
+    gap = compute_gap(DerivedRead({}, 0.4, {}), DerivedRead({}, 0.0, {}))
     assert gap.unnamed_pressure == 0.4
+
+
+def test_noise_floor_equals_ambient_channel_floor_invariant():
+    """The gap noise floor is intentionally equal to the ambient block's naming
+    floor (surface only what is loud enough to name). The two are declared as
+    separate local constants to avoid an import cycle; lock the documented
+    equality so a future edit to one cannot silently drift from the other."""
+    from brain.self_model.ambient import _CHANNEL_FLOOR
+
+    assert _GAP_NOISE_FLOOR == _CHANNEL_FLOOR


### PR DESCRIPTION
## What
Fixes the ambient-emotion self-model gap (#148) and makes the reconcile tool reachable (#149).

**The bug (#148):** the gap (`derived − declared`) compared a recent MAX (last 30 memories) against a lifetime MAX (all ~200) of the *same* emotion vector, so it was one-sided-negative by construction and rendered to the companion as an authenticity verdict ("performing, not inhabiting") that fired near-universally negative.

**The fix:**
- **Math:** `derived` and `declared` become a short vs long **time-weighted mean** over each channel's own bearing events (EMA half-lives 3 days / 30 days), so the gap is bidirectional (above/below recent baseline). The `+0.4` nudge is removed; a per-channel 0.5 noise floor keeps only genuine crosses. Both constraints the prior windowed-peak fix (`00cec25c`) defended are verified safe: no mass-normalized-mean dilution (300-memory pad → Δ 0.0) and away-persona safe (21-day idle → Δ <1e-9). Discrimination: rising +0.68 / falling −1.03 / steady 0.
- **Framing:** the ambient block and the Haiku note prompt (`ambient.py`, `articulate.py`) are rewritten as neutral present-tense "weather language," no authenticity verdict, authored to the persona's own preference.
- **Reconcile reachability (#149):** `select_tools` gains a `gap_open` kwarg set from the already-persisted `current_gap.status`, so `reconcile_self_read` is offered when a gap is open — no `SalienceSignal` change, not always-on. Safe now that the M fix makes gaps occasional.

## Notes
- Self-model subsystem, separate from the Phases 0-2 memory rework — branches off `main`.
- The gap is decoupled from the widely-shared `aggregate_state` (left untouched).
- Root-caused + red-teamed (4 cold plan reviews + a cold code review). CI green except the pre-existing `#136` date-brittle test (identical failure on base).

## Also folded in (self-model note bugs surfaced while live-testing this)
- **Weather-note literal-forecast leak (#153):** the articulate prompt's `What's the weather?` was answered literally by the substrate model (offering a forecast / asking for a location). Reframed to `What's the (metaphorical) weather?`; Haiku 10/10 -> 0/10 leak.
- **Note call mis-routed to the chat model (#152):** the articulate call inherited the persona chat model (Sonnet) instead of Haiku (no `model_override`). Added `build_self_model_provider` (mirrors compaction) to force Haiku; usage-log label now derives from the provider.
- **Docs:** a `docs/Behavioral_Observations.md` entry on small models taking prompts literally.

Fixes #148
Fixes #149
Fixes #152
Fixes #153

