### PR TITLE
Green the CI matrix: windows path assertion + systemd de-flake (#160)

### DIFF
--- a/tests/integration/test_systemd_install.py
+++ b/tests/integration/test_systemd_install.py
@@ -14,7 +14,10 @@ When the test runs it verifies:
   3. The unit file's ``ExecStart`` line contains
      ``--client-origin systemd`` (proves the systemd backend was
      invoked, not the launchd one).
-  4. The service reaches ``active`` or ``activating`` state.
+  4. systemd loads the unit (``LoadState=loaded``). Deliberately not
+     ``is-active``: the unit's bridge has no persona to boot under the
+     test's bare ``KINDLED_HOME``, so asserting liveness races its exit
+     (#160).
 
 Teardown via ``nell service uninstall --persona ci_test`` runs in a
 ``try/finally`` so a mid-test assertion failure still cleans up.
@@ -61,8 +64,8 @@ def _systemd_user_available() -> bool:
         return False
 
 
-def test_install_creates_unit_file_and_starts(tmp_path: Path) -> None:
-    """Round-trip: install → assert unit file + active state → uninstall."""
+def test_install_creates_unit_file_and_systemd_loads_it(tmp_path: Path) -> None:
+    """Round-trip: install → assert unit file + systemd loaded it → uninstall."""
     if not _systemd_user_available():
         pytest.skip("systemd --user not available on this host (expected in CI containers)")
 
@@ -116,16 +119,32 @@ def test_install_creates_unit_file_and_starts(tmp_path: Path) -> None:
             f"unit file ExecStart should contain '--client-origin systemd':\n{unit_content}"
         )
 
-        # 4. Service should be active or activating.
-        status = subprocess.run(
-            ["systemctl", "--user", "is-active", "companion-emergence-ci_test"],
+        # 4. systemd must have LOADED the unit — i.e. parsed it and accepted it
+        #    into the user manager. This is what `service install` actually owns.
+        #
+        #    Deliberately NOT `is-active`: KINDLED_HOME here is a bare tmp_path with
+        #    no persona dir, so the bridge the unit starts exits almost immediately.
+        #    Polling is-active right after install races that exit — a fast crash
+        #    reports "failed", a slow one is still "activating" — which is the
+        #    intermittent failure in #160. Bridge boot-success is a different
+        #    subject with different preconditions; it is not this test's claim.
+        load_state = subprocess.run(
+            [
+                "systemctl",
+                "--user",
+                "show",
+                "-p",
+                "LoadState",
+                "--value",
+                "companion-emergence-ci_test",
+            ],
             capture_output=True,
             text=True,
             timeout=10,
         )
-        active_state = status.stdout.strip()
-        assert active_state in ("active", "activating"), (
-            f"service not active after install; is-active returned: {active_state!r}"
+        assert load_state.stdout.strip() == "loaded", (
+            "systemd did not load the installed unit; "
+            f"LoadState={load_state.stdout.strip()!r} stderr={load_state.stderr!r}"
         )
 
     finally:

--- a/tests/unit/brain/bridge/test_provider_cwd_shadow.py
+++ b/tests/unit/brain/bridge/test_provider_cwd_shadow.py
@@ -91,4 +91,6 @@ def test_safe_path_prevents_cwd_shadow(tmp_path: Path) -> None:
     )
     # The fix: -P drops the cwd entry, so brain resolves from the installed/venv location.
     assert str(shadow) not in with_p, f"-P failed to prevent the cwd shadow (got {with_p})"
-    assert with_p.endswith("brain/__init__.py"), with_p
+    # str(Path) is OS-native — on Windows this string uses backslashes, so a
+    # POSIX literal can never match. as_posix() normalises; it is a no-op off Windows.
+    assert Path(with_p).as_posix().endswith("brain/__init__.py"), with_p


### PR DESCRIPTION
Two test-only fixes. No product code touched — both failures are defects in the assertions.

## 1. windows-latest CI red (no issue — diagnosed here)

`tests/unit/brain/bridge/test_provider_cwd_shadow.py:94` compared an OS-native
path string against the POSIX literal `"brain/__init__.py"`, which can never
match on Windows. This is the standing windows-latest red on `main` — present
in every run examined, including the latest merge (run 33224874558 @ 33bf0fe3):

```
assert with_p.endswith("brain/__init__.py")
AssertionError: D:\a\companion-emergence\companion-emergence\brain\__init__.py
```

Fixed with `Path(with_p).as_posix()`. Lines 90/93 were left alone — they compare
`str(shadow)` against the same OS-native string, so both sides already agree.

## 2. #160 — systemd install flake

`KINDLED_HOME` is a bare `tmp_path` with no persona dir, so the unit's bridge
exits almost immediately. Polling `is-active` right after install races that exit
(fast crash → `failed`, slow → `activating`), which is the reported 2-of-3 pass
rate. Now asserts `LoadState=loaded` — what `service install` actually owns.
Test renamed to match its claim.

Caveat: the test self-skips on macOS and on GitHub ubuntu runners (no live
`systemd --user`), so this assertion is reasoned, not executed. Logged as a
validation gap.

Fixes #160

## 3. #155 / #161 — no code change

Investigated and found no evidence behind either issue; see the comments posted on them. The hunt ledgers stay local — `hunts/` is gitignored and `docs/superpowers/` is a leak-guard denied path.

## Overlap note

`tests/unit/brain/bridge/test_provider_cwd_shadow.py` is also touched by #123/#127.
This is a one-line, test-only change and should rebase trivially.