### PR TITLE
Correct the false 'never tracked' comment on docs/guarded-change

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -146,8 +146,13 @@ hunts/
 changes/
 app/src-tauri/python-runtime/
 
-# ── Leak-guard local tier + private local docs (never tracked) ──
+# ── Leak-guard local tier + private local docs ──
 hooks/leak-rules.local
+# docs/guarded-change/ is NOT "never tracked": 52 files under it were committed
+# before this rule and are live on origin/main. .gitignore does not apply to
+# already-tracked files, so this entry only stops NEW ones — which matches the
+# leak-guard's own wording in hooks/denied-paths.txt ("no new files here on
+# public"). The existing tree is frozen, not private. See #163.
 docs/guarded-change/
 CLAUDE.local.md
 CLAUDE.local.history.md


### PR DESCRIPTION
Comment-only change to `.gitignore`. No behaviour change.

## Why

`.gitignore:149` grouped `docs/guarded-change/` under a header reading "(never tracked)", alongside `hooks/leak-rules.local` and `CLAUDE.local.md`, which genuinely never are. But 52 files under `docs/guarded-change/` **are** tracked and live on `origin/main`, and `.gitignore` has no effect on already-tracked files — so the entry is inert for them and the comment is false.

That combination reads as "this tree is private" when it isn't, which is how someone ends up drawing the wrong conclusion about what is and isn't published.

The replacement comment states what is actually true: the entry stops *new* files only, which is precisely what `hooks/denied-paths.txt` intends ("no new files here on public"). The existing tree is frozen, not private.

## Verified

Ignore behaviour is byte-for-byte identical — checked before and after:

| Path | Ignored? |
|---|---|
| `CLAUDE.local.md` | yes |
| `hooks/leak-rules.local` | yes |
| `docs/guarded-change/NEWFILE.md` (hypothetical new file) | yes |

`git ls-files docs/guarded-change/` still returns 52 — tracked files remain tracked, as expected.

## Scope

This fixes only the misleading comment, which is the half of #163 that has one obviously-correct answer. #163's other two parts are left open and still need a decision:

- `docs/superpowers/` and `docs/audits/` are denied-at-push but not gitignored, so they remain stageable traps.
- Whether those 52 files *should* be public at all is a judgement call, not a comment fix.

Refs #163