### PR TITLE
docs: require per-issue Closes #N in the PR description

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,7 +49,9 @@ Do not create `WIP.md`, `CLAIMS.md`, `TODO.md`, or similar files intended to tra
 ## Commits and PRs
 
 - Commit messages: imperative mood, present tense ("fix provider path resolution," not "fixed" or "fixes").
-- If a commit or PR resolves an issue, include `Fixes #N` in the PR description so it auto-closes.
+- **Closing issues: one `Closes #N` line per issue, in the PR description.** For every issue a PR resolves, put a separate `Closes #N` line in the PR **description** — not in a commit body, not as a prose list. "closes #43; #72/#120" closes only #43; the bare `#72/#120` close nothing. Two issues means two lines: `Closes #72` and `Closes #120`. (`Fixes` and `Resolves` are equivalent keywords.)
+- **Squash-merge only honors keywords in the PR description.** On a squash-merge, GitHub ignores closing keywords in individual commit messages — so the `Closes #N` lines must live in the PR body to survive.
+- **Verify after merge.** Once merged, confirm each referenced issue actually closed and manually close any that didn't.
 - Don't squash unrelated changes into one commit. If the user is fixing two different things, suggest two branches.
 - **Out-of-scope follow-ups → a new issue, not a PR-body note.** When you spot follow-up work during a PR that's outside that PR's scope, file it as its own issue rather than leaving a "follow-up" note in the PR description — PR-body notes get lost on merge; issues stay tracked. (Human-facing version in `CONTRIBUTING.md`.)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,10 @@ Every bug, feature, or chunk of work gets an issue in the Issues tab.
 - **Before starting work**, check the Issues tab for anything related. If it exists, assign yourself (Assignees field, right sidebar). If it doesn't, open one and assign yourself.
 - **If an issue is assigned to the other person, don't start work on it** without talking first. They might be mid-thought on it even if there's no PR yet.
 - **Labels are optional** but `bug`, `enhancement`, and `question` are worth using so we can filter.
-- **Closing:** if your PR fixes an issue, put `Fixes #12` in the PR description. GitHub auto-closes the issue when the PR merges.
+- **Closing:** put a `Closes #12` line in the PR **description** — one per issue the PR resolves. GitHub auto-closes each when the PR merges. Three things that have bitten us:
+  - **One keyword per issue.** `Closes #12` closes #12; a prose list like "#12/#13" closes nothing. Two issues → two lines.
+  - **Squash-merge only reads the PR description,** not commit messages — so the `Closes` lines have to be in the PR body, not in a commit.
+  - **Check after merging** that each issue actually closed; manually close any that slipped through. (`Fixes` and `Resolves` work the same as `Closes`.)
 - **Out-of-scope follow-ups get their own issue, not a PR note.** If you notice separate follow-up work while doing a PR (a related bug, a deferred cleanup, a "should also do X later"), open an issue for it. A note buried in a PR description disappears once the PR merges; an issue stays on the board.
 
 ## Branches: never commit to main
@@ -120,4 +123,4 @@ If it's a decision that affects the code or the plan, it belongs in an issue or 
 | Mark work as ready | Click "Ready for review" on the draft PR |
 | Catch up to main | `git checkout main && git pull && git checkout your-branch && git merge main` |
 | Claim an issue | Assign yourself in the right sidebar of the issue |
-| Link a PR to an issue | Put `Fixes #N` in the PR description |
+| Close an issue with a PR | One `Closes #N` line per issue, in the PR description (squash-merge ignores commit-message keywords) |


### PR DESCRIPTION
Doc-only change addressing #186.

## What
Expand the "Commits and PRs" guidance in `CLAUDE.md` and mirror it in `CONTRIBUTING.md` so issue auto-close reliably fires:

- One `Closes #N` line **per issue**, in the PR **description** — a shared prose mention like "#72/#120" closes nothing.
- Note that squash-merge only honors closing keywords in the PR **description**, not in commit bodies.
- A post-merge verify step: confirm each referenced issue actually closed, and manually close any that didn't.

## Why
After the Phase 0-2 integration, several fully-resolved issues (#72, #120, #82, #158, #159) stayed OPEN because their PRs never triggered auto-close — bare references, or closing keywords that lived only in squash-dropped commit bodies.

The optional CI check floated in #186 is intentionally out of scope here (kept doc-only).

Closes #186
