### PR TITLE
fix(ci): green the two cascade demo tests and gitignore the denied-path traps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -154,6 +154,9 @@ hooks/leak-rules.local
 # leak-guard's own wording in hooks/denied-paths.txt ("no new files here on
 # public"). The existing tree is frozen, not private. See #163.
 docs/guarded-change/
+# Retired private trees (leak-guard denied-paths.txt) — never stage on public (#163).
+docs/superpowers/
+docs/audits/
 CLAUDE.local.md
 CLAUDE.local.history.md
 

--- a/tests/bridge/test_cascade_rollover_endpoints.py
+++ b/tests/bridge/test_cascade_rollover_endpoints.py
@@ -24,6 +24,7 @@ import uuid
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
+import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
@@ -473,8 +474,12 @@ def test_c21_flags_all_five_sites_on_pre_fix_base_commit() -> None:
         cwd=repo_root,
         capture_output=True,
         text=True,
-        check=True,
+        check=False,
     )
+    if result.returncode != 0:
+        # #169: the base commit was dropped by a branch rewrite and is reachable
+        # from no origin ref; CI's shallow checkout never has it. Skip, don't fail.
+        pytest.skip(f"base object unavailable in this clone: {result.stderr.strip()}")
     base_source = result.stdout
     blocks = _handler_blocks(base_source)
     failing = []

--- a/tests/unit/brain/chat/test_rollover.py
+++ b/tests/unit/brain/chat/test_rollover.py
@@ -18,6 +18,8 @@ import types
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
+import pytest
+
 from brain.chat.rollover import perform_rollover
 from brain.ingest.buffer import (
     ingest_turn,
@@ -148,8 +150,12 @@ def _load_old_pipeline_module() -> types.ModuleType:
         cwd=repo_root,
         capture_output=True,
         text=True,
-        check=True,
+        check=False,
     )
+    if result.returncode != 0:
+        # #169: the base commit was dropped by a branch rewrite and is reachable
+        # from no origin ref; CI's shallow checkout never has it. Skip, don't fail.
+        pytest.skip(f"base object unavailable in this clone: {result.stderr.strip()}")
     mod = types.ModuleType("old_pipeline_pre_finalize_decoupling")
     exec(compile(result.stdout, "<old_pipeline_c2154a97^>", "exec"), mod.__dict__)
     return mod

--- a/tests/unit/test_denied_paths_gitignored.py
+++ b/tests/unit/test_denied_paths_gitignored.py
@@ -1,0 +1,29 @@
+"""Every leak-guard denied path must also be gitignored (#163).
+
+A denied path that is not gitignored is a trap: it shows as untracked,
+can be staged, and is only rejected by the pre-push guard.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_REPO = Path(__file__).resolve().parents[2]
+_DENIED = _REPO / "hooks" / "denied-paths.txt"
+
+
+def _denied_paths() -> list[str]:
+    lines = _DENIED.read_text(encoding="utf-8").splitlines()
+    return [ln.strip() for ln in lines if ln.strip() and not ln.startswith("#")]
+
+
+@pytest.mark.parametrize("path", _denied_paths())
+def test_denied_path_is_gitignored(path: str) -> None:
+    probe = f"{path.rstrip('/')}/probe.txt"
+    result = subprocess.run(
+        ["git", "check-ignore", "-q", probe], cwd=_REPO, capture_output=True, text=True
+    )
+    assert result.returncode == 0, f"{path} is in denied-paths.txt but not .gitignore"


### PR DESCRIPTION
## Summary
Tier 0 of the 2026-09-04 issue triage: the two things keeping CI red or trapping contributors.

- **#169** — `test_c21_flags_all_five_sites_on_pre_fix_base_commit` and `test_c10_pre_change_finalize_deleted_buffer_fail_demo` `git show` commits `cd29bc61` / `c2154a97` that a branch rewrite dropped from every origin ref (verified: `git cat-file -t` fails even in a long-lived local clone, so the old content cannot be vendored). They now `pytest.skip` with the git error when the object is absent instead of failing with exit 128.
- **#163** — `docs/superpowers/` and `docs/audits/` are leak-guard denied paths but were not gitignored (stageable, rejected only at push). Added both to `.gitignore` plus `tests/unit/test_denied_paths_gitignored.py`, a parametrised canary asserting every entry in `hooks/denied-paths.txt` is ignored.

Fixes #169
Fixes #163

## Verification
- Red → green watched for the canary (2 failed on the two traps, then 4 passed).
- The two cascade tests: `2 failed` → `2 skipped` with reason `base object unavailable in this clone`.
- `ruff check tests/` clean. Full `uv run pytest` result posted below once complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)