### PR TITLE
fix(bridge): keep build_app's background threads out of tests; /chat/history follows the rollover pointer (#155, #161)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -154,6 +154,9 @@ hooks/leak-rules.local
 # leak-guard's own wording in hooks/denied-paths.txt ("no new files here on
 # public"). The existing tree is frozen, not private. See #163.
 docs/guarded-change/
+# Retired private trees (leak-guard denied-paths.txt) — never stage on public (#163).
+docs/superpowers/
+docs/audits/
 CLAUDE.local.md
 CLAUDE.local.history.md
 

--- a/brain/bridge/server.py
+++ b/brain/bridge/server.py
@@ -810,6 +810,7 @@ class BridgeAppState:
     in_flight_locks: dict[str, asyncio.Lock]
     last_chat_at: datetime | None = None
     supervisor_thread: Any | None = None
+    migration_thread: Any | None = None  # compaction-backlog-migration (None when background threads are off)
     auth_token: str | None = None
     shutdown_controller: BridgeShutdownController | None = None
 
@@ -817,6 +818,15 @@ class BridgeAppState:
 # ---------------------------------------------------------------------------
 # Lifespan + app factory
 # ---------------------------------------------------------------------------
+
+
+# Test-only inhibit for the lifespan's background threads (the supervisor and the
+# compaction-backlog-migration thread). Mirrors ``pass2_queue._worker_inhibited``:
+# the root ``tests/conftest.py`` sets it True so endpoint tests do not race a live
+# supervisor over the session they just seeded (hunts/bridge-order-pollution-flakes).
+# NOT an ops/user knob — no env var, no config; production never sets it. An
+# explicit ``build_app(background_threads=...)`` always wins over this flag.
+_background_threads_inhibited: bool = False
 
 
 def build_app(
@@ -828,6 +838,7 @@ def build_app(
     auth_token: str | None = None,
     shutdown_controller: BridgeShutdownController | None = None,
     allowed_origins: tuple[str, ...] = DEFAULT_ALLOWED_ORIGINS,
+    background_threads: bool | None = None,
 ) -> FastAPI:
     """Build a FastAPI app for the given persona. Public for tests + daemon.
 
@@ -839,10 +850,25 @@ def build_app(
     allowed_origins: WebSocket Origin header allowlist (extra defense
     against browser-based attacks if someone proxies localhost). "null"
     matches CLI/non-browser clients; "tauri://localhost" matches SP-8.
+
+    background_threads: start the supervisor + compaction-backlog-migration
+    threads in the lifespan. None (default) → ``not _background_threads_inhibited``,
+    resolved at lifespan-enter so a test may flip the flag after constructing the
+    app. Production (runner.py) passes nothing and the flag is False → threads on.
     """
 
     @asynccontextmanager
     async def lifespan(app: FastAPI) -> AsyncIterator[None]:
+        bg = (
+            background_threads
+            if background_threads is not None
+            else not _background_threads_inhibited
+        )
+        if not bg:
+            logger.warning(
+                "bridge lifespan: background threads OFF (supervisor + backlog migration "
+                "not started) — test/dev inhibit; production never sets this"
+            )
         # Per HA hardening: NO persistent SQLite stores held on app.state.
         # Each worker thread / handler opens its own per-call stores against
         # persona_dir. The lifespan only constructs the provider (stateless),
@@ -932,11 +958,14 @@ def build_app(
             except Exception:  # noqa: BLE001 — startup must not break on the migration
                 logger.exception("compaction backlog migration thread crashed")
 
-        threading.Thread(
-            target=_run_backlog_migration,
-            name="compaction-backlog-migration",
-            daemon=True,
-        ).start()
+        if bg:
+            mig_thread = threading.Thread(
+                target=_run_backlog_migration,
+                name="compaction-backlog-migration",
+                daemon=True,
+            )
+            mig_thread.start()
+            app.state.bridge.migration_thread = mig_thread
 
         # Spawn supervisor thread (non-daemon — joins on shutdown)
         from brain.bridge.supervisor import run_folded
@@ -952,22 +981,24 @@ def build_app(
             return lk is not None and lk.locked()
 
         stop_event = threading.Event()
-        sup_thread = threading.Thread(
-            target=run_folded,
-            kwargs={
-                "stop_event": stop_event,
-                "persona_dir": persona_dir,
-                "provider": provider,
-                "event_bus": bus,
-                "tick_interval_s": tick_interval_s,
-                "silence_minutes": silence_minutes,
-                "is_session_busy": _is_session_busy,
-            },
-            name="sp7-supervisor",
-            daemon=False,
-        )
-        sup_thread.start()
-        app.state.bridge.supervisor_thread = sup_thread
+        sup_thread: threading.Thread | None = None
+        if bg:
+            sup_thread = threading.Thread(
+                target=run_folded,
+                kwargs={
+                    "stop_event": stop_event,
+                    "persona_dir": persona_dir,
+                    "provider": provider,
+                    "event_bus": bus,
+                    "tick_interval_s": tick_interval_s,
+                    "silence_minutes": silence_minutes,
+                    "is_session_busy": _is_session_busy,
+                },
+                name="sp7-supervisor",
+                daemon=False,
+            )
+            sup_thread.start()
+            app.state.bridge.supervisor_thread = sup_thread
 
         # Idle-shutdown watcher (only if requested)
         idle_task = None
@@ -1039,11 +1070,12 @@ def build_app(
                 except Exception:
                     logger.exception("failed to record drain_errors to state file")
 
-            # 4. Stop supervisor thread
+            # 4. Stop supervisor thread (None when background threads are off)
             stop_event.set()
-            sup_thread.join(timeout=180.0)
-            if sup_thread.is_alive():
-                logger.warning("supervisor thread did not stop within 180s")
+            if sup_thread is not None:
+                sup_thread.join(timeout=180.0)
+                if sup_thread.is_alive():
+                    logger.warning("supervisor thread did not stop within 180s")
 
             # 5. Heartbeat close-trigger — anchor for Reflex Phase 2 weekly growth.
             #    In-process import + run_tick(trigger="close"). Best-effort:
@@ -2397,7 +2429,45 @@ def build_app(
         limit = max(1, min(int(limit), 1000))
 
         s: BridgeAppState = app.state.bridge
-        path = s.persona_dir / "active_conversations" / f"{session_id}.jsonl"
+        # Follow a rollover's ``rolled_to`` pointer like /chat does, so a renderer
+        # that reloads history after a rollover sees the successor's turns rather
+        # than an empty "fresh session" (hunts/bridge-order-pollution-flakes, C3).
+        # Divergences from /chat, deliberate for a read-only GET: an unresolvable
+        # (cyclic / corrupt) pointer falls back to the request sid with a WARNING
+        # instead of a 404; ``before_turn`` cursors are not translated across the
+        # redirect and the resolved sid is not echoed back (both deferred).
+        from brain.chat.session import resolve_successor
+        from brain.ingest.buffer import read_rolled_to
+
+        resolved = resolve_successor(s.persona_dir, session_id)
+        if resolved is None:
+            if read_rolled_to(s.persona_dir, session_id) is not None:
+                logger.warning(
+                    "chat_history: rolled_to pointer for %s is unresolvable (cyclic/corrupt); "
+                    "serving the request sid's own buffer",
+                    session_id,
+                )
+            resolved = session_id
+        elif not _BUFFER_SESSION_ID_RE.fullmatch(resolved):
+            # Defence in depth: resolve_successor's walk already validates each
+            # hop, so this branch is unreachable today; it guards a future walk
+            # change because the handler builds its own path and never passes
+            # through read_session's validation (stage-6 L-1).
+            logger.warning(
+                "chat_history: rolled_to successor %r for %s fails sid validation; "
+                "serving the request sid's own buffer",
+                resolved, session_id,
+            )
+            resolved = session_id
+        path = s.persona_dir / "active_conversations" / f"{resolved}.jsonl"
+        if not path.exists() and resolved == session_id:
+            # A rollover may have landed between our resolve and this stat:
+            # pointer written + old buffer deleted. Re-resolve once (stage-6 M-1/C-1)
+            # rather than report a "fresh session" for a conversation that exists.
+            again = resolve_successor(s.persona_dir, session_id)
+            if again is not None and _BUFFER_SESSION_ID_RE.fullmatch(again):
+                resolved = again
+                path = s.persona_dir / "active_conversations" / f"{resolved}.jsonl"
         if not path.exists():
             return ChatHistoryResponse(messages=[], next_before_turn=None)
 

--- a/brain/chat/session.py
+++ b/brain/chat/session.py
@@ -18,6 +18,7 @@ session id across a clean bridge restart.
 
 from __future__ import annotations
 
+import logging
 import threading
 import uuid
 from dataclasses import dataclass, field
@@ -33,6 +34,8 @@ from brain.bridge.chat import ChatMessage
 # fails. A high ceiling is fine; it never hits the prompt unless the
 # buffer is unreadable.
 HISTORY_MAX_TURNS = 5000
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -220,12 +223,16 @@ def get_or_hydrate_session(
         return state
 
 
-def _resolve_successor(persona_dir: Path, session_id: str) -> str | None:
+def resolve_successor(persona_dir: Path, session_id: str) -> str | None:
     """Full-follow the ``rolled_to`` successor chain from ``session_id`` to its live
     end. Returns the terminal successor sid (the one with no further pointer), or
-    None when ``session_id`` has no pointer at all OR the chain is cyclic (corrupt).
+    None when ``session_id`` has no pointer at all OR the chain is corrupt: cyclic,
+    or a pointer naming a sid that fails validation (a hand-edited / torn file).
     A visited-set guards a cycle — not a depth cap, so a long legitimate chain still
-    resolves (round-6 L-1)."""
+    resolves (round-6 L-1). Never raises on a corrupt pointer: the ``ValueError``
+    from the successor's sid validation is caught and logged so a GET on the
+    original (already validated) sid can fall back instead of 500-ing
+    (hunts/bridge-order-pollution-flakes, C3b)."""
     from brain.ingest.buffer import read_rolled_to
 
     visited: set[str] = set()
@@ -234,10 +241,20 @@ def _resolve_successor(persona_dir: Path, session_id: str) -> str | None:
         if cur in visited:
             return None  # cyclic pointer → abort to 404-then-reattach
         visited.add(cur)
-        nxt = read_rolled_to(persona_dir, cur)
+        try:
+            nxt = read_rolled_to(persona_dir, cur)
+        except ValueError as exc:
+            logger.warning(
+                "rolled_to chain from %s names an invalid successor %r: %s — treating as unresolvable",
+                session_id, cur, exc,
+            )
+            return None
         if nxt is None:
             return None if cur == session_id else cur
         cur = nxt
+
+
+_resolve_successor = resolve_successor  # internal callers (persist-side redirect) keep the old name
 
 
 def registry_lock() -> threading.RLock:

--- a/tests/bridge/test_build_app_background_threads.py
+++ b/tests/bridge/test_build_app_background_threads.py
@@ -1,0 +1,54 @@
+"""build_app must not start its background threads inside tests unless asked (C1/C2).
+
+Diagnosis: hunts/bridge-order-pollution-flakes/diagnosis.md — the supervisor thread that
+build_app's lifespan starts raced every bridge endpoint test's seeded session.
+"""
+
+from __future__ import annotations
+
+import threading
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from brain.bridge import server
+
+_BG = {"sp7-supervisor", "compaction-backlog-migration"}
+
+
+def _thread_names() -> set[str]:
+    return {t.name for t in threading.enumerate()}
+
+
+def test_default_in_tests_starts_no_background_threads(persona_dir: Path, caplog) -> None:
+    import logging
+
+    app = server.build_app(persona_dir=persona_dir, client_origin="tests")
+    with caplog.at_level(logging.WARNING, logger="brain.bridge.server"):
+        with TestClient(app) as c:
+            assert not (_thread_names() & _BG), _thread_names() & _BG
+            assert app.state.bridge.supervisor_thread is None
+            assert app.state.bridge.migration_thread is None
+            assert c.get("/health").json()["supervisor_thread"] == "not-started"
+    # The one operator-visible artifact of threads-off is the WARNING line (stage-6 F-1).
+    assert any("background threads OFF" in r.getMessage() for r in caplog.records)
+
+
+def test_flag_off_starts_both_threads(persona_dir: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Production value of the flag (False) + kwarg None → both threads run, as runner.py sees it."""
+    monkeypatch.setattr(server, "_background_threads_inhibited", False)
+    app = server.build_app(persona_dir=persona_dir, client_origin="tests")
+    with TestClient(app):
+        assert "sp7-supervisor" in _thread_names()
+        assert app.state.bridge.supervisor_thread.is_alive()
+        assert app.state.bridge.migration_thread is not None  # started (daemon; may already be done)
+    assert not app.state.bridge.supervisor_thread.is_alive()  # joined on lifespan exit
+
+
+def test_kwarg_true_overrides_inhibit(persona_dir: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(server, "_background_threads_inhibited", True)
+    app = server.build_app(persona_dir=persona_dir, client_origin="tests", background_threads=True)
+    with TestClient(app):
+        assert "sp7-supervisor" in _thread_names()
+        assert app.state.bridge.migration_thread is not None

--- a/tests/bridge/test_cascade_rollover_endpoints.py
+++ b/tests/bridge/test_cascade_rollover_endpoints.py
@@ -24,6 +24,7 @@ import uuid
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
+import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
@@ -473,8 +474,12 @@ def test_c21_flags_all_five_sites_on_pre_fix_base_commit() -> None:
         cwd=repo_root,
         capture_output=True,
         text=True,
-        check=True,
+        check=False,
     )
+    if result.returncode != 0:
+        # #169: the base commit was dropped by a branch rewrite and is reachable
+        # from no origin ref; CI's shallow checkout never has it. Skip, don't fail.
+        pytest.skip(f"base object unavailable in this clone: {result.stderr.strip()}")
     base_source = result.stdout
     blocks = _handler_blocks(base_source)
     failing = []

--- a/tests/bridge/test_chat_corrupt_pointer.py
+++ b/tests/bridge/test_chat_corrupt_pointer.py
@@ -1,0 +1,42 @@
+"""POST /chat on a session with a corrupt rolled_to pointer is a 404, not a 500 (C3b iii)."""
+
+from __future__ import annotations
+
+import json
+import uuid
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from brain.bridge.server import build_app
+
+
+def _seed(persona_dir: Path, sid: str, *, with_buffer: bool) -> None:
+    d = persona_dir / "active_conversations"
+    if with_buffer:
+        (d / f"{sid}.jsonl").write_text(
+            json.dumps({"session_id": sid, "speaker": "user", "text": "hi", "ts": "2026-05-20T10:00:00Z"})
+            + "\n",
+            encoding="utf-8",
+        )
+    (d / f"{sid}.rolled_to").write_text('{"successor": "../x"}', encoding="utf-8")
+
+
+def test_chat_invalid_successor_pointer_with_buffer_is_200_not_500(persona_dir: Path) -> None:
+    """Pointer corrupt but the sid's own buffer still exists → /chat serves that session."""
+    sid = str(uuid.uuid4())  # ChatReq requires a UUID-shaped session_id
+    _seed(persona_dir, sid, with_buffer=True)
+    app = build_app(persona_dir=persona_dir, client_origin="tests")
+    with TestClient(app, raise_server_exceptions=False) as c:
+        r = c.post("/chat", json={"session_id": sid, "message": "hello"})
+    assert r.status_code == 200, r.text
+
+
+def test_chat_invalid_successor_pointer_without_buffer_is_404_not_500(persona_dir: Path) -> None:
+    """Pointer corrupt and the old buffer already gone (post-rollover) → 404, never 500."""
+    sid = str(uuid.uuid4())
+    _seed(persona_dir, sid, with_buffer=False)
+    app = build_app(persona_dir=persona_dir, client_origin="tests")
+    with TestClient(app, raise_server_exceptions=False) as c:
+        r = c.post("/chat", json={"session_id": sid, "message": "hello"})
+    assert r.status_code == 404, r.text

--- a/tests/bridge/test_chat_history_endpoint.py
+++ b/tests/bridge/test_chat_history_endpoint.py
@@ -214,3 +214,66 @@ def test_history_early_break_closes_reader_generator(
         r = c.get("/chat/history", params={"session_id": "s_close", "before_turn": 3})
     assert r.status_code == 200
     assert closed["v"], "endpoint abandoned the buffer reader without closing it"
+
+
+# --------------------------------------------------------------------------- rollover pointer
+# hunts/bridge-order-pollution-flakes/diagnosis.md: /chat/history read the old buffer path
+# directly and returned [] after a rollover deleted it, unlike /chat which follows the
+# rolled_to pointer. Criteria C3 / C3b.
+
+
+def _two_turns(sid: str) -> list[dict]:
+    return [
+        {"session_id": sid, "speaker": "user", "text": "hi", "ts": "2026-05-20T10:00:00Z"},
+        {"session_id": sid, "speaker": "assistant", "text": "hello", "ts": "2026-05-20T10:00:05Z"},
+    ]
+
+
+def test_history_follows_rollover_pointer(persona_dir: Path) -> None:
+    from brain.chat.rollover import perform_rollover
+
+    _seed_buffer(persona_dir, "s_a", _two_turns("s_a"))
+    new_sid = perform_rollover(persona_dir, "s_a", persona_dir.name, seed_mode="tiers_plus_tail")
+    assert new_sid is not None
+    assert not (persona_dir / "active_conversations" / "s_a.jsonl").exists()
+
+    with _make_client(persona_dir) as c:
+        r = c.get("/chat/history", params={"session_id": "s_a"})
+    assert r.status_code == 200
+    body = r.json()
+    assert [m["content"] for m in body["messages"]] == ["hi", "hello"]
+    assert [m["role"] for m in body["messages"]] == ["user", "assistant"]
+
+
+def test_history_cyclic_pointer_falls_back_and_warns(persona_dir: Path, caplog) -> None:
+    import logging
+
+    _seed_buffer(persona_dir, "s_a", _two_turns("s_a"))
+    (persona_dir / "active_conversations" / "s_a.rolled_to").write_text(
+        '{"successor": "s_a"}', encoding="utf-8"
+    )
+    with caplog.at_level(logging.WARNING, logger="brain.bridge.server"):
+        with _make_client(persona_dir) as c:
+            r = c.get("/chat/history", params={"session_id": "s_a"})
+    assert r.status_code == 200
+    assert len(r.json()["messages"]) == 2  # falls back to the request sid's own buffer
+    assert any(
+        rec.name == "brain.bridge.server" and "rolled_to" in rec.getMessage() for rec in caplog.records
+    ), [rec.getMessage() for rec in caplog.records]
+
+
+def test_history_invalid_successor_falls_back_and_warns(persona_dir: Path, caplog) -> None:
+    import logging
+
+    _seed_buffer(persona_dir, "s_a", _two_turns("s_a"))
+    (persona_dir / "active_conversations" / "s_a.rolled_to").write_text(
+        '{"successor": "../x"}', encoding="utf-8"
+    )
+    with caplog.at_level(logging.WARNING):
+        with _make_client(persona_dir) as c:
+            r = c.get("/chat/history", params={"session_id": "s_a"})
+    assert r.status_code == 200, r.text
+    assert len(r.json()["messages"]) == 2
+    names = {rec.name for rec in caplog.records if rec.levelno >= logging.WARNING}
+    assert "brain.chat.session" in names, names  # the walk itself caught the bad successor
+    assert "brain.bridge.server" in names, names

--- a/tests/bridge/test_lifecycle.py
+++ b/tests/bridge/test_lifecycle.py
@@ -12,6 +12,10 @@ from brain.bridge.server import build_app
 
 
 def _client(persona_dir: Path, **kw) -> TestClient:
+    # This module tests the lifecycle itself (supervisor tick, pruning, shutdown drain),
+    # so it opts back INTO the background threads the root conftest inhibits for
+    # endpoint tests (hunts/bridge-order-pollution-flakes; C7 opt-in list).
+    kw.setdefault("background_threads", True)
     return TestClient(build_app(persona_dir=persona_dir, client_origin="tests", **kw))
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,6 +26,23 @@ def _reset_cli_throttle() -> Iterator[None]:
 
 
 @pytest.fixture(autouse=True)
+def _inhibit_bridge_background_threads(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep build_app's lifespan from starting the supervisor + migration threads.
+
+    Every bridge endpoint test enters build_app's lifespan; the real supervisor
+    thread it started ran a startup catch-up compaction that rolled over the
+    months-old session the test had just seeded and deleted its buffer, racing
+    the test's own request (hunts/bridge-order-pollution-flakes/diagnosis.md —
+    #155, #161, and the c8 / WinError-32 CI reds). Mirrors _reset_pass2_queue:
+    tests that genuinely exercise those threads pass background_threads=True.
+    """
+    from brain.bridge import server
+
+    # raising=False: a bisect onto a pre-flag commit must not error every test at setup.
+    monkeypatch.setattr(server, "_background_threads_inhibited", True, raising=False)
+
+
+@pytest.fixture(autouse=True)
 def _reset_pass2_queue() -> Iterator[None]:
     """Reset pass2_queue global state before and after each test.
 

--- a/tests/unit/brain/chat/test_rollover.py
+++ b/tests/unit/brain/chat/test_rollover.py
@@ -18,6 +18,8 @@ import types
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
+import pytest
+
 from brain.chat.rollover import perform_rollover
 from brain.ingest.buffer import (
     ingest_turn,
@@ -148,8 +150,12 @@ def _load_old_pipeline_module() -> types.ModuleType:
         cwd=repo_root,
         capture_output=True,
         text=True,
-        check=True,
+        check=False,
     )
+    if result.returncode != 0:
+        # #169: the base commit was dropped by a branch rewrite and is reachable
+        # from no origin ref; CI's shallow checkout never has it. Skip, don't fail.
+        pytest.skip(f"base object unavailable in this clone: {result.stderr.strip()}")
     mod = types.ModuleType("old_pipeline_pre_finalize_decoupling")
     exec(compile(result.stdout, "<old_pipeline_c2154a97^>", "exec"), mod.__dict__)
     return mod

--- a/tests/unit/brain/chat/test_session_resolve_successor.py
+++ b/tests/unit/brain/chat/test_session_resolve_successor.py
@@ -1,0 +1,21 @@
+"""resolve_successor never raises on a corrupt pointer (C3b, walk-level)."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+from brain.chat.session import _resolve_successor, resolve_successor
+
+
+def test_invalid_successor_pointer_returns_none_and_warns(tmp_path: Path, caplog) -> None:
+    d = tmp_path / "active_conversations"
+    d.mkdir()
+    (d / "s_a.rolled_to").write_text('{"successor": "../x"}', encoding="utf-8")
+    with caplog.at_level(logging.WARNING, logger="brain.chat.session"):
+        assert resolve_successor(tmp_path, "s_a") is None
+    assert any(rec.name == "brain.chat.session" for rec in caplog.records)
+
+
+def test_underscore_alias_kept() -> None:
+    assert _resolve_successor is resolve_successor

--- a/tests/unit/test_denied_paths_gitignored.py
+++ b/tests/unit/test_denied_paths_gitignored.py
@@ -1,0 +1,29 @@
+"""Every leak-guard denied path must also be gitignored (#163).
+
+A denied path that is not gitignored is a trap: it shows as untracked,
+can be staged, and is only rejected by the pre-push guard.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_REPO = Path(__file__).resolve().parents[2]
+_DENIED = _REPO / "hooks" / "denied-paths.txt"
+
+
+def _denied_paths() -> list[str]:
+    lines = _DENIED.read_text(encoding="utf-8").splitlines()
+    return [ln.strip() for ln in lines if ln.strip() and not ln.startswith("#")]
+
+
+@pytest.mark.parametrize("path", _denied_paths())
+def test_denied_path_is_gitignored(path: str) -> None:
+    probe = f"{path.rstrip('/')}/probe.txt"
+    result = subprocess.run(
+        ["git", "check-ignore", "-q", probe], cwd=_REPO, capture_output=True, text=True
+    )
+    assert result.returncode == 0, f"{path} is in denied-paths.txt but not .gitignore"


### PR DESCRIPTION
## Summary
Root cause of the "order-dependent" bridge flakes, found by a dragonfly hunt (`hunts/bridge-order-pollution-flakes/diagnosis.md`, local): every bridge endpoint test entered `build_app`'s lifespan, which started the **real supervisor thread** and the compaction-migration thread inside the test process. The supervisor's startup catch-up tick weekly-rolled-over the months-old session the test had just seeded and deleted its buffer mid-request. Proven with a reproduce-on-demand instrument and a causal toggle (S1 8/8 → 0/8; unforced `c8` 1-in-5 → 0/40). Not collection-order pollution: both tests fail in a single-test process with no preceding test once the race is widened. Same root explains the `c8` and Windows `WinError 32` CI reds on the open PR stack.

## Changes
- **`build_app(background_threads: bool | None = None)`** + module flag `server._background_threads_inhibited` (house pattern: `pass2_queue._worker_inhibited`). Resolved at lifespan-enter; explicit kwarg always wins; both thread starts and the supervisor join are guarded; a WARNING is logged when off. **No env var** — nothing outside the process can switch production off. `runner.py` passes nothing → threads on, unchanged.
- **Root `tests/conftest.py`** inhibits the threads for the whole suite. `tests/bridge/test_lifecycle.py` (which tests the supervisor tick / prune / shutdown drain) opts back in.
- **`/chat/history`** now follows the `rolled_to` pointer like `/chat` does (a real product bug: a renderer reloading history after a rollover saw an empty conversation), re-validates the resolved sid, warns + falls back on a cyclic/corrupt pointer, and re-resolves once if the buffer vanished between resolve and stat.
- **`resolve_successor`** (public name for `_resolve_successor`, alias kept) catches a corrupt successor's sid-validation `ValueError` inside the walk, so `/chat` and the persist-side redirect no longer 500 on a hand-corrupted pointer.
- `BridgeAppState.migration_thread` records the migration thread (None when off) so the tests have a deterministic oracle for a fast daemon.

Fixes #155
Fixes #161

## Verification (guarded-change loop, 3 plan reviews + 1 code review, all cold)
- Every new test watched red first: threads present (`AssertionError: {'sp7-supervisor'}`), `assert [] == ['hi', 'hello']`, missing WARNINGs, `ImportError` for the new name.
- Mutation proofs: guard inverted → the default and flag-off tests go red, kwarg-wins stays green; pre-change `session.py` stashed back → corrupt-pointer `/chat` returns `500`.
- Dragonfly instrument re-run post-fix: **0 background events, 0 failures** on every arm (was 7/25, 8/8, 8/8).
- Unforced `c8` × 40 → `40 passed` (was: failed on run 5).
- Full suite (CI filter, per-test timeout): `2 failed, 4600 passed` — the 2 are the #169 pair fixed in #188. `ruff check .` clean.
- Suite wall-clock: ~255 s → ~98 s, since no test spins up a supervisor any more.
- First full-suite attempt hung on `test_lifecycle.py` (blocking `receive_json` for a `supervisor_tick`); root-caused and fixed by the opt-in above.

## §Deferred (follow-up issues to file)
- `list_images` glob→read gap (sub-millisecond, self-heals next call; successor carries the shas).
- `is_session_busy` is inert for GET handlers (only `/chat` populates `in_flight_locks`).
- `/chat/history` paging cursor (`before_turn`) is not translated across a redirect; response does not echo the resolved sid.
- Production `WinError 32`: `save_with_backup_text` rename vs the supervisor's `PersonaConfig.load` (Windows only).
- `_BUFFER_SESSION_ID_RE` / `_SESSION_ID_RE` are duplicated constants kept in sync by a comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)