### PR TITLE
fix(cli): preserve conversation buffer on chat exit (#203)

### DIFF
--- a/brain/cli.py
+++ b/brain/cli.py
@@ -1717,7 +1717,12 @@ def _chat_direct_mode(args: argparse.Namespace) -> int:
     """
     from brain.chat.engine import respond
     from brain.chat.session import create_session
-    from brain.ingest.pipeline import close_session
+    from brain.ingest.pipeline import close_session, extract_session_snapshot
+
+    # #203: default exit is a NON-destructive snapshot (matches the GUI, which
+    # only ever calls /sessions/snapshot). close_session deletes the buffer,
+    # which starves cascade-compaction / archive / rollover. --close opts in.
+    flush_session = close_session if getattr(args, "close", False) else extract_session_snapshot
 
     persona_dir = get_persona_dir(args.persona)
     if not persona_dir.exists():
@@ -1755,7 +1760,7 @@ def _chat_direct_mode(args: argparse.Namespace) -> int:
                 # one-shot reply orphans its buffer file and no memories
                 # ever commit (live-exercise 2026-04-27 surfaced the bug).
                 try:
-                    close_session(
+                    flush_session(
                         persona_dir,
                         result.session_id,
                         store=store,
@@ -1800,7 +1805,7 @@ def _chat_direct_mode(args: argparse.Namespace) -> int:
             finally:
                 # Flush conversation through ingest pipeline (best-effort)
                 try:
-                    close_session(
+                    flush_session(
                         persona_dir,
                         session.session_id,
                         store=store,
@@ -2912,6 +2917,16 @@ def _build_parser() -> argparse.ArgumentParser:
         action="store_true",
         default=False,
         help="Bypass the bridge daemon and call engine.respond() in-process.",
+    )
+    chat_sub.add_argument(
+        "--close",
+        action="store_true",
+        default=False,
+        help=(
+            "On exit, finalise the session and delete its conversation buffer. "
+            "Default is a non-destructive snapshot that preserves the buffer "
+            "for compaction / archive / rollover (same as the GUI)."
+        ),
     )
     chat_sub.add_argument(
         "--bridge-only",

--- a/tests/unit/brain/test_cli_chat.py
+++ b/tests/unit/brain/test_cli_chat.py
@@ -69,19 +69,20 @@ def test_chat_one_shot_exits_zero() -> None:
     assert exit_code == 0
 
 
-def test_chat_one_shot_calls_close_session() -> None:
+def test_chat_one_shot_flushes_through_ingest() -> None:
     """One-shot mode must flush the conversation through the SP-4 ingest pipeline.
 
     Without this, every one-shot reply leaves the buffer file orphaned and no
     memories are ever committed (the bug the 2026-04-27 live-exercise stress
-    test surfaced — 0 ingest events across 20 prompts).
+    test surfaced — 0 ingest events across 20 prompts). Since #203 the flush
+    is the non-destructive snapshot, not close_session.
     """
-    with patch("brain.ingest.pipeline.close_session") as mock_close:
+    with patch("brain.ingest.pipeline.extract_session_snapshot") as mock_flush:
         exit_code = main(["chat", "--persona", "nell", "--no-bridge", "hello"])
     assert exit_code == 0
-    assert mock_close.call_count == 1
+    assert mock_flush.call_count == 1
     # First positional arg is persona_dir; second is session_id (must be set)
-    call_args = mock_close.call_args
+    call_args = mock_flush.call_args
     assert call_args.args[1]  # session_id non-empty
 
 
@@ -91,7 +92,9 @@ def test_chat_one_shot_close_failure_warns_not_raises() -> None:
     Mirrors the REPL's best-effort flush pattern (cli.py:828-845): persistence
     failures must never break the user-visible chat outcome.
     """
-    with patch("brain.ingest.pipeline.close_session", side_effect=RuntimeError("boom")):
+    with patch(
+        "brain.ingest.pipeline.extract_session_snapshot", side_effect=RuntimeError("boom")
+    ):
         with pytest.warns(RuntimeWarning, match="ingest flush failed"):
             exit_code = main(["chat", "--persona", "nell", "--no-bridge", "hello"])
     assert exit_code == 0
@@ -221,3 +224,74 @@ def test_chat_via_bridge_labels_reply_with_persona_name(
     assert rc == 0
     assert "phoebe: " in out
     assert "nell: " not in out
+
+
+# ── #203: exit preserves the buffer by default; --close deletes it ────────────
+
+
+def _ok_empty_extraction(*_a, **_k):
+    """Successful, empty extraction — the branch where close_session deletes."""
+    from brain.ingest.extract import ExtractionOutcome
+
+    return ExtractionOutcome(items=[])
+
+
+def test_chat_one_shot_preserves_buffer_on_disk(persona_dir: Path) -> None:
+    """Default exit is a non-destructive snapshot — the buffer file survives.
+
+    #203: close_session() deleted active_conversations/<sid>.jsonl on every
+    CLI exit, so cascade-compaction / archive / rollover never had anything to
+    act on. The GUI only ever snapshots; the CLI must match.
+
+    Extraction is patched to succeed — with the fake provider it fails, and a
+    failed close_session already retains the buffer, which would mask the bug.
+    """
+    with patch("brain.ingest.pipeline.extract_items_with_status", _ok_empty_extraction):
+        exit_code = main(["chat", "--persona", "nell", "--no-bridge", "hello"])
+    assert exit_code == 0
+    buffers = list((persona_dir / "active_conversations").glob("*.jsonl"))
+    assert len(buffers) == 1, buffers
+
+
+def test_chat_one_shot_default_snapshots_not_closes() -> None:
+    with (
+        patch("brain.ingest.pipeline.extract_session_snapshot") as mock_snap,
+        patch("brain.ingest.pipeline.close_session") as mock_close,
+    ):
+        exit_code = main(["chat", "--persona", "nell", "--no-bridge", "hello"])
+    assert exit_code == 0
+    assert mock_snap.call_count == 1
+    assert mock_snap.call_args.args[1]  # session_id non-empty
+    assert mock_close.call_count == 0
+
+
+def test_chat_one_shot_close_flag_deletes_buffer(persona_dir: Path) -> None:
+    with patch("brain.ingest.pipeline.extract_items_with_status", _ok_empty_extraction):
+        exit_code = main(["chat", "--persona", "nell", "--no-bridge", "--close", "hello"])
+    assert exit_code == 0
+    buffers = list((persona_dir / "active_conversations").glob("*.jsonl"))
+    assert buffers == []
+
+
+def test_chat_repl_default_snapshots_not_closes() -> None:
+    with (
+        patch("builtins.input", side_effect=["hello there", "exit"]),
+        patch("brain.ingest.pipeline.extract_session_snapshot") as mock_snap,
+        patch("brain.ingest.pipeline.close_session") as mock_close,
+    ):
+        exit_code = main(["chat", "--persona", "nell", "--no-bridge"])
+    assert exit_code == 0
+    assert mock_snap.call_count == 1
+    assert mock_close.call_count == 0
+
+
+def test_chat_repl_close_flag_calls_close_session() -> None:
+    with (
+        patch("builtins.input", side_effect=["hello there", "exit"]),
+        patch("brain.ingest.pipeline.extract_session_snapshot") as mock_snap,
+        patch("brain.ingest.pipeline.close_session") as mock_close,
+    ):
+        exit_code = main(["chat", "--persona", "nell", "--no-bridge", "--close"])
+    assert exit_code == 0
+    assert mock_close.call_count == 1
+    assert mock_snap.call_count == 0


### PR DESCRIPTION
## Summary
`nell chat` deleted its own conversation buffer on every exit (both one-shot and REPL) via `close_session()`, starving cascade-compaction / archive / rollover. The CLI now defaults to the non-destructive `extract_session_snapshot()` (same as the GUI's `/sessions/snapshot`) and adds `--close` to opt into the destructive finalise.

## Verification (root cause verified by reading, not recalled)
- `brain/cli.py` had two `close_session(...)` sites (one-shot + REPL `finally`); `extract_session_snapshot` takes identical kwargs, so the swap is a drop-in selected once via `flush_session`.
- **Test-first**: 5 new tests in `tests/unit/brain/test_cli_chat.py` were red before the change (`assert 0 == 1` buffers on disk; snapshot never called; `--close` unrecognised). Two legacy tests that encoded the old default were updated.
- Finding worth recording: with the fake provider extraction *fails*, and a failed `close_session` already retains the buffer, so an unpatched on-disk test passed against the bug. The on-disk tests patch `extract_items_with_status` to a successful empty outcome so `close_session` actually reaches its delete branch.

## Gate
- `uv run pytest`: 4675 passed, 6 failed. All 6 fail identically on `main` with this diff stashed (2× live claude-cli OAuth/422 in the agent shell, 2× dangling local `.claude/skills/caveman*` symlinks in `test_dropin_integration`, 1× `test_threading_safety` round-trip `committed 0`, 1× `test_emotion_backfill_model_tier` source-oracle). Pre-existing, not introduced here.
- `ruff check .` clean. `pnpm test` + `pnpm build` clean (frontend untouched).

Closes #203

🤖 Generated with [Claude Code](https://claude.com/claude-code)