### PR TITLE
fix(bridge): harden /chat/history and /images across rollover (#197 #199 #201)

### DIFF
--- a/app/src/bridge.ts
+++ b/app/src/bridge.ts
@@ -534,6 +534,8 @@ export interface ChatHistoryResponse {
   messages: ChatHistoryEntry[];
   /** Pagination cursor for the next older page — null when no more turns. */
   next_before_turn: number | null;
+  /** The sid actually served — differs from the request sid after a rollover redirect (#199). */
+  session_id?: string;
 }
 
 /**

--- a/brain/bridge/server.py
+++ b/brain/bridge/server.py
@@ -72,6 +72,7 @@ from brain.chat.session import (
 from brain.health.alarm import compute_pending_alarms
 from brain.health.jsonl_reader import iter_jsonl_skipping_corrupt
 from brain.health.walker import walk_persona
+from brain.ingest.buffer import _SESSION_ID_RE as _BUFFER_SESSION_ID_RE
 from brain.memory.embeddings import EmbeddingCache, FakeEmbeddingProvider
 from brain.memory.hebbian import HebbianMatrix
 from brain.memory.store import MemoryStore
@@ -777,13 +778,15 @@ class ChatHistoryResponse(BaseModel):
 
     messages: list[ChatHistoryEntry]
     next_before_turn: int | None
+    # The sid actually served — differs from the request sid after a rollover
+    # redirect (#199), mirroring /chat's echo of the resolved sid.
+    session_id: str
 
 
-# Buffer session_id grammar — matches brain.ingest.buffer._SESSION_ID_RE
-# so /chat/history can serve any legitimately written session file (UUIDs
-# from the bridge plus the ``sess_<8hex>`` fallback). Stricter than
+# Buffer session_id grammar — THE buffer grammar, imported rather than copied
+# (#201), so /chat/history can serve any legitimately written session file
+# (UUIDs from the bridge plus the ``sess_<8hex>`` fallback). Stricter than
 # ChatReq (which requires UUIDs) but still rejects path traversal.
-_BUFFER_SESSION_ID_RE = re.compile(r"^[A-Za-z0-9_-]{1,64}$")
 
 
 # ---------------------------------------------------------------------------
@@ -2344,7 +2347,8 @@ def build_app(
         # Collect (sha, first_ts) pairs from buffer files
         seen: dict[str, str] = {}  # sha → first_seen_ts
         if buffers_dir.is_dir():
-            for buf_path in sorted(buffers_dir.glob("*.jsonl")):
+
+            def _scan(buf_path: Path) -> None:
                 try:
                     for line in _read_jsonl_lines(buf_path):
                         turn_ts = line.get("ts") or line.get("at", "")
@@ -2363,6 +2367,21 @@ def build_app(
                         buf_path,
                         exc_info=True,
                     )
+
+            # A rollover can delete a globbed buffer (and write its successor)
+            # between this snapshot and the read — before OR during the read.
+            # If any globbed file is gone afterwards, re-glob once and scan
+            # only the paths not yet seen, so the successor's image_shas are
+            # served instead of a silent [] (#197). Dedupe is min-by-ts, so
+            # the extra scan is safe.
+            paths = sorted(buffers_dir.glob("*.jsonl"))
+            for buf_path in paths:
+                _scan(buf_path)
+            if any(not p.exists() for p in paths):
+                scanned = set(paths)
+                for buf_path in sorted(buffers_dir.glob("*.jsonl")):
+                    if buf_path not in scanned:
+                        _scan(buf_path)
 
         # Filter by before_ts
         if before_ts is not None:
@@ -2443,10 +2462,11 @@ def build_app(
         # Follow a rollover's ``rolled_to`` pointer like /chat does, so a renderer
         # that reloads history after a rollover sees the successor's turns rather
         # than an empty "fresh session" (hunts/bridge-order-pollution-flakes, C3).
-        # Divergences from /chat, deliberate for a read-only GET: an unresolvable
+        # Divergence from /chat, deliberate for a read-only GET: an unresolvable
         # (cyclic / corrupt) pointer falls back to the request sid with a WARNING
-        # instead of a 404; ``before_turn`` cursors are not translated across the
-        # redirect and the resolved sid is not echoed back (both deferred).
+        # instead of a 404. On a redirect the ``before_turn`` cursor is dropped
+        # (#199): it was computed against the OLD buffer's line index and means
+        # nothing against the successor's — serve the newest page instead.
         from brain.chat.session import resolve_successor
         from brain.ingest.buffer import read_rolled_to
 
@@ -2479,8 +2499,10 @@ def build_app(
             if again is not None and _BUFFER_SESSION_ID_RE.fullmatch(again):
                 resolved = again
                 path = s.persona_dir / "active_conversations" / f"{resolved}.jsonl"
+        if resolved != session_id:
+            before_turn = None
         if not path.exists():
-            return ChatHistoryResponse(messages=[], next_before_turn=None)
+            return ChatHistoryResponse(messages=[], next_before_turn=None, session_id=resolved)
 
         entries: list[ChatHistoryEntry] = []
         # 1-based line index = turn cursor. Corrupt lines are dropped by
@@ -2509,7 +2531,9 @@ def build_app(
         # order returned; older pages come back via ``before_turn``.
         trimmed = entries[-limit:]
         next_cursor = trimmed[0].turn if trimmed and len(entries) > len(trimmed) else None
-        return ChatHistoryResponse(messages=trimmed, next_before_turn=next_cursor)
+        return ChatHistoryResponse(
+            messages=trimmed, next_before_turn=next_cursor, session_id=resolved
+        )
 
     # ── POST /chat — JSON one-shot fallback ────────────────────────────────
     @app.post("/chat", dependencies=[Depends(require_http_auth)])

--- a/tests/bridge/test_chat_history_endpoint.py
+++ b/tests/bridge/test_chat_history_endpoint.py
@@ -54,7 +54,7 @@ def test_history_returns_empty_array_for_missing_session(persona_dir: Path) -> N
     with _make_client(persona_dir) as c:
         r = c.get("/chat/history", params={"session_id": "s_missing"})
         assert r.status_code == 200
-        assert r.json() == {"messages": [], "next_before_turn": None}
+        assert r.json() == {"messages": [], "next_before_turn": None, "session_id": "s_missing"}
 
 
 def test_history_returns_buffered_turns_in_order(persona_dir: Path) -> None:
@@ -277,3 +277,75 @@ def test_history_invalid_successor_falls_back_and_warns(persona_dir: Path, caplo
     names = {rec.name for rec in caplog.records if rec.levelno >= logging.WARNING}
     assert "brain.chat.session" in names, names  # the walk itself caught the bad successor
     assert "brain.bridge.server" in names, names
+
+
+# ── #199: echo the resolved sid; reset the cursor across a rollover redirect ──
+
+
+def test_history_echoes_session_id(persona_dir: Path) -> None:
+    _seed_buffer(persona_dir, "s_plain", _two_turns("s_plain"))
+    with _make_client(persona_dir) as c:
+        r = c.get("/chat/history", params={"session_id": "s_plain"})
+    assert r.status_code == 200
+    assert r.json()["session_id"] == "s_plain"
+
+
+def test_history_echoes_resolved_sid_after_rollover(persona_dir: Path) -> None:
+    from brain.chat.rollover import perform_rollover
+
+    _seed_buffer(persona_dir, "s_a", _two_turns("s_a"))
+    new_sid = perform_rollover(persona_dir, "s_a", persona_dir.name, seed_mode="tiers_plus_tail")
+    assert new_sid is not None
+
+    with _make_client(persona_dir) as c:
+        r = c.get("/chat/history", params={"session_id": "s_a"})
+    assert r.status_code == 200
+    assert r.json()["session_id"] == new_sid
+
+
+def test_history_resets_cursor_across_rollover_redirect(persona_dir: Path) -> None:
+    """A ``before_turn`` cursor was computed against the OLD buffer's line index.
+
+    Applying it to the successor's index returns a different window under the
+    same cursor (#199). On redirect the cursor is dropped and the newest page
+    of the successor is served instead.
+    """
+    from brain.chat.rollover import perform_rollover
+
+    turns = [
+        {"session_id": "s_a", "speaker": "user" if i % 2 == 0 else "assistant",
+         "text": f"t{i}", "ts": f"2026-01-01T00:00:{i:02d}Z"}
+        for i in range(6)
+    ]
+    _seed_buffer(persona_dir, "s_a", turns)
+    new_sid = perform_rollover(persona_dir, "s_a", persona_dir.name, seed_mode="tiers_plus_tail")
+    assert new_sid is not None
+
+    with _make_client(persona_dir) as c:
+        direct = c.get("/chat/history", params={"session_id": new_sid, "limit": 2}).json()
+        redirected = c.get(
+            "/chat/history", params={"session_id": "s_a", "limit": 2, "before_turn": 2}
+        ).json()
+    assert redirected["session_id"] == new_sid
+    # Cursor ignored on redirect → same newest page as a direct, cursorless read.
+    assert redirected["messages"] == direct["messages"]
+    assert redirected["next_before_turn"] == direct["next_before_turn"]
+
+
+# ── #201: one session-id grammar, not two copies kept in sync by a comment ──
+
+
+def test_history_sid_grammar_is_the_buffer_grammar() -> None:
+    """server.py must import the grammar, not re-compile its own copy.
+
+    ``re.compile`` caches identical patterns, so an ``is`` check between the
+    two names passes even with two literals — this is a source oracle instead.
+    """
+    import inspect
+
+    from brain.bridge import server
+    from brain.ingest import buffer
+
+    assert server._BUFFER_SESSION_ID_RE is buffer._SESSION_ID_RE
+    src = inspect.getsource(server)
+    assert "_BUFFER_SESSION_ID_RE = re.compile(" not in src

--- a/tests/bridge/test_images_list.py
+++ b/tests/bridge/test_images_list.py
@@ -237,6 +237,41 @@ class TestListImages:
             r = c.get("/images", headers=_auth_headers("secret"))
         assert r.status_code == 200
 
+    # ── #197: a buffer deleted between glob and read must not blank the list ──
+
+    def test_survives_buffer_vanishing_mid_scan(self, tmp_path: Path, monkeypatch):
+        """Simulate a rollover landing between ``glob`` and the read of a buffer.
+
+        The first read of the globbed buffer deletes it and writes its
+        successor (carrying the same ``image_shas``) — what ``perform_rollover``
+        does. Before #197 the vanished file yielded zero rows and the successor
+        was never in the glob snapshot, so the response was ``[]``.
+        """
+        import brain.bridge.server as server_mod
+
+        _patch_fake_provider(monkeypatch)
+        persona_dir = tmp_path / "test-persona"
+        persona_dir.mkdir()
+        sha, _ext = _write_real_image(persona_dir, "png")
+        turn = {"ts": "2026-05-01T10:00:00Z", "image_shas": [sha]}
+        old = _write_buffer(persona_dir, "old-sid", [turn])
+        real_read = server_mod._read_jsonl_lines
+        fired = False
+
+        def racing_read(path: Path):
+            nonlocal fired
+            if path == old and not fired:
+                fired = True
+                _write_buffer(persona_dir, "new-sid", [turn])
+                old.unlink()
+            yield from real_read(path)
+
+        monkeypatch.setattr(server_mod, "_read_jsonl_lines", racing_read)
+        with _make_client(persona_dir) as c:
+            r = c.get("/images")
+        assert r.status_code == 200
+        assert [x["sha"] for x in r.json()] == [sha]
+
 
 class TestServeImage:
     def test_serves_image_bytes(self, tmp_path: Path, monkeypatch):


### PR DESCRIPTION
## Summary
Three small, verified-at-HEAD defects in `brain/bridge/server.py`'s history/images handlers, deferred from #196. One PR because they share the file and the rollover mechanism.

- **#199** `/chat/history` echoes the resolved `session_id` and resets `before_turn` on a rollover redirect (the cursor was an index into the old buffer). Renderer already reloads from the top after a rollover, so dropping the cursor serves the newest page, which is what it expects.
- **#197** `/images` re-globs once after the scan if any globbed buffer vanished, scanning only unscanned paths. Covers a vanish before *or during* the read. Dedupe is min-by-ts so the extra scan is safe.
- **#201** import `_SESSION_ID_RE` from `brain.ingest.buffer` instead of a duplicate literal.

## Verification
- Root causes re-read at HEAD, not taken from the triage summary.
- **Test-first**: 5 new tests red before the change (`KeyError: 'session_id'` ×3; images `[] == [sha]`; #201 source oracle). One pre-existing test updated for the new response field.
- Finding worth recording: an `is` identity test for #201 passed *before* the fix because `re.compile` caches identical patterns. The regression test is a source-level oracle instead.
- The first #197 fix (re-glob when `is_file()` is false before the read) did not catch a vanish during the read; the test exposed it and the fix was restructured to check after the scan.

## Gate
- `uv run pytest`: 4675 passed, 6 failed. Same 6 as `main` @ 880e2522 with no diff applied (2× live claude-cli OAuth/422 in the agent shell, 2× dangling local `.claude/skills/caveman*` symlinks, #205, #206). Not introduced here.
- `ruff check .` clean. `pnpm test` + `pnpm build` clean.

Not in scope: #198 (which GETs should hold the session busy) needs a design ruling first.

Closes #197
Closes #199
Closes #201

🤖 Generated with [Claude Code](https://claude.com/claude-code)