### PR TITLE
test: unstick main CI (#205, #206)

### DIFF
--- a/tests/integration/brain/bridge/test_threading_safety.py
+++ b/tests/integration/brain/bridge/test_threading_safety.py
@@ -167,10 +167,15 @@ def test_chat_threaded_round_trip_no_silent_sqlite_drop(
         body = r.json()
         assert body["closed"] is True
 
-        # The load-bearing assertion: at least one memory committed. If the
-        # threading bug were back, committed would be 0 with errors > 0.
-        assert body["committed"] >= 1, (
-            f"expected >= 1 memory committed; got {body}\ncaplog: {caplog.text[:1000]}"
+        # The load-bearing assertion: the extracted memory reached persistence
+        # with no errors. If the threading bug were back, both counters would
+        # be 0 with errors > 0. Since #167 conversation-extraction labels route
+        # through the pending gate (``enqueued``) rather than a direct
+        # ``store.create`` (``committed``), so either counter proves the write
+        # landed (#206).
+        assert body["committed"] + body["enqueued"] >= 1 and body["errors"] == 0, (
+            f"expected >= 1 memory persisted with no errors; got {body}\n"
+            f"caplog: {caplog.text[:1000]}"
         )
 
     # Sanity: no SQLite cross-thread errors in the captured log.

--- a/tests/unit/brain/ingest/test_emotion_backfill_model_tier.py
+++ b/tests/unit/brain/ingest/test_emotion_backfill_model_tier.py
@@ -118,19 +118,22 @@ def test_oracle_fails_against_the_pre_fix_source(monkeypatch):
     assert _emotion_backfill_call_site_tier(pre_fix_src) is None
 
 
+# The last main commit BEFORE #194 completed the #154 tier routing (first
+# parent of its merge commit 5589f096). Pinned, not computed: the previous
+# ``git merge-base HEAD origin/main`` was only "pre-fix" while #154 lived on a
+# feature branch — once merged, every main checkout's merge-base was post-fix
+# and the oracle failed on main (#205).
+_PRE_154_BASE_SHA = "44b4d5227b791ccf0756294f08f82223e726a979"
+
+
 def _find_pre_154_base_sha() -> str | None:
-    """The commit this branch's #154 work is based on top of — the merge of
-    #166 per this project's handoff notes. Resolved dynamically (not
-    hardcoded) via the merge-base with origin/main, falling back to None
-    (skip) if that ref isn't available in this checkout (e.g. a shallow
-    clone or CI worker without the remote configured)."""
+    """Return the pinned pre-#154 sha if this checkout has it, else None (skip)
+    — e.g. a shallow clone on a CI worker."""
     result = subprocess.run(
-        ["git", "merge-base", "HEAD", "origin/main"],
+        ["git", "cat-file", "-e", f"{_PRE_154_BASE_SHA}^{{commit}}"],
         cwd=_REPO_ROOT,
         capture_output=True,
         text=True,
         check=False,
     )
-    if result.returncode != 0 or not result.stdout.strip():
-        return None
-    return result.stdout.strip()
+    return _PRE_154_BASE_SHA if result.returncode == 0 else None


### PR DESCRIPTION
## Summary
Main's `test.yml` has failed on every run since 2026-09-05 because two tests went stale when their subjects merged. Test-only fix, no production code touched.

- **#205** The C7 fail-capable oracle computed its "pre-fix" base as `git merge-base HEAD origin/main`. Once #154 landed on main, that base is post-fix, so the precondition asserts false. Now pinned to `44b4d522` (first parent of #194's merge commit). Verified by `git show` that this sha carries `_emotion_backfill_run(persona_dir, provider=provider)` and current main does not. Skips (not fails) when the checkout lacks the sha, e.g. a shallow clone.
- **#206** The threading round-trip asserted `committed >= 1`, but since #167 conversation-extraction labels go through the pending gate and are counted as `enqueued`. Now asserts `committed + enqueued >= 1 and errors == 0`, which is the property the test exists to guard: the write reached persistence and no cross-thread SQLite error occurred.

## Verification
- Both tests failed on `main` @ db0fec1a before the change (CI run for main and local run agree). Both pass after. Full file runs: 6 passed.
- `ruff check` clean. A pre-existing `ruff format` flag on the backfill test (a blank line after the module docstring) is untouched; CI runs `ruff check` only.

This also unblocks CI on #204 and #207, whose only failing check is #206's test.

Closes #205
Closes #206

🤖 Generated with [Claude Code](https://claude.com/claude-code)