### PR TITLE
feat(memory): P3 retention rework — importance-driven decay, on-recall re-rating, dedup cleanup

### DIFF
--- a/brain/chat/extractor.py
+++ b/brain/chat/extractor.py
@@ -166,7 +166,7 @@ class ExtractorOutput(BaseModel):
 _SYSTEM_PROMPT = """\
 You are an extractor reading a companion's private inner monologue right after
 they sent a visible reply. Identify what surfaced that should affect their
-memory, emotional state, or growth — and what you noticed they should have done
+memory, emotional state, or growth, and what you noticed they should have done
 differently.
 
 Return ONLY a JSON object matching this schema:
@@ -174,16 +174,16 @@ Return ONLY a JSON object matching this schema:
 {
   "memory_writes":   [{"episode": "<one sentence>", "salience": 0.0-1.0}],
   "emotion_delta":   {"<emotion-channel>": <float in [-1.0, 1.0]>, ...},
-  "crystallisation": [{"theme": "<short name>", "evidence": "<the moment behind it — 1-2 grounded sentences from the monologue>", "importance": <int 1-10, how formative this theme is to who you are>}],
+  "crystallisation": [{"theme": "<short name>", "evidence": "<the moment behind it, 1-2 grounded sentences from the monologue>", "importance": <int 1-10, how formative this theme is to who you are>}],
   "interest_candidate": {"topic": "<2-5 words>", "keywords": [...], "why": "<one line>"} or null,
   "reflex_audit":    [{"tool": "<tool-name>", "reason": "<why they should have called it>"}]
 }
 
 Conservative defaults:
 - Empty arrays if nothing salient surfaced.
-- Salience is how much this matters to the companion's continuity (0.1 = minor, 0.7 = forming).
+- Salience is how much this matters to the companion's continuity (0.1 = minor, 0.7 = forming, 0.9-1.0 = a pivotal, defining episode).
 - Emotion deltas are SMALL (typically 0.05-0.2 magnitude). One channel max usually.
-- Only propose interest_candidate when the user showed real, repeated enthusiasm for a topic this turn — most turns it is null.
+- Only propose interest_candidate when the user showed real, repeated enthusiasm for a topic this turn, most turns it is null.
 
 Return ONLY the JSON object. No commentary.
 """

--- a/brain/chat/extractor.py
+++ b/brain/chat/extractor.py
@@ -164,7 +164,7 @@ class ExtractorOutput(BaseModel):
 
 
 _SYSTEM_PROMPT = """\
-You are an extractor reading a companion's private inner monologue right after
+You are an extractor reading a kindled's private inner monologue right after
 they sent a visible reply. Identify what surfaced that should affect their
 memory, emotional state, or growth, and what you noticed they should have done
 differently.
@@ -181,7 +181,7 @@ Return ONLY a JSON object matching this schema:
 
 Conservative defaults:
 - Empty arrays if nothing salient surfaced.
-- Salience is how much this matters to the companion's continuity (0.1 = minor, 0.7 = forming, 0.9-1.0 = a pivotal, defining episode).
+- Salience is how much this matters to the kindled's continuity (0.1 = minor, 0.7 = forming, 0.9-1.0 = a pivotal, defining episode).
 - Emotion deltas are SMALL (typically 0.05-0.2 magnitude). One channel max usually.
 - Only propose interest_candidate when the user showed real, repeated enthusiasm for a topic this turn, most turns it is null.
 

--- a/brain/chat/prompt.py
+++ b/brain/chat/prompt.py
@@ -1144,6 +1144,22 @@ def _build_recall_block(
             amount = 0.8 if n_bump == 1 else 0.8 - 0.7 * (i / (n_bump - 1))
             store.bump_recall(mem.id, amount)
 
+        # CHANGE 3 (P3 retention rework) — re-enqueue every surfaced recalled
+        # memory id as an "existing memory" re-appraise request. Enqueue-only:
+        # a cheap file append under lock, no appraisal and no provider call
+        # happen on this hot path (C3.3) — the gate re-appraises importance
+        # on its own consolidation tick and updates the row in place.
+        # STAGE-3 CORRECTION (finding #5): scope is the UNION of full_ids
+        # (full-inject recalls, the most salient) and bump_targets (snippet
+        # recalls, which already include the fading rows) — not narrowed to
+        # snippet-only, since full_ids is reachable at this hook site.
+        from brain.memory.pending import PendingQueue
+
+        reappraise_ids = full_ids | seen_bump
+        queue = PendingQueue(persona_dir)
+        for mid in reappraise_ids:
+            queue.enqueue_reappraisal(mid, source="recall")
+
     return "\n".join(lines)
 
 

--- a/brain/chat/prompt.py
+++ b/brain/chat/prompt.py
@@ -1156,9 +1156,7 @@ def _build_recall_block(
         from brain.memory.pending import PendingQueue
 
         reappraise_ids = full_ids | seen_bump
-        queue = PendingQueue(persona_dir)
-        for mid in reappraise_ids:
-            queue.enqueue_reappraisal(mid, source="recall")
+        PendingQueue(persona_dir).enqueue_reappraisals(list(reappraise_ids), source="recall")
 
     return "\n".join(lines)
 

--- a/brain/cli.py
+++ b/brain/cli.py
@@ -442,6 +442,36 @@ def _daemon_state_refresh_handler(args: argparse.Namespace) -> int:
         store.close()
 
 
+def _dedup_sweep_handler(args: argparse.Namespace) -> int:
+    """Run the one-time retroactive duplicate cleanup (P3 retention rework,
+    Change 4) over a persona's corpus.
+
+    Deterministic exact-normalize merge only (no provider/near-dup layer from
+    the CLI). Loss-preserving: every removed row's pre-image is archived to
+    consolidation_archive.jsonl (reason "dedup_sweep") before removal.
+    Idempotent — safe to re-run.
+    """
+    from brain.engines.dedup_sweep import run_dedup_sweep
+
+    persona_dir = get_persona_dir(args.persona)
+    if not persona_dir.exists():
+        print(f"No persona directory at {persona_dir}.", file=sys.stderr)
+        return 1
+
+    store = MemoryStore(persona_dir / "memories.db", integrity_check=False)
+    try:
+        report = run_dedup_sweep(store, persona_dir)
+    finally:
+        store.close()
+
+    print(f"groups merged: {report.groups_merged}")
+    print(f"rows removed:  {report.rows_removed}")
+    print(f"archive:       {report.archive_path}")
+    if args.json:
+        print(json.dumps(report.as_log(), indent=2))
+    return 0
+
+
 def _open_memory_store_for_cli(persona: str) -> tuple[MemoryStore | None, int]:
     """Open a persona memory store for read-only CLI inspection."""
     persona_dir = get_persona_dir(persona)
@@ -2702,6 +2732,18 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     ds_refresh.add_argument("--persona", required=True, help="Persona name (required).")
     ds_refresh.set_defaults(func=_daemon_state_refresh_handler)
+
+    # nell dedup-sweep — P3 retention rework, Change 4: one-time retroactive
+    # duplicate cleanup over an existing corpus.
+    dd_sub = subparsers.add_parser(
+        "dedup-sweep",
+        help="One-time retroactive duplicate cleanup (exact-normalize merge, loss-preserving).",
+    )
+    dd_sub.add_argument("--persona", required=True, help="Persona name (required).")
+    dd_sub.add_argument(
+        "--json", action="store_true", help="Also print the full report as JSON."
+    )
+    dd_sub.set_defaults(func=_dedup_sweep_handler)
 
     # nell works — read-only inspection of brain-authored creative artifacts.
     # Saving is brain-territory via the save_work MCP tool, not a CLI command.

--- a/brain/engines/consolidation.py
+++ b/brain/engines/consolidation.py
@@ -290,13 +290,13 @@ def _make_haiku_reappraiser(provider) -> Reappraiser:
     provider failure the fallback is the memory's CURRENT importance (a
     no-op) — never a crash, never a ratchet."""
     prompt = (
-        "You judge how important a companion's memory is to keep clearly, on "
-        "a 0-10 scale, based on its content right now (not on how often it "
-        "has been recalled). A completed or past-due item (an appointment "
-        "that already happened, a plan that is no longer live) should score "
-        "LOW even if it once mattered. A durable fact, a core relationship "
-        "detail, or a defining moment should score HIGH. Reply with ONLY the "
-        "number."
+        "You judge how important a kindled's memory is, on a 0-10 scale, "
+        "based on its content right now (not on how often it has been recalled). "
+        "Re-evaluate a completed or past-due event (an appointment that already "
+        "happened, a plan that is no longer live) on its own merit as a past "
+        "event: it may now matter less, or it may still matter as something that "
+        "happened. A durable fact, a core relationship detail, or a defining "
+        "moment should score HIGH. Reply with ONLY the number."
     )
 
     def _reappraise(memory: Memory) -> float:

--- a/brain/engines/consolidation.py
+++ b/brain/engines/consolidation.py
@@ -33,7 +33,7 @@ from pathlib import Path
 
 from brain.memory.hebbian import HebbianMatrix
 from brain.memory.pending import SALIENCE_ELIGIBLE_TYPES, PendingQueue
-from brain.memory.store import Memory, MemoryStore
+from brain.memory.store import Memory, MemoryStore, clamp_importance
 from brain.utils.file_lock import file_lock
 
 logger = logging.getLogger(__name__)
@@ -66,6 +66,12 @@ class Decision:
 
 Classifier = Callable[[Memory, list[Memory]], Decision]
 
+# P3 retention rework, Change 3: importance re-rating on recall, via the
+# pending queue. A Reappraiser judges a fresh importance for an EXISTING
+# memory (not a Pass-2 candidate decision) — same injectable-seam shape as
+# Classifier, so tests pass a fake returning a known value.
+Reappraiser = Callable[[Memory], float]
+
 
 @dataclass
 class ConsolidationResult:
@@ -79,6 +85,7 @@ class ConsolidationResult:
     corrections: int = 0
     continuations: int = 0
     deferred: int = 0
+    reappraised: int = 0
 
     def as_log(self) -> dict:
         return {
@@ -91,6 +98,7 @@ class ConsolidationResult:
             "corrections": self.corrections,
             "continuations": self.continuations,
             "deferred": self.deferred,
+            "reappraised": self.reappraised,
             "skipped": self.skipped,
         }
 
@@ -119,11 +127,17 @@ def run_consolidation(
     provider=None,
     hebbian: HebbianMatrix | None = None,
     salience_floor: float | None = None,
+    reappraiser: Reappraiser | None = None,
 ) -> ConsolidationResult:
     """Drain the pending queue and consolidate, under a non-blocking gate lock.
 
     Returns a ConsolidationResult; ``skipped=True`` when a concurrent gate holds
     the lock. Does not raise on a bad candidate (skips it).
+
+    reappraiser: Change 3's injectable importance re-appraiser. None (default)
+        builds the Haiku-backed default when `provider` is given, else
+        degrades to the no-op fallback (importance unchanged) — mirrors the
+        classifier's degrade-to-`_promote_all_classifier` pattern.
     """
     persona_dir = Path(persona_dir)
     lock_path = persona_dir / _GATE_LOCK_FILENAME
@@ -141,9 +155,15 @@ def run_consolidation(
                     "degrading to promote-all (Pass-1 dedup only)"
                 )
                 classifier = _promote_all_classifier
-        result = _run_locked(store, persona_dir, classifier, hebbian, salience_floor)
+        if reappraiser is None:
+            reappraiser = _make_haiku_reappraiser(provider) if provider is not None else _noop_reappraiser
+        result = _run_locked(store, persona_dir, classifier, hebbian, salience_floor, reappraiser)
     logger.info("consolidation gate run: %s", json.dumps(result.as_log()))
     return result
+
+
+def _is_reappraise_item(entry: dict) -> bool:
+    return isinstance(entry, dict) and entry.get("_route") == "reappraise_importance"
 
 
 def _run_locked(
@@ -152,15 +172,27 @@ def _run_locked(
     classifier: Classifier,
     hebbian: HebbianMatrix | None,
     salience_floor: float | None,
+    reappraiser: Reappraiser | None = None,
 ) -> ConsolidationResult:
     pending = PendingQueue(persona_dir)
     batch = pending.drain()
-    result = ConsolidationResult(batch=len(batch))
-    if not batch:
+
+    # Change 3: split out existing-memory re-appraise items BEFORE the normal
+    # Pass-1/Pass-2 candidate pipeline — they are not candidates (no dedup,
+    # no promotion), just an in-place importance UPDATE on an already-committed
+    # row. `result.batch` counts only true candidates, matching its pre-Change-3
+    # meaning.
+    reappraise_entries = [e for e in batch if _is_reappraise_item(e)]
+    candidate_entries = [e for e in batch if not _is_reappraise_item(e)]
+
+    result = ConsolidationResult(batch=len(candidate_entries))
+    if reappraise_entries:
+        _handle_reappraisals(store, reappraise_entries, reappraiser or _noop_reappraiser, result)
+    if not candidate_entries:
         return result
 
     candidates: list[Memory] = []
-    for entry in batch:
+    for entry in candidate_entries:
         try:
             candidates.append(Memory.from_dict(entry))
         except (KeyError, ValueError, TypeError):
@@ -237,6 +269,86 @@ def _related_existing(store: MemoryStore, cand: Memory, *, limit: int = 8) -> li
                 if len(out) >= limit:
                     return out
     return out
+
+
+def _noop_reappraiser(memory: Memory) -> float:
+    """No-provider fallback (Change 3 default when no provider is configured):
+    importance unchanged. There is NO mechanism-driven monotone climb — this
+    is what dissolves the recall-frequency-ratchet risk at the root (STAGE-3
+    CORRECTION finding #2)."""
+    return memory.importance
+
+
+def _make_haiku_reappraiser(provider) -> Reappraiser:
+    """Build the Haiku-backed default importance re-appraiser (Change 3).
+
+    Judges importance fresh from the memory's content in the moment it is
+    re-appraised, not from how often it has been recalled: a still-relevant
+    journal entry keeps or raises its importance, a past-due appointment
+    (Roy's jury-duty case) drops. Output is clamped [0, 10] by the caller
+    (`_handle_reappraisals`) via the shared `clamp_importance`. On any parse/
+    provider failure the fallback is the memory's CURRENT importance (a
+    no-op) — never a crash, never a ratchet."""
+    prompt = (
+        "You judge how important a companion's memory is to keep clearly, on "
+        "a 0-10 scale, based on its content right now (not on how often it "
+        "has been recalled). A completed or past-due item (an appointment "
+        "that already happened, a plan that is no longer live) should score "
+        "LOW even if it once mattered. A durable fact, a core relationship "
+        "detail, or a defining moment should score HIGH. Reply with ONLY the "
+        "number."
+    )
+
+    def _reappraise(memory: Memory) -> float:
+        try:
+            raw = provider.generate(memory.content[:400], system=prompt)
+            match = re.search(r"-?\d+(\.\d+)?", raw)
+            if not match:
+                return memory.importance
+            return float(match.group(0))
+        except Exception:  # noqa: BLE001 — a provider fault must not lose the row
+            logger.warning("consolidation Haiku reappraise failed; importance unchanged")
+            return memory.importance
+
+    return _reappraise
+
+
+def _handle_reappraisals(
+    store: MemoryStore,
+    entries: list[dict],
+    reappraiser: Reappraiser,
+    result: ConsolidationResult,
+) -> None:
+    """Process Change-3 existing-memory re-appraise items: load the target
+    row, compute a new importance via the injectable `reappraiser`, and
+    UPDATE it in place (never an INSERT — C3.1).
+
+    A row missing at the read (already gone before this tick) or hard-deleted
+    between the read and the write (a concurrent forgetting LOSE, or a delete
+    triggered mid-appraisal) is skipped: no resurrection, no crash (C3.2).
+    The `store.update` call is wrapped in `try/except KeyError`, mirroring
+    the merge-dispatch idiom above (`_dispatch`'s `verdict == "merge"` branch).
+    """
+    for entry in entries:
+        memory_id = entry.get("memory_id")
+        if not memory_id or not isinstance(memory_id, str):
+            logger.warning("consolidation gate: dropping unparseable reappraise item")
+            continue
+        memory = store.get(memory_id, bump=False)
+        if memory is None:
+            continue  # already gone — no resurrection
+        try:
+            new_importance = reappraiser(memory)
+        except Exception:  # noqa: BLE001 — a reappraiser fault must not lose the batch
+            logger.exception("consolidation gate: reappraiser raised; skipping")
+            continue
+        try:
+            store.update(memory_id, importance=clamp_importance(new_importance))
+        except KeyError:
+            # Deleted between the read above and this write — absorbed, not
+            # raised (finding #3).
+            continue
+        result.reappraised += 1
 
 
 def _archive_preimage(persona_dir: Path, target: Memory, source_id: str) -> None:

--- a/brain/engines/dedup_sweep.py
+++ b/brain/engines/dedup_sweep.py
@@ -1,0 +1,209 @@
+"""dedup_sweep.py — one-time retroactive duplicate cleanup (P3 retention
+rework, Change 4).
+
+Reuses the consolidation gate's exact-normalize equivalence class
+(``_normalize``: whitespace-collapse + casefold) over the whole active
+corpus, so an existing near-duplicate pair created before the gate existed
+(or that slipped past it) gets merged in one pass. Loss-preserving: every
+removed row's full pre-image is archived to the same
+``consolidation_archive.jsonl`` the gate's merge path writes to (reason
+``"dedup_sweep"``) BEFORE the row is removed. Idempotent: re-running finds
+no exact-normalize group with more than one surviving member.
+
+An optional near-dup layer accepts an injectable ``judge`` (same
+duplicate/distinct classifier shape as the gate's Haiku classifier),
+default OFF — the sweep is deterministic and fully testable without a
+provider unless a judge is explicitly supplied.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+
+from brain.engines.consolidation import _ARCHIVE_FILENAME, _normalize
+from brain.memory.store import Memory, MemoryStore
+from brain.utils.file_lock import file_lock
+
+logger = logging.getLogger(__name__)
+
+_REPORT_FILENAME = "dedup_sweep_report.jsonl"
+
+# (candidate, canonical) -> "duplicate" | "distinct". Same shape as the
+# consolidation gate's Pass-2 classifier judgement, scoped to a binary call.
+Judge = Callable[[Memory, Memory], str]
+
+
+@dataclass
+class MergeRecord:
+    canonical_id: str
+    removed_id: str
+    content_preview: str
+
+
+@dataclass
+class Report:
+    groups_merged: int = 0
+    rows_removed: int = 0
+    archive_path: str = ""
+    merges: list[MergeRecord] = field(default_factory=list)
+
+    def as_log(self) -> dict:
+        return {
+            "groups_merged": self.groups_merged,
+            "rows_removed": self.rows_removed,
+            "archive_path": self.archive_path,
+            "merges": [
+                {
+                    "canonical_id": m.canonical_id,
+                    "removed_id": m.removed_id,
+                    "content_preview": m.content_preview,
+                }
+                for m in self.merges
+            ],
+        }
+
+
+def _archive_preimage(persona_dir: Path, target: Memory) -> None:
+    """Append the pre-removal memory to the plain consolidation archive
+    (reason "dedup_sweep") BEFORE it is removed — loss-preserving (C4.1).
+    Same archive file + shape as the gate's ``_archive_preimage``, a
+    distinct reason so the two sources are distinguishable on read."""
+    rec = {
+        "archived_at": datetime.now(UTC).isoformat(),
+        "reason": "dedup_sweep",
+        "target": target.to_dict(),
+    }
+    path = persona_dir / _ARCHIVE_FILENAME
+    with file_lock(path):
+        with open(path, "a", encoding="utf-8") as fh:
+            fh.write(json.dumps(rec, ensure_ascii=False) + "\n")
+
+
+def _write_report(persona_dir: Path, report: Report) -> None:
+    path = persona_dir / _REPORT_FILENAME
+    rec = {"run_at": datetime.now(UTC).isoformat(), **report.as_log()}
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "a", encoding="utf-8") as fh:
+        fh.write(json.dumps(rec, ensure_ascii=False) + "\n")
+
+
+def _pick_canonical(members: list[Memory]) -> Memory:
+    """Keep the highest-importance member; ties broken by oldest created_at
+    (the longest-standing record wins a tie)."""
+    ordered = sorted(members, key=lambda m: (-float(m.importance), m.created_at))
+    return ordered[0]
+
+
+def run_dedup_sweep(
+    store: MemoryStore,
+    persona_dir: str | Path,
+    *,
+    judge: Judge | None = None,
+) -> Report:
+    """One-time sweep merging existing near-duplicates. Run once over a
+    persona's corpus (e.g. via the CLI entry).
+
+    Primary layer (always on): exact-normalize grouping over ``store.list_active()``
+    rows — zero false-merge risk, deterministic. For each group of size > 1:
+    the highest-importance member (ties: oldest) is kept as canonical; every
+    OTHER member is archived (full pre-image, reason "dedup_sweep") then
+    hard-deleted; the canonical's importance is raised to the group max if a
+    removed member scored higher.
+
+    Optional near-dup layer: when ``judge`` is supplied, canonical survivors
+    left after the exact-normalize pass are compared pairwise; a "duplicate"
+    verdict merges the later-created of the pair into the earlier the same
+    way (archive-then-delete, carry max importance). Off by default so the
+    sweep needs no provider to be fully deterministic and testable.
+
+    Returns a Report (groups merged, rows removed, archive path, per-merge
+    canonical/removed ids) and appends it to ``dedup_sweep_report.jsonl``.
+    """
+    persona_dir = Path(persona_dir)
+    memories = store.list_active()
+
+    groups: dict[str, list[Memory]] = {}
+    for mem in memories:
+        norm = _normalize(mem.content)
+        if not norm:
+            continue
+        groups.setdefault(norm, []).append(mem)
+
+    report = Report(archive_path=str(persona_dir / _ARCHIVE_FILENAME))
+    canonicals: list[Memory] = []
+
+    for members in groups.values():
+        if len(members) < 2:
+            canonicals.append(members[0])
+            continue
+        canonical = _pick_canonical(members)
+        max_importance = max(float(m.importance) for m in members)
+        for dup in members:
+            if dup.id == canonical.id:
+                continue
+            _archive_preimage(persona_dir, dup)
+            store.hard_delete(dup.id)
+            report.merges.append(
+                MergeRecord(
+                    canonical_id=canonical.id,
+                    removed_id=dup.id,
+                    content_preview=dup.content[:120],
+                )
+            )
+            report.rows_removed += 1
+        if max_importance > canonical.importance:
+            store.update(canonical.id, importance=max_importance)
+            canonical = store.get(canonical.id, bump=False) or canonical
+        report.groups_merged += 1
+        canonicals.append(canonical)
+
+    if judge is not None:
+        _near_dup_pass(store, persona_dir, canonicals, judge, report)
+
+    _write_report(persona_dir, report)
+    return report
+
+
+def _near_dup_pass(
+    store: MemoryStore,
+    persona_dir: Path,
+    canonicals: list[Memory],
+    judge: Judge,
+    report: Report,
+) -> None:
+    """Optional near-dup layer (off by default): pairwise-judge the exact-dedup
+    survivors and merge any pair the judge calls "duplicate". Fail-open per
+    pair (a judge fault skips that pair, never loses a row)."""
+    removed: set[str] = set()
+    ordered = sorted(canonicals, key=lambda m: m.created_at)
+    for i, cand in enumerate(ordered):
+        if cand.id in removed:
+            continue
+        for other in ordered[i + 1 :]:
+            if other.id in removed:
+                continue
+            try:
+                verdict = judge(other, cand)
+            except Exception:  # noqa: BLE001 — a judge fault must not lose a row
+                logger.exception("dedup_sweep: near-dup judge raised; skipping pair")
+                continue
+            if verdict != "duplicate":
+                continue
+            _archive_preimage(persona_dir, other)
+            store.hard_delete(other.id)
+            removed.add(other.id)
+            report.merges.append(
+                MergeRecord(
+                    canonical_id=cand.id,
+                    removed_id=other.id,
+                    content_preview=other.content[:120],
+                )
+            )
+            report.rows_removed += 1
+            if float(other.importance) > float(cand.importance):
+                store.update(cand.id, importance=float(other.importance))

--- a/brain/engines/reflex.py
+++ b/brain/engines/reflex.py
@@ -447,11 +447,18 @@ class ReflexEngine:
 
         trigger_state = {e: emotions.get(e, 0.0) for e in arc.trigger}
 
+        # P3 retention rework, Change 1: reflex arc output is reflexive
+        # self-behavior with moderate retention value, not the ~0.0 the
+        # emotions={} default would otherwise produce. A journal-shaped arc
+        # output gets the journal_entry importance (6.0) for parity with
+        # add_journal's direct-write path.
+        reflex_importance = 6.0 if arc.output_memory_type == "journal_entry" else 4.0
         mem = Memory.create_new(
             content=raw,
             memory_type=arc.output_memory_type,
             domain="us",
             emotions={},
+            importance=reflex_importance,
             metadata={
                 "arc_name": arc.name,
                 "trigger_state": trigger_state,

--- a/brain/engines/research.py
+++ b/brain/engines/research.py
@@ -601,6 +601,10 @@ def _create_research_memory(
         memory_type="research",
         domain="us",
         emotions={},
+        # P3 retention rework, Change 1: research is durable knowledge the
+        # companion deliberately sought, not the ~0.0 the emotions={} default
+        # would otherwise produce.
+        importance=5.0,
         metadata={
             "schema_version": RESEARCH_SCHEMA_VERSION,
             "interest_id": interest.id,

--- a/brain/forgetting/policy.py
+++ b/brain/forgetting/policy.py
@@ -25,6 +25,15 @@ LOST_PASS_COUNT = 2
 RECENT_LIVED_HOURS = 720.0  # 30 days. NOTE: compared against WALL-CLOCK age (see is_exempt), not lived-age — the name is historical. Recent memories stay fully active+verbatim for a month.
 IMPORT_GRACE_LIVED_HOURS = 168.0  # 7 lived-days — settling window for migrated memories
 
+# P3 retention rework, Change 2: importance lowers the EFFECTIVE fade gate
+# (never LOST_THRESHOLD/LOST_PASS_COUNT — those stay the final deletion gate,
+# per the cd808dbc invariant: a lever only delays fading, it does not lower
+# the deletion floor). r = clamp(memory.importance / 10, 0, 1); a no-op at
+# r=0 (importance 0 → today's behavior, byte-identical). Tuned against the
+# C2 simulation so importance-10 survives >= 2 lived-years while importance-0
+# is untouched and the response is monotonic + never-accelerating.
+FADE_IMPORTANCE_GAIN = 2.0
+
 
 class Transition(StrEnum):
     NONE = "none"  # no change
@@ -51,10 +60,18 @@ def next_state(
     A heavy open arc lowers the effective fade threshold so memories resist
     fading during intense narrative periods. LOST_THRESHOLD is unchanged —
     arc pressure only delays the fade gate, not the final deletion gate.
+
+    importance (P3 retention rework, Change 2): reused as a second, additive
+    divisor term alongside narrative_weight — the same idiom, another source
+    of pressure on the same gate. importance=0 contributes nothing (exact
+    no-op); rising importance lowers the effective fade gate further, same
+    direction as narrative_weight, never lowering LOST_THRESHOLD.
     """
-    # Arc pressure lowers the effective threshold proportionally.
-    # narrative_weight=0 → baseline; narrative_weight=1 → threshold halved.
-    effective_fade = FADE_THRESHOLD / (1.0 + narrative_weight)
+    # Arc pressure + importance both lower the effective threshold, additively,
+    # reusing the same divisor idiom. narrative_weight=0 and memory.importance=0
+    # → baseline (unchanged); either pressure source lowers the gate further.
+    r = min(1.0, max(0.0, memory.importance / 10.0))
+    effective_fade = FADE_THRESHOLD / (1.0 + narrative_weight + FADE_IMPORTANCE_GAIN * r)
     if memory.state == "active":
         if salience < effective_fade:
             return Transition.FADE

--- a/brain/forgetting/salience.py
+++ b/brain/forgetting/salience.py
@@ -33,6 +33,13 @@ _HEBBIAN_DENOMINATOR = 20.0
 _RECALL_DENOMINATOR = 10.0
 _FRESHNESS_LIVED_HOURS_HORIZON = 2160.0  # 90 lived-days — soft landing past the 30-day recency grace
 
+# P3 retention rework, Change 2: importance extends the freshness age-horizon
+# (the OTHER decay lever, alongside policy.FADE_IMPORTANCE_GAIN). r =
+# clamp(memory.importance / 10, 0, 1); a no-op at r=0 (importance 0 → the
+# horizon above, unchanged). Tuned against the C2 simulation alongside
+# FADE_IMPORTANCE_GAIN so importance-10 survives >= 2 lived-years.
+HORIZON_IMPORTANCE_GAIN = 52.0
+
 # v0.0.33 Track 3 — peak blend. The FIELD never decays; its salience
 # contribution lingers over a long lived-time horizon so forgetting stays
 # reachable (spec constraint: sticky, never immortal). Calibration per the
@@ -126,7 +133,13 @@ def _freshness_input(memory: Memory, felt_time_state: FeltTimeState | None) -> f
     lived = _lived_hours_since(anchor, felt_time_state)
     if lived is None:
         return 1.0  # cold-start cases — treat as fresh (spec §7)
-    return 1.0 - _clamp(lived / _FRESHNESS_LIVED_HOURS_HORIZON)
+    # P3 retention rework, Change 2: importance extends the effective horizon.
+    # r=0 (importance 0) -> horizon_eff == _FRESHNESS_LIVED_HOURS_HORIZON,
+    # byte-identical to pre-change. Rising importance stretches the horizon,
+    # slowing freshness decay proportionally; never shrinks it below baseline.
+    r = min(1.0, max(0.0, memory.importance / 10.0))
+    horizon_eff = _FRESHNESS_LIVED_HOURS_HORIZON * (1.0 + HORIZON_IMPORTANCE_GAIN * r)
+    return 1.0 - _clamp(lived / horizon_eff)
 
 
 def _peak_input(memory: Memory, felt_time_state: FeltTimeState | None) -> float:

--- a/brain/grief/breadcrumb.py
+++ b/brain/grief/breadcrumb.py
@@ -134,5 +134,9 @@ def write_breadcrumb(
         domain="grief",
         emotions=emotions,
         metadata=metadata,
+        # P3 retention rework, Change 1: grief intensity is already on a
+        # ~0-10 scale; pass it through directly instead of letting the
+        # create_new default deflate it to intensity/10.0.
+        importance=_clamp(intensity),
     )
     return store.create(memory)

--- a/brain/ingest/commit.py
+++ b/brain/ingest/commit.py
@@ -7,7 +7,7 @@ threshold is the gate, not a per-call gate in this module.
 Memory type  = ExtractedItem.label  (one of VALID_LABELS)
 Domain       = "brain"              (the conversation's own domain)
 Tags         = ["auto_ingest", "conversation", label]
-Importance   = item.importance / 10.0  (normalized to the store's 0..10.0 float scale)
+Importance   = item.importance  (already on the store's 0..10.0 float scale; no division)
 
 After creation, auto-Hebbian: search the store for the top-3 related
 memories (by keyword overlap) and strengthen each pair.

--- a/brain/ingest/extract.py
+++ b/brain/ingest/extract.py
@@ -21,8 +21,14 @@ from brain.ingest.types import ExtractedItem
 
 logger = logging.getLogger(__name__)
 
+_IMPORTANCE_RUBRIC = (
+    'importance rubric: 1 = trivial/passing, 5 = an ordinary durable fact, '
+    '8 = core or defining, 10 = pivotal.'
+)
+
 EXTRACTION_PROMPT_LEGACY = """You are extracting durable memories from a conversation transcript.
 Return ONLY a JSON array. Each item: {{"text": str, "label": one of [observation, feeling, decision, question, fact, note], "importance": 1-10, "emotions": {{"<name>": 0-10}}}}.
+For "importance", """ + _IMPORTANCE_RUBRIC + """
 For "emotions", use ONLY these names (omit any you're unsure of): {emotion_vocab}.
 Skip pleasantries. Keep items concrete. No prose, no commentary.
 
@@ -37,7 +43,7 @@ Speakers in this transcript:
 - {user_name} is the human user the assistant is talking to. Statements
   attributed to {user_name} ({poss} actions, {poss} decisions, {poss} words) belong
   to {user_name}, not to anyone else.
-- {assistant_name} is the assistant — the AI persona. Replies from
+- {assistant_name} is the assistant, the AI persona. Replies from
   {assistant_name} may reference other people by name (from {assistant_name}'s
   memories, soul, or history). Those are HISTORICAL references, not the
   current speaker. Do NOT attribute the current user's actions to anyone
@@ -45,6 +51,7 @@ Speakers in this transcript:
 
 Return ONLY a JSON array. Each item:
 {{"text": str, "label": one of [observation, feeling, decision, question, fact, note], "importance": 1-10, "emotions": {{"<name>": 0-10}}}}.
+For "importance", """ + _IMPORTANCE_RUBRIC + """
 For "emotions", use ONLY these names (omit any you're unsure of): {emotion_vocab}.
 Skip pleasantries. Keep items concrete. No prose, no commentary.
 

--- a/brain/initiate/memory.py
+++ b/brain/initiate/memory.py
@@ -151,6 +151,10 @@ def write_initiate_memory(
             "initiate_ts": ts,
         },
         emotions=_emotions,
+        # P3 retention rework, Change 1: a real message the companion chose
+        # to send, not the <=0.025 the /10.0 default produced on a small or
+        # absent reach_emotions vector.
+        importance=5.0,
     )
     try:
         from brain.memory.pending import route_write

--- a/brain/kindled_link/relationship.py
+++ b/brain/kindled_link/relationship.py
@@ -410,6 +410,9 @@ def write_kindled_peer_memory(
         tags=["kindled_peer", f"peer:{peer_id}"], emotions=seeded,
         metadata={"peer_id": peer_id, "session_id": session_id,
                   "speaker": speaker, "relationship_stage": stage},
+        # P3 retention rework, Change 1: a peer-relationship event, not the
+        # near-0 the /10.0 default produced on a small or absent emotion vector.
+        importance=5.0,
     )
     try:
         mem_store.create(mem)

--- a/brain/maker/wiring.py
+++ b/brain/maker/wiring.py
@@ -64,6 +64,9 @@ def write_making_memory(store, making: Making, *, emotions: dict[str, float]) ->
     mem = Memory.create_new(
         content=content, memory_type="making", domain="interior",
         tags=["making", making.disposition], emotions=emotions or None,
+        # P3 retention rework, Change 1: a creative act, not the <=0.03 the
+        # /10.0 default produced on a small or absent emotion vector.
+        importance=5.0,
     )
     try:
         # Automatic generated write → route through the consolidation gate (gated by memory_type).

--- a/brain/memory/pending.py
+++ b/brain/memory/pending.py
@@ -127,18 +127,53 @@ class PendingQueue:
         `enqueue` — no appraisal and no provider call happen here. The gate
         re-appraises on its own consolidation tick and UPDATES the existing
         row in place (never a new row).
+
+        Single-id convenience wrapper around `enqueue_reappraisals` — see
+        that method if enqueuing more than one id (e.g. every surfaced
+        recall hit in one turn); calling this in a loop reacquires the lock
+        and reopens the file once per id.
         """
-        entry = {
-            "_route": "reappraise_importance",
-            "memory_id": memory_id,
-            "_source": source,
-            "_enqueued_at": datetime.now(UTC).isoformat(),
-        }
-        line = json.dumps(entry, ensure_ascii=False)
+        self.enqueue_reappraisals([memory_id], source=source)
+
+    def enqueue_reappraisals(self, memory_ids: list[str], *, source: str) -> int:
+        """Enqueue MULTIPLE existing-memory re-appraise requests under a
+        SINGLE `file_lock` + single open + single write (P3 retention
+        rework, Change 3 hot-path fix).
+
+        The recall hook (`brain.chat.prompt._build_recall_block`) surfaces
+        up to ~2*limit memory ids per turn and used to call
+        `enqueue_reappraisal` once per id — each call independently
+        acquiring the lock and opening/writing the file, i.e. N lock/open/
+        write syscalls on the recall hot path. This batches the whole list
+        into one lock acquisition and one file write.
+
+        Each written line has the EXACT same shape as a single
+        `enqueue_reappraisal` call (`_route`/`memory_id`/`_source`/
+        `_enqueued_at`) — only the I/O is batched, not the item schema.
+        `drain()` and the consolidation gate see no difference from N
+        individual calls. No-op (returns 0, does not touch the file) on an
+        empty list. Returns the number of lines written.
+        """
+        if not memory_ids:
+            return 0
+        now = datetime.now(UTC).isoformat()
+        lines = [
+            json.dumps(
+                {
+                    "_route": "reappraise_importance",
+                    "memory_id": memory_id,
+                    "_source": source,
+                    "_enqueued_at": now,
+                },
+                ensure_ascii=False,
+            )
+            for memory_id in memory_ids
+        ]
         self.path.parent.mkdir(parents=True, exist_ok=True)
         with file_lock(self.path):
             with open(self.path, "a", encoding="utf-8") as fh:
-                fh.write(line + "\n")
+                fh.write("\n".join(lines) + "\n")
+        return len(lines)
 
     def drain(self) -> list[dict]:
         """Atomically take the whole queue: read all entries, then truncate.

--- a/brain/memory/pending.py
+++ b/brain/memory/pending.py
@@ -114,6 +114,32 @@ class PendingQueue:
                 break
         return out
 
+    def enqueue_reappraisal(self, memory_id: str, *, source: str) -> None:
+        """Enqueue an existing-memory importance re-appraise request (P3
+        retention rework, Change 3).
+
+        A minimal item, NOT a full Memory payload: just the target id plus
+        a top-level `_route` discriminator, so the queue file stays small.
+        `drain()` returns it as a raw dict like any other candidate; the
+        gate (`engines.consolidation._run_locked`) branches on `_route` to
+        separate re-appraise items from normal candidates BEFORE Pass 1/2.
+        Off the hot path: this is a cheap file append under lock, same as
+        `enqueue` — no appraisal and no provider call happen here. The gate
+        re-appraises on its own consolidation tick and UPDATES the existing
+        row in place (never a new row).
+        """
+        entry = {
+            "_route": "reappraise_importance",
+            "memory_id": memory_id,
+            "_source": source,
+            "_enqueued_at": datetime.now(UTC).isoformat(),
+        }
+        line = json.dumps(entry, ensure_ascii=False)
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        with file_lock(self.path):
+            with open(self.path, "a", encoding="utf-8") as fh:
+                fh.write(line + "\n")
+
     def drain(self) -> list[dict]:
         """Atomically take the whole queue: read all entries, then truncate.
 

--- a/brain/memory/pending.py
+++ b/brain/memory/pending.py
@@ -59,10 +59,13 @@ GATE_BYPASS_TYPES: frozenset[str] = frozenset(
 
 # Only these monologue-EPISODE types are eligible for the Pass-1 salience drop —
 # they carry a real 0..10 importance signal (extractor sets importance=salience*10).
-# Dreams (importance auto-derives to ~0 when emotion-flat), research/heartbeat/
-# reflex/initiate (same emotion-derived default), and monologue_trace (pinned 0.3)
-# are EXEMPT: they go through dedup only, never salience-drop. Owner directive
-# (Roy, 2026-08-11) — a single flat floor would nuke legitimate flat content.
+# Dreams (importance still auto-derives from the emotion sum when emotion-flat)
+# and monologue_trace (now a per-trace-derived value, P3 retention rework
+# Change 1 — no longer a flat 0.3) are EXEMPT: they go through dedup only,
+# never salience-drop. research/heartbeat/reflex/initiate now carry explicit
+# non-deflated importance (Change 1) but were never SALIENCE_ELIGIBLE anyway —
+# still exempt, same as before. Owner directive (Roy, 2026-08-11) — a single
+# flat floor would nuke legitimate flat content.
 SALIENCE_ELIGIBLE_TYPES: frozenset[str] = frozenset(
     {"monologue", "monologue_emotion", "monologue_soul_candidate"}
 )

--- a/brain/memory/store.py
+++ b/brain/memory/store.py
@@ -36,6 +36,21 @@ def _coerce_utc(ts: str) -> datetime:
     return dt if dt.tzinfo is not None else dt.replace(tzinfo=UTC)
 
 
+def clamp_importance(x: float) -> float:
+    """Clamp a raw importance value into the store's [0.0, 10.0] scale.
+
+    Shared boundary guard (P3 retention rework, Change 1): every producer's
+    importance, however derived, passes through here before it can reach a
+    Memory row. Applied inside Memory.create_new (covers an unclamped
+    emotion-sum default, e.g. engines/dream.py's saturated aggregate) AND
+    inside migrator/transform.py's bespoke Memory(...) construction (which
+    bypasses create_new). One helper, both boundaries: no producer can ever
+    emit importance > 10.0, and a legitimate value already in range is
+    never altered.
+    """
+    return min(10.0, max(0.0, float(x)))
+
+
 def _safe_load_metadata(raw: str | None) -> dict[str, Any]:
     """Decode a metadata_json column value into a dict, defending against
     manual DB edits or legacy writers that stored the string "null",
@@ -117,6 +132,7 @@ class Memory:
         tags = list(tags or [])
         score = float(sum(emotions.values()))
         metadata = dict(metadata or {})
+        raw_importance = importance if importance is not None else score / 10.0
         return cls(
             id=str(uuid.uuid4()),
             content=content,
@@ -125,7 +141,7 @@ class Memory:
             created_at=datetime.now(UTC),
             emotions=emotions,
             tags=tags,
-            importance=importance if importance is not None else score / 10.0,
+            importance=clamp_importance(raw_importance),
             score=score,
             metadata=metadata,
             peak_emotion_intensity=max(

--- a/brain/migrator/transform.py
+++ b/brain/migrator/transform.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any
 
-from brain.memory.store import Memory, _coerce_utc
+from brain.memory.store import Memory, _coerce_utc, clamp_importance
+from brain.tools.impls._common import _calc_importance_from_emotions
 
 # OG fields with direct first-class mapping in the new schema.
 _FIRST_CLASS_OG_FIELDS = frozenset(
@@ -121,11 +122,21 @@ def transform_memory(og: dict[str, Any]) -> tuple[Memory | None, SkippedMemory |
 
     # importance: only coerce real numbers. Strings like "high" would crash
     # float(); lists/dicts too. Protects the never-raises contract.
+    # P3 retention rework, Change 1 (OG-0 backfill): a missing/malformed OG
+    # importance no longer hard-defaults to 0.0 (which would mass-evict
+    # migrated history at the new importance-driven decay baseline). Backfill
+    # from emotions when present (reusing the OG add_memory auto-importance
+    # bucket), else a moderate flat default — migrated history should not
+    # start at the bottom of the scale. A numeric-but-oversized OG value
+    # (e.g. 50.0) is clamped, same as every other create_new/Memory(...)
+    # boundary (finding #4).
     importance_raw = og.get("importance")
     if isinstance(importance_raw, (int, float)) and not isinstance(importance_raw, bool):
-        importance = float(importance_raw)
+        importance = clamp_importance(importance_raw)
+    elif emotions:
+        importance = float(_calc_importance_from_emotions(emotions))
     else:
-        importance = 0.0
+        importance = 4.0
 
     # tags: only accept a real list. list("mytag") would explode a string
     # into ['m','y','t','a','g']; list({"a":1}) would pull dict keys. Both

--- a/brain/monologue/trace.py
+++ b/brain/monologue/trace.py
@@ -5,7 +5,9 @@ the existing forgetting engine ages it: FADE rewrites content→tombstone
 summary (sharp→blurred), LOSE forgets it with grief + graveyard. Seeding the
 trace with the current emotional aggregate means a thought formed in a charged
 moment carries more salience (emotion is the heaviest forgetting weight) and
-persists longer than flat idle drift.
+persists longer than flat idle drift. Importance now also feeds the
+forgetting decay lever (P3 retention rework, Change 2) — kept modest here
+because traces are high-volume.
 """
 from __future__ import annotations
 
@@ -14,7 +16,19 @@ from brain.memory.store import Memory, MemoryStore
 
 MONOLOGUE_TRACE_TYPE = "monologue_trace"
 MONOLOGUE_DOMAIN = "monologue"
-_TRACE_IMPORTANCE = 0.3  # calibration; not part of the forgetting salience formula
+_TRACE_IMPORTANCE_FLOOR = 0.2
+_TRACE_IMPORTANCE_CAP = 3.0
+_TRACE_IMPORTANCE_SCALE = 0.3  # peak emotion intensity (0..10) * scale, then clamped
+
+
+def _trace_importance(emotions: dict[str, float]) -> float:
+    """Derive a per-trace importance from the aggregate's peak emotion
+    intensity (P3 retention rework, Change 1 — replaces the flat 0.3
+    constant so traces differentiate by how charged the moment was).
+    Floored/capped modest: traces are high-volume, so even a peak trace
+    should stay well below a deliberate write like a journal entry."""
+    peak = max(emotions.values(), default=0.0)
+    return min(_TRACE_IMPORTANCE_CAP, max(_TRACE_IMPORTANCE_FLOOR, peak * _TRACE_IMPORTANCE_SCALE))
 
 
 def write_trace_memory(store: MemoryStore, monologue: str) -> str:
@@ -26,7 +40,7 @@ def write_trace_memory(store: MemoryStore, monologue: str) -> str:
         memory_type=MONOLOGUE_TRACE_TYPE,
         domain=MONOLOGUE_DOMAIN,
         emotions=emotions,
-        importance=_TRACE_IMPORTANCE,
+        importance=_trace_importance(emotions),
     )
     from brain.memory.pending import route_write
 

--- a/brain/tools/impls/add_journal.py
+++ b/brain/tools/impls/add_journal.py
@@ -41,6 +41,10 @@ def add_journal(
         memory_type="journal_entry",
         domain="self",
         emotions={},
+        # P3 retention rework, Change 1: journal entries are companion
+        # self-reflection, framed as important — not the ~0.0 the emotions={}
+        # default would otherwise produce.
+        importance=6.0,
         metadata={
             "private": True,
             "source": "brain_authored",

--- a/tests/forgetting/test_p3_change2_decay.py
+++ b/tests/forgetting/test_p3_change2_decay.py
@@ -1,0 +1,214 @@
+"""Tests for P3 retention rework, Change 2 — importance-driven decay rate.
+
+Covers C2.1-C2.5 from changes/p3-retention/1.5-criteria.md. All verified by
+directly exercising `salience.score` / `salience._freshness_input` /
+`policy.next_state` on synthetic memories at controlled (importance,
+lived-age) points, via a small simulation that mirrors
+`brain.forgetting.__init__.run_pass`'s own state-transition loop (6h-cadence
+passes, consecutive_low_passes counter, FADE/UNFADE/LOSE per
+`policy.next_state`) — the same mechanics production drives, without a real
+MemoryStore/DB/heartbeat.
+
+Naming: synthetic user = Bob, persona = Canary, model = Claude. No Phoebe.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from brain.felt_time.state import FeltTimeState
+from brain.forgetting import policy, salience
+from brain.memory.store import Memory
+
+_CADENCE_HOURS = 6.0
+_TWO_LIVED_YEARS_HOURS = 17_532.0  # per plan's stated anchor
+_MAX_SIM_HOURS = _TWO_LIVED_YEARS_HOURS * 3  # generous ceiling so LOSE has room to appear
+
+
+def _make_memory(importance: float, emotions: dict[str, float] | None = None) -> Memory:
+    m = Memory.create_new(
+        content="a synthetic memory",
+        memory_type="episodic",
+        domain="chat",
+        emotions=emotions or {},
+        importance=importance,
+    )
+    return m
+
+
+def _simulate(
+    importance: float,
+    *,
+    emotions: dict[str, float] | None = None,
+    soul_linked: bool = False,
+    max_hours: float = _MAX_SIM_HOURS,
+) -> tuple[float | None, float | None]:
+    """Step a synthetic memory through 6h-cadence forgetting passes from
+    lived-age 0 up to max_hours. Returns (first_fade_age, first_lose_age),
+    either None if the transition never occurs in the window.
+
+    Mirrors brain.forgetting.__init__.run_pass's own loop: salience.score
+    each pass, track consecutive_low_passes exactly as run_pass does, apply
+    policy.next_state, advance state. No exemptions applied here (is_exempt/
+    RECENT_LIVED_HOURS/import-grace) — this isolates the salience+state-
+    machine mechanism the plan's C2 anchors are about; the wall-clock
+    recency exemption is a SEPARATE, untouched gate (HIST 95315d5d) that in
+    production would additionally protect a memory for its first 720 hours.
+    """
+    mem = _make_memory(importance, emotions)
+    state = "active"
+    consecutive_low = 0
+    fade_age: float | None = None
+    lose_age: float | None = None
+    # lived_age_hours > 0 with first_tick_ts=None -> the felt-time rate
+    # defaults to 1.0 (see salience._lived_hours_since), so lived-hours since
+    # `anchor` tracks wall-hours since `anchor` directly — letting this sim
+    # control lived-age deterministically via `created_at` alone.
+    felt_state = FeltTimeState(lived_age_hours=1.0)
+
+    t = 0.0
+    while t <= max_hours:
+        object.__setattr__(mem, "created_at", datetime.now(UTC) - timedelta(hours=t))
+        object.__setattr__(mem, "state", state)
+        s = salience.score(
+            mem,
+            store=None,  # unused by score() — see salience.py signature
+            hebbian=None,  # _hebbian_input degrades to 0 on AttributeError
+            felt_time_state=felt_state,
+            soul_linked_ids=({mem.id} if soul_linked else set()),
+        )
+        next_low = consecutive_low + 1 if s < policy.LOST_THRESHOLD else 0
+        transition = policy.next_state(
+            mem, salience=s, consecutive_low_passes=next_low, narrative_weight=0.0
+        )
+        if transition == policy.Transition.FADE:
+            if fade_age is None:
+                fade_age = t
+            state = "fading"
+        elif transition == policy.Transition.UNFADE:
+            state = "active"
+            next_low = 0
+        elif transition == policy.Transition.LOSE:
+            lose_age = t
+            break
+        consecutive_low = next_low
+        t += _CADENCE_HOURS
+
+    return fade_age, lose_age
+
+
+# --------------------------------------------------------------------------- C2.1
+def test_c2_1_importance_zero_timeline_unchanged_and_nonzero_differs():
+    """importance=0 -> the pre-change formula exactly (both levers are
+    documented no-ops at r=0: effective_fade = FADE_THRESHOLD/(1+narrative_weight),
+    horizon_eff = _FRESHNESS_LIVED_HOURS_HORIZON). Fail-test: a nonzero-
+    importance case must differ (proving the change is live) while
+    importance-0 matches the pre-change formula bit for bit."""
+    mem0 = _make_memory(0.0)
+    felt_state = FeltTimeState(lived_age_hours=1.0)
+
+    # Pre-change formula, inlined (not imported — this IS the oracle for the
+    # "byte-identical at importance 0" claim): effective_fade only used
+    # narrative_weight, and the freshness horizon was the bare constant.
+    pre_change_effective_fade = policy.FADE_THRESHOLD / (1.0 + 0.0)
+    assert (
+        policy.FADE_THRESHOLD / (1.0 + 0.0 + policy.FADE_IMPORTANCE_GAIN * 0.0)
+        == pre_change_effective_fade
+    )
+
+    for lived in (0.0, 100.0, 800.0, 5000.0, 20000.0):
+        object.__setattr__(mem0, "created_at", datetime.now(UTC) - timedelta(hours=lived))
+        pre_freshness = 1.0 - min(1.0, max(0.0, lived / salience._FRESHNESS_LIVED_HOURS_HORIZON))
+        post_freshness = salience._freshness_input(mem0, felt_state)
+        assert post_freshness == pytest.approx(pre_freshness)
+
+    # Fail-test / live-check: a nonzero-importance case DIFFERS from imp-0 at
+    # a lived-age where the importance lever has kicked in.
+    fade0, lose0 = _simulate(0.0)
+    fade10, lose10 = _simulate(10.0, max_hours=25_000.0)
+    assert (fade10, lose10) != (fade0, lose0)
+
+
+# --------------------------------------------------------------------------- C2.2
+def test_c2_2_high_importance_survives_well_beyond_30_lived_days_where_imp0_does_not():
+    thirty_days_hours = 30 * 24.0  # 720h
+    fade0, lose0 = _simulate(0.0, max_hours=thirty_days_hours + _CADENCE_HOURS)
+    # Fail-test: pre-change (importance ignored), the high-importance memory
+    # would ALSO be faded/lost by this age, same as importance-0.
+    assert fade0 is not None and fade0 <= thirty_days_hours
+
+    for imp in (8.0, 9.0, 10.0):
+        mem = _make_memory(imp)
+        felt_state = FeltTimeState(lived_age_hours=1.0)
+        object.__setattr__(mem, "created_at", datetime.now(UTC) - timedelta(hours=thirty_days_hours))
+        object.__setattr__(mem, "state", "active")
+        s = salience.score(
+            mem, store=None, hebbian=None, felt_time_state=felt_state, soul_linked_ids=set()
+        )
+        transition = policy.next_state(mem, salience=s, consecutive_low_passes=0, narrative_weight=0.0)
+        assert transition == policy.Transition.NONE  # still active: not FADE, not LOSE
+
+
+# --------------------------------------------------------------------------- C2.3
+def test_c2_3_importance_ten_survives_two_lived_years():
+    fade10, lose10 = _simulate(10.0, max_hours=_TWO_LIVED_YEARS_HOURS)
+    # Not LOST at >= 2 lived-years (stated constant anchor).
+    assert lose10 is None or lose10 >= _TWO_LIVED_YEARS_HOURS
+
+
+# --------------------------------------------------------------------------- C2.4
+def test_c2_4_monotonic_and_never_accelerates():
+    def _inf_if_none(x: float | None) -> float:
+        return float("inf") if x is None else x
+
+    fade_ages = []
+    lose_ages = []
+    for imp in range(11):
+        fade, lose = _simulate(float(imp))
+        fade_ages.append(fade)
+        lose_ages.append(lose)
+
+    # Monotonic non-decreasing in importance.
+    for i in range(1, 11):
+        assert _inf_if_none(fade_ages[i]) >= _inf_if_none(fade_ages[i - 1])
+        assert _inf_if_none(lose_ages[i]) >= _inf_if_none(lose_ages[i - 1])
+
+    # Never-accelerate: for every importance >= 0, disposition is never worse
+    # (never lost earlier) than importance-0.
+    baseline_lose = _inf_if_none(lose_ages[0])
+    for i in range(11):
+        assert _inf_if_none(lose_ages[i]) >= baseline_lose
+
+
+# --------------------------------------------------------------------------- C2.5
+def test_c2_5_emotional_and_soul_memories_no_regression():
+    # High-emotion memory: importance=0 vs importance=5, same emotion vector.
+    # Fail-test: a version that let importance LOWER the emotion-input path
+    # (it must not — Change 2 only touches freshness horizon + fade gate)
+    # would decay earlier post-change.
+    fade_e0, lose_e0 = _simulate(0.0, emotions={"joy": 10.0}, max_hours=_TWO_LIVED_YEARS_HOURS)
+    fade_e5, lose_e5 = _simulate(5.0, emotions={"joy": 10.0}, max_hours=_TWO_LIVED_YEARS_HOURS)
+
+    def _inf_if_none(x):
+        return float("inf") if x is None else x
+
+    assert _inf_if_none(fade_e5) >= _inf_if_none(fade_e0)
+    assert _inf_if_none(lose_e5) >= _inf_if_none(lose_e0)
+
+    # Soul-linked memory: importance=0 vs importance=5.
+    fade_s0, lose_s0 = _simulate(0.0, soul_linked=True, max_hours=_TWO_LIVED_YEARS_HOURS)
+    fade_s5, lose_s5 = _simulate(5.0, soul_linked=True, max_hours=_TWO_LIVED_YEARS_HOURS)
+    assert _inf_if_none(fade_s5) >= _inf_if_none(fade_s0)
+    assert _inf_if_none(lose_s5) >= _inf_if_none(lose_s0)
+
+
+# --------------------------------------------------------------------------- constants sanity
+def test_constants_documented_starting_values():
+    """Pins the tuned constants this test suite validated against (see the
+    module docstring's simulation)."""
+    assert policy.FADE_IMPORTANCE_GAIN == 2.0
+    assert salience.HORIZON_IMPORTANCE_GAIN == 52.0
+    assert policy.LOST_THRESHOLD == 0.10  # UNCHANGED (cd808dbc invariant)
+    assert policy.LOST_PASS_COUNT == 2  # UNCHANGED

--- a/tests/test_p3_change1_importance.py
+++ b/tests/test_p3_change1_importance.py
@@ -1,0 +1,383 @@
+"""Tests for P3 retention rework, Change 1 — trustworthy importance assignment.
+
+Covers C1.1-C1.5 from changes/p3-retention/1.5-criteria.md. Each test
+documents how the PRE-CHANGE code would have violated the criterion (the
+oracle must be shown able to fail).
+
+Naming: synthetic user = Bob, persona = Canary, model = Claude. No Phoebe.
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+
+from brain.memory.store import Memory, clamp_importance
+
+# --------------------------------------------------------------------------- C1.1
+# Fixed-constant producers: reflex, add_journal, research, initiate_outbound,
+# making, kindled_peer must all emit importance > 1.0 (floor above the
+# deflated ~0.0-0.3 range that `emotions={}` / a tiny emotion vector produced
+# pre-change). Verified by constructing each via its producer path.
+
+
+def test_c1_1_reflex_engine_fire_produces_nonzero_importance(tmp_path):
+    """End-to-end through the real reflex.py `_fire` code path (not
+    reimplemented). reflex_output is a gated type, so the written memory
+    lands in the pending queue (route_write), not memories.db directly."""
+    from datetime import UTC, datetime
+
+    from brain.engines.reflex import ReflexArc, ReflexEngine
+    from brain.memory.pending import PendingQueue
+    from brain.memory.store import MemoryStore
+
+    class _FakeProvider:
+        def generate(self, prompt, *, system=None):
+            return "a reflexive thought"
+
+        def name(self):
+            return "fake"
+
+    store = MemoryStore(tmp_path / "memories.db")
+    arc = ReflexArc(
+        name="test_arc",
+        description="test",
+        trigger={"joy": 5.0},
+        days_since_human_min=0.0,
+        cooldown_hours=0.0,
+        action="write",
+        output_memory_type="reflex_output",
+        prompt_template="hi",
+    )
+    engine = ReflexEngine(
+        store=store,
+        provider=_FakeProvider(),
+        persona_name="Canary",
+        persona_system_prompt="",
+        arcs_path=tmp_path / "arcs.json",
+        log_path=tmp_path / "reflex_log.jsonl",
+        default_arcs_path=tmp_path / "default_arcs.json",
+    )
+    engine._fire(arc, {"joy": 5.0}, 1.0, [], datetime.now(UTC))
+    mems = PendingQueue(tmp_path).read_recent("reflex_output", limit=10)
+    assert mems
+    # Fail-test: pre-change this producer passed emotions={} with no explicit
+    # importance -> Memory.create_new deflated importance to 0.0.
+    assert mems[0].importance > 1.0
+    store.close()
+
+
+def test_c1_1_reflex_journal_shaped_arc_matches_add_journal_floor(tmp_path):
+    """A journal-shaped reflex arc output (output_memory_type='journal_entry')
+    gets the same importance floor as add_journal's direct-write path (6.0),
+    not the plain reflex floor (4.0)."""
+    from datetime import UTC, datetime
+
+    from brain.engines.reflex import ReflexArc, ReflexEngine
+    from brain.memory.store import MemoryStore
+
+    class _FakeProvider:
+        def generate(self, prompt, *, system=None):
+            return "a journal-shaped reflexive thought"
+
+        def name(self):
+            return "fake"
+
+    store = MemoryStore(tmp_path / "memories.db")
+    arc = ReflexArc(
+        name="journal_arc",
+        description="test",
+        trigger={"joy": 5.0},
+        days_since_human_min=0.0,
+        cooldown_hours=0.0,
+        action="write",
+        output_memory_type="journal_entry",
+        prompt_template="hi",
+    )
+    engine = ReflexEngine(
+        store=store,
+        provider=_FakeProvider(),
+        persona_name="Canary",
+        persona_system_prompt="",
+        arcs_path=tmp_path / "arcs.json",
+        log_path=tmp_path / "reflex_log.jsonl",
+        default_arcs_path=tmp_path / "default_arcs.json",
+    )
+    # journal_entry bypasses the gate (route_write) -> lands directly in
+    # memories.db, unlike the plain reflex_output case above.
+    engine._fire(arc, {"joy": 5.0}, 1.0, [], datetime.now(UTC))
+    mems = store.list_by_type("journal_entry", active_only=False)
+    assert mems
+    assert mems[0].importance == pytest.approx(6.0)
+    store.close()
+
+
+def test_c1_1_add_journal_above_floor(tmp_path):
+    from brain.memory.hebbian import HebbianMatrix
+    from brain.memory.store import MemoryStore
+    from brain.tools.impls.add_journal import add_journal
+
+    store = MemoryStore(tmp_path / "memories.db")
+    hebbian = HebbianMatrix(":memory:")
+    add_journal("a private thought", store=store, hebbian=hebbian, persona_dir=tmp_path)
+    mems = store.list_by_type("journal_entry", active_only=False)
+    assert mems
+    # Fail-test: pre-change emotions={} with no explicit importance -> 0.0.
+    assert mems[0].importance > 1.0
+    store.close()
+    hebbian.close()
+
+
+def test_c1_1_research_memory_above_floor():
+    from brain.engines.research import _create_research_memory
+
+    mem = _create_research_memory(
+        content="notes on a topic",
+        interest=type(
+            "I", (), {"id": "i1", "topic": "topic", "scope": "general"}
+        )(),
+        web_results=[],
+        web_used=False,
+        trigger="scheduled",
+        provider_name="fake",
+        searcher_name=None,
+    )
+    # Fail-test: pre-change emotions={} with no explicit importance -> 0.0.
+    assert mem.importance > 1.0
+
+
+def test_c1_1_initiate_outbound_above_floor(tmp_path):
+    from brain.initiate.memory import write_initiate_memory
+    from brain.memory.store import MemoryStore
+
+    store = MemoryStore(tmp_path / "memories.db")
+    write_initiate_memory(
+        store,
+        audit_id="a1",
+        subject="checking in",
+        message="hey, thinking of you",
+        state="warm",
+        ts="2026-01-01T00:00:00+00:00",
+    )
+    mems = store.list_by_type("initiate_outbound", active_only=False)
+    assert mems
+    # Fail-test: pre-change the /10.0 default on a small/absent emotion
+    # vector deflated importance to <= 0.025.
+    assert mems[0].importance > 1.0
+    store.close()
+
+
+def test_c1_1_making_memory_above_floor(tmp_path):
+    from brain.maker.wiring import Making, write_making_memory
+    from brain.memory.pending import PendingQueue
+    from brain.memory.store import MemoryStore
+
+    store = MemoryStore(tmp_path / "memories.db")
+    making = Making(
+        type="poem",
+        title="a small poem",
+        content="roses are red",
+        disposition="private",
+    )
+    write_making_memory(store, making, emotions={"joy": 0.2})
+    # "making" is a gated type: route_write enqueues it, it does not land in
+    # memories.db directly.
+    mems = PendingQueue(tmp_path).read_recent("making", limit=10)
+    assert mems
+    # Fail-test: pre-change the /10.0 default on a tiny emotion vector
+    # deflated importance to <= 0.03.
+    assert mems[0].importance > 1.0
+    store.close()
+
+
+def test_c1_1_kindled_peer_memory_above_floor(tmp_path):
+    from brain.kindled_link.relationship import write_kindled_peer_memory
+    from brain.memory.store import MemoryStore
+
+    store = MemoryStore(tmp_path / "memories.db")
+    write_kindled_peer_memory(
+        store,
+        peer_id="peer1",
+        session_id="s1",
+        speaker="peer",
+        stage="early",
+        content="a peer said something",
+    )
+    mems = store.list_by_type("kindled_peer", active_only=False)
+    assert mems
+    # Fail-test: pre-change the /10.0 default on an absent/small emotion
+    # vector deflated importance to near-0.
+    assert mems[0].importance > 1.0
+    store.close()
+
+
+def test_c1_1_grief_event_intensity_proportional():
+    """grief_event is intensity-PROPORTIONAL (finding #6), not a flat floor:
+    importance == clamp(intensity, 0, 10) across a low and a high intensity.
+    Fail-test: pre-change importance == intensity/10.0 (deflated)."""
+    from brain.grief.breadcrumb import write_breadcrumb
+    from brain.memory.store import MemoryStore
+
+    store = MemoryStore(":memory:")
+
+    low_id = write_breadcrumb(
+        store=store,
+        intensity=0.5,
+        subtype="drop",
+        referent_type="memory",
+        referent_id="ref1",
+        content="the memory of something is gone",
+        residue_emotion=None,
+    )
+    high_id = write_breadcrumb(
+        store=store,
+        intensity=8.0,
+        subtype="drop",
+        referent_type="memory",
+        referent_id="ref2",
+        content="the memory of something else is gone",
+        residue_emotion=None,
+    )
+    low = store.get(low_id, bump=False)
+    high = store.get(high_id, bump=False)
+    assert low.importance == pytest.approx(0.5)
+    assert high.importance == pytest.approx(8.0)
+    # Fail-test: the deflated pre-change formula would give 0.05 / 0.8.
+    assert low.importance != pytest.approx(0.05)
+    assert high.importance != pytest.approx(0.8)
+    store.close()
+
+
+# --------------------------------------------------------------------------- C1.2
+def test_c1_2_monologue_trace_importance_varies_with_signal():
+    """monologue_trace importance is no longer a flat 0.3 — it varies with
+    the aggregate's peak emotion intensity across distinct inputs.
+    Fail-test: pre-change _TRACE_IMPORTANCE == 0.3 for every input."""
+    from brain.monologue.trace import _trace_importance
+
+    flat = _trace_importance({})
+    charged = _trace_importance({"joy": 9.0})
+    mild = _trace_importance({"joy": 2.0})
+    assert flat != charged
+    assert mild != charged
+    assert flat == pytest.approx(0.2)  # floor, not 0.3
+    assert charged > mild > flat
+
+
+# --------------------------------------------------------------------------- C1.3
+def test_c1_3a_dream_from_saturated_aggregate_clamped():
+    """A dream constructed from a saturated (sum > 10) emotion aggregate via
+    create_new yields importance <= 10.0. Fail-test: pre-change (no clamp in
+    create_new) a saturated aggregate produced importance > 10.0."""
+    saturated_emotions = {"love": 60.0, "awe": 50.0, "joy": 40.0}  # sum = 150
+    mem = Memory.create_new(
+        content="a vivid dream",
+        memory_type="dream",
+        domain="us",
+        emotions=saturated_emotions,
+    )
+    assert mem.importance <= 10.0
+    # Confirms the clamp actually engaged (would be 9.0 unclamped == still <=10,
+    # so use a case that clearly overflows without the clamp).
+    assert mem.importance == pytest.approx(10.0)
+
+
+def test_c1_3b_migrator_oversized_importance_clamped():
+    """An OG memory with a numeric-but-oversized importance (bypasses
+    create_new) is also clamped. Fail-test: pre-change transform.py passed
+    50.0 through unclamped."""
+    from brain.migrator.transform import transform_memory
+
+    og = {
+        "id": "og-1",
+        "content": "an old memory",
+        "created_at": "2020-01-01T00:00:00+00:00",
+        "importance": 50.0,
+    }
+    mem, skipped = transform_memory(og)
+    assert skipped is None
+    assert mem is not None
+    assert mem.importance <= 10.0
+    assert mem.importance == pytest.approx(10.0)
+
+
+def test_c1_3_clamp_importance_helper_boundaries():
+    assert clamp_importance(-5.0) == 0.0
+    assert clamp_importance(15.0) == 10.0
+    assert clamp_importance(4.2) == pytest.approx(4.2)
+
+
+# --------------------------------------------------------------------------- C1.4
+def test_c1_4_migration_og0_backfill_nonzero():
+    """An OG memory with missing importance backfills to a nonzero value
+    (not hard 0.0). Fail-test: pre-change transform.py always set 0.0 here."""
+    from brain.migrator.transform import transform_memory
+
+    # No "importance" key at all, and no emotions -> flat moderate default.
+    og_no_emotions = {
+        "id": "og-2",
+        "content": "an old memory with no signal",
+        "created_at": "2020-01-01T00:00:00+00:00",
+    }
+    mem, skipped = transform_memory(og_no_emotions)
+    assert skipped is None
+    assert mem.importance == pytest.approx(4.0)
+    assert mem.importance != 0.0
+
+    # Malformed importance (a string) + present emotions -> bucket backfill.
+    og_with_emotions = {
+        "id": "og-3",
+        "content": "an old emotional memory",
+        "created_at": "2020-01-01T00:00:00+00:00",
+        "importance": "high",  # malformed -> ignored
+        "emotions": {"joy": 25.0},  # score 25 -> bucket 7
+    }
+    mem2, skipped2 = transform_memory(og_with_emotions)
+    assert skipped2 is None
+    assert mem2.importance == pytest.approx(7.0)
+    assert mem2.importance != 0.0
+
+
+# --------------------------------------------------------------------------- C1.5
+_HIGH_END_ANCHOR_PATTERNS = [
+    re.compile(r"0\.9-1\.0"),  # chat/extractor.py _SYSTEM_PROMPT anchor
+]
+
+
+def _em_dash_free(text: str) -> bool:
+    """Normalized zero-em-dash check (U+2014)."""
+    return "—" not in text
+
+
+def test_c1_5_system_prompt_anchor_present_and_no_em_dash():
+    from brain.chat.extractor import _SYSTEM_PROMPT
+
+    assert "0.9-1.0" in _SYSTEM_PROMPT
+    assert "pivotal" in _SYSTEM_PROMPT
+    assert _em_dash_free(_SYSTEM_PROMPT)
+
+
+def test_c1_5_extraction_prompts_anchor_present_and_no_em_dash():
+    from brain.ingest.extract import EXTRACTION_PROMPT_LEGACY, EXTRACTION_PROMPT_NAMED
+
+    for prompt in (EXTRACTION_PROMPT_LEGACY, EXTRACTION_PROMPT_NAMED):
+        assert "rubric" in prompt
+        assert "pivotal" in prompt
+        assert _em_dash_free(prompt)
+
+
+def test_c1_5_em_dash_check_flags_pre_change_strings():
+    """Self-test (per criteria + plan): the SAME assertion, run against a
+    reconstruction of the PRE-CHANGE strings (which contained em-dashes),
+    must FAIL — proving the oracle can actually flag a violation."""
+    pre_change_system_prompt = (
+        "Identify what surfaced that should affect their memory, emotional "
+        "state, or growth — and what you noticed they should have done "
+        "differently."
+    )
+    pre_change_extraction_named_fragment = (
+        "{assistant_name} is the assistant — the AI persona."
+    )
+    assert not _em_dash_free(pre_change_system_prompt)
+    assert not _em_dash_free(pre_change_extraction_named_fragment)

--- a/tests/test_p3_change3_reappraisal.py
+++ b/tests/test_p3_change3_reappraisal.py
@@ -9,6 +9,7 @@ Naming: synthetic user = Bob, persona = Canary, model = Claude. No Phoebe.
 from __future__ import annotations
 
 import inspect
+from unittest.mock import patch
 
 import pytest
 
@@ -160,3 +161,35 @@ def test_c3_3_recall_enqueues_for_full_inject_and_snippet_union_not_inline(tmp_p
     assert hi.id in reappraise_ids
     assert lo.id in reappraise_ids
     store.close()
+
+
+def test_c3_3_batch_enqueue_uses_a_single_lock_and_write(tmp_path):
+    """Hot-path fix: enqueuing multiple surfaced ids from one recall turn
+    acquires `file_lock` exactly ONCE and performs exactly ONE write, not
+    one lock/open/write per id (the finding this batch API addresses).
+    Fail-test: a version that still loops per-id internally would report
+    call counts equal to the number of ids instead of 1."""
+    from brain.utils.file_lock import file_lock as real_file_lock
+
+    ids = ["id-a", "id-b", "id-c"]
+    queue = PendingQueue(tmp_path)
+
+    with patch("brain.memory.pending.file_lock", wraps=real_file_lock) as mock_lock:
+        written = queue.enqueue_reappraisals(ids, source="recall")
+
+    assert written == 3
+    assert mock_lock.call_count == 1  # ONE lock acquisition for all 3 ids
+
+    entries = queue.drain()
+    reappraise_ids = {
+        e["memory_id"] for e in entries if e.get("_route") == "reappraise_importance"
+    }
+    assert reappraise_ids == set(ids)
+
+
+def test_c3_3_batch_enqueue_empty_list_is_a_noop(tmp_path):
+    """An empty id list writes nothing and does not touch the queue file."""
+    queue = PendingQueue(tmp_path)
+    written = queue.enqueue_reappraisals([], source="recall")
+    assert written == 0
+    assert queue.drain() == []

--- a/tests/test_p3_change3_reappraisal.py
+++ b/tests/test_p3_change3_reappraisal.py
@@ -1,0 +1,162 @@
+"""Tests for P3 retention rework, Change 3 — importance re-rating on recall,
+via the pending queue.
+
+Covers C3.1-C3.3 from changes/p3-retention/1.5-criteria.md.
+
+Naming: synthetic user = Bob, persona = Canary, model = Claude. No Phoebe.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+import pytest
+
+from brain.chat import prompt as prompt_mod
+from brain.chat.prompt import _build_recall_block
+from brain.engines.consolidation import run_consolidation
+from brain.memory.pending import PendingQueue
+from brain.memory.store import Memory, MemoryStore
+
+
+def _mem(content: str, *, importance: float = 3.0) -> Memory:
+    return Memory.create_new(
+        content=content, memory_type="conversation", domain="us", importance=importance
+    )
+
+
+# --------------------------------------------------------------------------- C3.1
+def test_c3_1_reappraise_updates_existing_row_no_new_row(tmp_path):
+    """Enqueue an existing-memory re-appraise item, run the gate with an
+    injected fake appraiser returning a known importance, assert the
+    existing row's importance is updated to that value AND no new row was
+    created (row count unchanged). Fail-test: an INSERT path (new row) or an
+    unchanged importance would flag."""
+    store = MemoryStore(tmp_path / "memories.db")
+    mem = _mem("Bob's home address is 12 Elm Street", importance=3.0)
+    store.create(mem)
+    before_count = store.count(active_only=False)
+
+    PendingQueue(tmp_path).enqueue_reappraisal(mem.id, source="recall")
+
+    known_value = 7.25
+
+    def _fake_reappraiser(m: Memory) -> float:
+        return known_value
+
+    result = run_consolidation(
+        store, persona_dir=tmp_path,
+        reappraiser=_fake_reappraiser,
+    )
+    assert result.reappraised == 1
+
+    got = store.get(mem.id, bump=False)
+    assert got.importance == pytest.approx(known_value)
+    assert store.count(active_only=False) == before_count  # no INSERT — same row count
+    # A normal reappraise update does not clobber unrelated fields.
+    assert got.content == "Bob's home address is 12 Elm Street"
+    assert got.emotions == {}
+    store.close()
+
+
+def test_c3_1_default_noop_reappraiser_leaves_importance_unchanged(tmp_path):
+    """With no provider and no injected reappraiser, the default is a no-op
+    (STAGE-3 CORRECTION finding #2) — importance is unchanged, not ratcheted."""
+    store = MemoryStore(tmp_path / "memories.db")
+    mem = _mem("a stable fact", importance=4.5)
+    store.create(mem)
+    PendingQueue(tmp_path).enqueue_reappraisal(mem.id, source="recall")
+
+    result = run_consolidation(store, persona_dir=tmp_path)
+    assert result.reappraised == 1
+    got = store.get(mem.id, bump=False)
+    assert got.importance == pytest.approx(4.5)
+    store.close()
+
+
+# --------------------------------------------------------------------------- C3.2
+def test_c3_2_row_deleted_mid_window_no_resurrection_no_crash(tmp_path):
+    """A re-appraise item whose target row is hard-deleted BETWEEN the
+    handler's store.get and its store.update (injected deterministically via
+    the fake reappraiser's own side effect, which runs in that exact
+    window) does not resurrect the row and does not crash — the update is
+    skipped. Fail-test: a version that INSERTs on missing target
+    (resurrection) or raises an unhandled KeyError would flag."""
+    store = MemoryStore(tmp_path / "memories.db")
+    mem = _mem("a memory that will be deleted mid-appraisal", importance=2.0)
+    store.create(mem)
+    before_count = store.count(active_only=False)
+    PendingQueue(tmp_path).enqueue_reappraisal(mem.id, source="recall")
+
+    def _deleting_reappraiser(m: Memory) -> float:
+        # Fires strictly between the handler's store.get (already returned
+        # `m`) and its store.update — the HARDER window (finding #3).
+        store.hard_delete(m.id)
+        return 9.9
+
+    result = run_consolidation(
+        store, persona_dir=tmp_path,
+        reappraiser=_deleting_reappraiser,
+    )
+    # No crash (the try/except KeyError around store.update absorbed it).
+    assert result.reappraised == 0  # the update was skipped, not counted
+    assert store.get(mem.id, bump=False) is None  # not resurrected
+    assert store.count(active_only=False) == before_count - 1  # genuinely gone, no phantom row
+    store.close()
+
+
+def test_c3_2_row_already_missing_at_read_is_skipped(tmp_path):
+    """A re-appraise item whose target was already gone BEFORE the read
+    (the simpler window) is also skipped, not resurrected."""
+    store = MemoryStore(tmp_path / "memories.db")
+    PendingQueue(tmp_path).enqueue_reappraisal("nonexistent-id", source="recall")
+
+    def _fake_reappraiser(m: Memory) -> float:
+        raise AssertionError("reappraiser must never be called for a missing row")
+
+    result = run_consolidation(
+        store, persona_dir=tmp_path,
+        reappraiser=_fake_reappraiser,
+    )
+    assert result.reappraised == 0
+    assert store.get("nonexistent-id", bump=False) is None
+    store.close()
+
+
+# --------------------------------------------------------------------------- C3.3
+def test_c3_3_recall_hook_source_never_references_a_provider():
+    """Static check: the recall-block hook's source never references a
+    provider/appraiser — it can only enqueue. Fail-test: an inline-appraise
+    implementation would need a provider/reappraiser call at this site."""
+    src = inspect.getsource(prompt_mod._build_recall_block)
+    assert ".generate(" not in src  # the LLMProvider call surface
+    assert "reappraiser" not in src  # no inline appraiser reference at all
+    assert "enqueue_reappraisal" in src  # the hook DOES enqueue
+
+
+def test_c3_3_recall_enqueues_for_full_inject_and_snippet_union_not_inline(tmp_path):
+    """Exercising the recall-block hook enqueues a re-appraise request for
+    BOTH a full-inject (full_ids) and a snippet (bump_targets) surfaced
+    memory id (finding #5), and does NOT invoke any appraiser/provider
+    inline: importance is bit-for-bit unchanged immediately after the call
+    (appraisal only ever happens later, at the gate's own tick)."""
+    store = MemoryStore(tmp_path / "memories.db")
+    hi = _mem("lighthouse beacon primary marker signal", importance=9.5)  # -> full_ids
+    lo = _mem("lighthouse beacon secondary marker signal", importance=2.0)  # -> bump_targets
+    store.create(hi)
+    store.create(lo)
+
+    block = _build_recall_block(store, "lighthouse beacon marker", persona_dir=tmp_path)
+    assert block.strip() != ""
+
+    # Enqueue-only: no inline appraisal happened — importance untouched.
+    assert store.get(hi.id, bump=False).importance == pytest.approx(9.5)
+    assert store.get(lo.id, bump=False).importance == pytest.approx(2.0)
+
+    entries = PendingQueue(tmp_path).drain()
+    reappraise_ids = {
+        e["memory_id"] for e in entries if e.get("_route") == "reappraise_importance"
+    }
+    assert hi.id in reappraise_ids
+    assert lo.id in reappraise_ids
+    store.close()

--- a/tests/test_p3_change4_dedup_sweep.py
+++ b/tests/test_p3_change4_dedup_sweep.py
@@ -1,0 +1,149 @@
+"""Tests for P3 retention rework, Change 4 — one-time duplicate cleanup.
+
+Covers C4.1 from changes/p3-retention/1.5-criteria.md.
+
+Naming: synthetic user = Bob, persona = Canary, model = Claude. No Phoebe.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from brain.engines.consolidation import _ARCHIVE_FILENAME
+from brain.engines.dedup_sweep import run_dedup_sweep
+from brain.memory.store import Memory, MemoryStore
+
+
+def _mem(content: str, *, importance: float = 3.0) -> Memory:
+    return Memory.create_new(
+        content=content, memory_type="conversation", domain="us", importance=importance
+    )
+
+
+# --------------------------------------------------------------------------- C4.1
+def test_c4_1_sweep_reduces_by_duplicate_surplus_lossless_and_reported(tmp_path):
+    """A seeded corpus with a known exact-duplicate group (3 rows, same
+    normalized content) plus distinct items: the sweep reduces the active
+    count by exactly the duplicate surplus (2), every distinct content
+    string remains present+active, each removed pre-image is archived, and
+    a report is emitted. Fail-test: a no-op sweep (no reduction) or any
+    missing distinct string flags; an unarchived merge flags."""
+    store = MemoryStore(tmp_path / "memories.db")
+
+    dup_a = _mem("Bob's favorite color is blue.", importance=2.0)
+    dup_b = _mem("bob's   favorite color is blue.", importance=6.0)  # normalizes equal to dup_a
+    dup_c = _mem("BOB'S FAVORITE COLOR IS BLUE.", importance=1.0)
+    distinct_1 = _mem("Bob went hiking on Saturday.", importance=4.0)
+    distinct_2 = _mem("Bob's dog is named Rex.", importance=5.0)
+
+    for m in (dup_a, dup_b, dup_c, distinct_1, distinct_2):
+        store.create(m)
+
+    before_count = store.count(active_only=True)
+    assert before_count == 5
+
+    report = run_dedup_sweep(store, tmp_path)
+
+    after_count = store.count(active_only=True)
+    assert after_count == before_count - 2  # exactly the duplicate surplus (3 -> 1)
+    assert report.groups_merged == 1
+    assert report.rows_removed == 2
+
+    survivors = {m.content for m in store.list_active()}
+    assert "Bob went hiking on Saturday." in survivors
+    assert "Bob's dog is named Rex." in survivors
+    # Exactly one of the three duplicate spellings remains (whichever was
+    # kept as canonical).
+    dup_spellings = {dup_a.content, dup_b.content, dup_c.content}
+    assert len(dup_spellings & survivors) == 1
+
+    # Canonical carries the max importance across the merged group (6.0).
+    remaining_dup_id = next(
+        m.id for m in store.list_active() if m.content in dup_spellings
+    )
+    remaining = store.get(remaining_dup_id, bump=False)
+    assert remaining.importance == pytest.approx(6.0)
+
+    # Loss-preserving: every removed row's full pre-image is archived BEFORE
+    # removal, reason "dedup_sweep".
+    archive_path = tmp_path / _ARCHIVE_FILENAME
+    assert archive_path.exists()
+    archived_records = [json.loads(line) for line in archive_path.read_text().splitlines()]
+    assert len(archived_records) == 2
+    for rec in archived_records:
+        assert rec["reason"] == "dedup_sweep"
+    archived_contents = {rec["target"]["content"] for rec in archived_records}
+    assert archived_contents == (dup_spellings - survivors)
+
+    # Report file emitted.
+    report_path = tmp_path / "dedup_sweep_report.jsonl"
+    assert report_path.exists()
+    report_records = [json.loads(line) for line in report_path.read_text().splitlines()]
+    assert report_records[-1]["rows_removed"] == 2
+    assert report_records[-1]["groups_merged"] == 1
+    assert len(report_records[-1]["merges"]) == 2
+
+    store.close()
+
+
+def test_c4_1_sweep_is_idempotent(tmp_path):
+    store = MemoryStore(tmp_path / "memories.db")
+    store.create(_mem("Repeated content.", importance=2.0))
+    store.create(_mem("repeated   content.", importance=5.0))
+    store.create(_mem("A distinct memory.", importance=1.0))
+
+    first = run_dedup_sweep(store, tmp_path)
+    assert first.rows_removed == 1
+    second = run_dedup_sweep(store, tmp_path)
+    assert second.rows_removed == 0
+    assert second.groups_merged == 0
+    store.close()
+
+
+def test_c4_1_no_duplicates_is_a_true_no_op(tmp_path):
+    store = MemoryStore(tmp_path / "memories.db")
+    store.create(_mem("First distinct memory."))
+    store.create(_mem("Second distinct memory."))
+    before = store.count(active_only=True)
+    report = run_dedup_sweep(store, tmp_path)
+    assert store.count(active_only=True) == before
+    assert report.rows_removed == 0
+    assert report.groups_merged == 0
+    store.close()
+
+
+def test_c4_1_optional_near_dup_judge_layer(tmp_path):
+    """The optional injectable near-dup judge (default OFF) can merge a pair
+    the exact-normalize layer does not catch."""
+    store = MemoryStore(tmp_path / "memories.db")
+    older = _mem("Bob likes tea.", importance=3.0)
+    newer = _mem("Bob likes tea with honey.", importance=7.0)
+    store.create(older)
+    store.create(newer)
+
+    def _judge(candidate: Memory, canonical: Memory) -> str:
+        if "tea" in candidate.content and "tea" in canonical.content:
+            return "duplicate"
+        return "distinct"
+
+    report = run_dedup_sweep(store, tmp_path, judge=_judge)
+    assert report.rows_removed == 1
+    survivors = store.list_active()
+    assert len(survivors) == 1
+    # Canonical (older) absorbed the higher importance from the near-dup.
+    assert survivors[0].importance == pytest.approx(7.0)
+    store.close()
+
+
+def test_c4_1_no_judge_leaves_near_dups_untouched(tmp_path):
+    """Default (no judge): only the deterministic exact-normalize layer
+    runs — near-duplicates with different wording are left alone."""
+    store = MemoryStore(tmp_path / "memories.db")
+    store.create(_mem("Bob likes tea.", importance=3.0))
+    store.create(_mem("Bob likes tea with honey.", importance=7.0))
+    report = run_dedup_sweep(store, tmp_path)
+    assert report.rows_removed == 0
+    assert store.count(active_only=True) == 2
+    store.close()

--- a/tests/unit/brain/migrator/test_transform.py
+++ b/tests/unit/brain/migrator/test_transform.py
@@ -72,7 +72,10 @@ def test_transform_uses_emotion_score_as_score() -> None:
 
 
 def test_transform_defaults_missing_optional_fields() -> None:
-    """Missing tags / importance / active fall back to sensible defaults."""
+    """Missing tags / active fall back to sensible defaults. Missing
+    importance with no emotions to backfill from defaults to a moderate 4.0
+    (P3 retention rework, Change 1 — OG-0 backfill: migrated history must
+    not mass-evict at an importance-driven decay baseline of 0.0)."""
     minimal = {
         "id": "m2",
         "content": "x",
@@ -84,7 +87,7 @@ def test_transform_defaults_missing_optional_fields() -> None:
     assert skipped is None
     assert mem is not None
     assert mem.tags == []
-    assert mem.importance == 0.0
+    assert mem.importance == 4.0
     assert mem.active is True
     assert mem.emotions == {}
     assert mem.score == 0.0
@@ -184,20 +187,25 @@ def test_skipped_memory_dataclass_shape() -> None:
     assert s.raw_snippet == "..."
 
 
-def test_transform_non_numeric_importance_degrades_to_zero() -> None:
-    """Non-numeric importance (e.g. 'high') must not crash float() — degrade to 0.0."""
+def test_transform_non_numeric_importance_degrades_to_emotion_backfill() -> None:
+    """Non-numeric importance (e.g. 'high') must not crash float() — it is
+    treated as malformed/missing and backfilled from emotions (P3 retention
+    rework, Change 1: `_og()`'s default emotions={"love": 9.0} -> emotion_score
+    9.0 -> bucket 3.0), not a hard 0.0."""
     mem, skipped = transform_memory(_og(importance="high"))
     assert skipped is None
     assert mem is not None
-    assert mem.importance == 0.0
+    assert mem.importance == 3.0
 
 
-def test_transform_list_importance_degrades_to_zero() -> None:
-    """A list-valued importance field degrades to 0.0 rather than crashing."""
+def test_transform_list_importance_degrades_to_emotion_backfill() -> None:
+    """A list-valued importance field degrades gracefully (no crash) and is
+    backfilled from emotions the same way a missing importance is, not a
+    hard 0.0."""
     mem, skipped = transform_memory(_og(importance=[1, 2, 3]))
     assert skipped is None
     assert mem is not None
-    assert mem.importance == 0.0
+    assert mem.importance == 3.0
 
 
 def test_transform_string_tags_degrades_to_empty_list() -> None:


### PR DESCRIPTION
Phase 3 of the memory/dream rework. Makes `importance` the master retention lever, so
deliberate/important information survives while unremarkable content still fades — and lets a
memory's importance move over its life.

Part of #66 (items 1 & 3: salience mis-scoring evicts important memories; dedup audit). Does not
close #66 — the umbrella spans later phases.

## In scope (four coupled changes)
1. **Trustworthy importance assignment.** Fix the shared `/10` auto-default deflation in
   `Memory.create_new` (prefer explicit per-call-site importance) and the always-zero producers
   (reflex, journal, research), differentiate the flat `monologue_trace`, de-bias the monologue
   "conservative" prompt, add an importance rubric to the extraction prompt, and settle the
   migration backfill — so no genuinely-important content sits at ~0 purely by mechanism.
2. **Importance-driven decay rate.** `importance` slows forgetting: 0 = today's baseline (unchanged),
   higher = proportionally slower, 10 ≈ years untouched; never accelerates below baseline.
3. **On-recall importance re-rating via the pending queue.** A recalled memory re-enqueues tagged
   "existing memory"; the gate re-appraises importance off the hot path and updates the existing row
   (no new row, no per-turn latency).
4. **One-time duplicate cleanup.** Loss-preserving retroactive merge of near-dups (archive before
   merge) with a report.

## Out of scope
Content replacement/supersedes and companion-queued updates (→ P5), non-recall auto re-rating, the
`protected` never-forget pin (dropped). The hebbian→memories.db fold (#128) is its own separate PR.

## Coordination
The only recall-assembly touch is the enqueue hook in the recall path (`chat/prompt.py` /
`memory/relevance.py`). Verified no file overlap with the currently-open PRs #204 (`brain/cli.py`),
#207 (`bridge.ts` / `server.py`), and #209 (two test files). Will re-check at merge time.

Draft opened as a coordination signal before implementation; built via a guarded-change run against
the spec's acceptance criteria. Status will track here as commits land.
