### PR TITLE
fix: audit-mark deduped monologue; re-run vocab placeholder backfill (#175 #173)

### DIFF
--- a/brain/chat/monologue_capture.py
+++ b/brain/chat/monologue_capture.py
@@ -48,7 +48,7 @@ def capture_monologue(
     monologue: str,
     feed_digest: str,
     surface: bool = True,
-) -> str:
+) -> str | None:
     """Validate, persist the Tier-2 trace memory + the gated Tier-3 digest line.
 
     Returns the monologue text. Raises CaptureRejected on validation failure
@@ -88,7 +88,10 @@ def capture_monologue(
 
         recent = PendingQueue(store.persona_dir).read_recent(MONOLOGUE_TRACE_TYPE, limit=1)
         if recent and recent[0].content == monologue:
-            return monologue
+            # #175: None tells the caller this was a dedupe, not a capture, so
+            # dispatch does not emit monologue_text for the duplicate (the key
+            # the audit row and the pass-2 trigger key on).
+            return None
     except Exception:  # noqa: BLE001
         logger.debug("monologue dedupe lookup failed; capturing anyway", exc_info=True)
 

--- a/brain/health/vocab_repair.py
+++ b/brain/health/vocab_repair.py
@@ -84,11 +84,15 @@ def _save_state(persona_dir: Path, state: dict) -> None:
 # ---------------------------------------------------------------------------
 
 def should_run_vocab_repair(persona_dir: Path) -> bool:
-    """Return True iff vocab_repair has not completed AND the vocab file has stubs."""
-    existing = _load_state(persona_dir)
-    if existing is not None and existing.get("status") == "complete":
-        return False
+    """Return True iff the vocab file has any placeholder-description entry.
 
+    #173: the completed-state file only retires Step 1 (the one-time 1.0 → 14.0
+    half-life bump). Placeholders keep being minted afterwards by
+    reconstruct.py / persona_loader.py (already at 14.0), so Step 2 (describe)
+    must be allowed to run again whenever any placeholder exists. The
+    supervisor only asks at startup, so the retry cadence is once per bridge
+    start, bounded by _DESCRIBE_BATCH per run.
+    """
     vocab_path = persona_dir / "emotion_vocabulary.json"
     if not vocab_path.exists():
         return False
@@ -101,11 +105,7 @@ def should_run_vocab_repair(persona_dir: Path) -> bool:
     from brain.health.reconstruct import PLACEHOLDER_DESCRIPTION
 
     for entry in data.get("emotions", []):
-        if (
-            isinstance(entry, dict)
-            and entry.get("description") == PLACEHOLDER_DESCRIPTION
-            and entry.get("decay_half_life_days") == _OLD_STUB_DECAY_DAYS
-        ):
+        if isinstance(entry, dict) and entry.get("description") == PLACEHOLDER_DESCRIPTION:
             return True
     return False
 
@@ -116,17 +116,26 @@ def run_vocab_repair(
     store: MemoryStore,
     provider: LLMProvider | None,
 ) -> RepairReport:
-    """Run the one-time vocab repair. Idempotent — skips if state==complete.
+    """Run the vocab repair.
+
+    Step 1 (bump legacy 1.0 half-life stubs to 14.0) is one-time, retired by
+    the completed-state file. Step 2 (derive a description for every
+    placeholder entry) runs whenever placeholders exist and a provider is
+    available (#173). Counts in the state file accumulate across runs.
 
     Returns a RepairReport whether or not work was done.
     """
     from brain.health.reconstruct import PLACEHOLDER_DESCRIPTION
 
     existing = _load_state(persona_dir)
-    if existing is not None and existing.get("status") == "complete":
+    prior_complete = existing is not None and existing.get("status") == "complete"
+    prior_repaired = int(existing.get("repaired", 0)) if prior_complete else 0
+    prior_described = int(existing.get("described", 0)) if prior_complete else 0
+    if prior_complete and provider is None:
+        # Step 1 already done and Step 2 needs a provider: nothing to do.
         return RepairReport(
-            repaired=existing.get("repaired", 0),
-            described=existing.get("described", 0),
+            repaired=prior_repaired,
+            described=prior_described,
             status="complete",
             completed_at=existing.get("completed_at", ""),
         )
@@ -151,12 +160,12 @@ def run_vocab_repair(
     for entry in emotions:
         if not isinstance(entry, dict):
             continue
-        if (
-            entry.get("description") == PLACEHOLDER_DESCRIPTION
-            and entry.get("decay_half_life_days") == _OLD_STUB_DECAY_DAYS
-        ):
+        if entry.get("description") != PLACEHOLDER_DESCRIPTION:
+            continue
+        # Step 2 target: every placeholder, whatever its half-life (#173).
+        stub_names.append(entry["name"])
+        if not prior_complete and entry.get("decay_half_life_days") == _OLD_STUB_DECAY_DAYS:
             entry["decay_half_life_days"] = _REPAIRED_DECAY_DAYS
-            stub_names.append(entry["name"])
             repaired += 1
 
     if repaired > 0:
@@ -169,12 +178,9 @@ def run_vocab_repair(
         )
 
     # ------------------------------------------------------------------
-    # Step 2: derive descriptions via provider (fail-soft)
-    # F4 (crash-window): if the process dies here — after the Step-1 vocab
-    # write but before the state-file write at the end — the next run finds
-    # no 1.0-decay entries and therefore no stub_names, so Step 2 is silently
-    # skipped forever.  That is accepted: Step 1 (the load-bearing half-life
-    # fix) has already landed, and placeholder descriptions are cosmetic.
+    # Step 2: derive descriptions via provider (fail-soft). Re-runnable: any
+    # placeholder still present (crash here, provider failure, or a newly
+    # minted one) is picked up on the next startup pass (#173).
     # ------------------------------------------------------------------
     described = 0
     if provider is not None and stub_names:
@@ -192,7 +198,11 @@ def run_vocab_repair(
                 "vocab_repair: Step 2 description derivation failed (kept placeholders): %s", exc
             )
 
-    return _write_and_return(persona_dir, repaired=repaired, described=described)
+    return _write_and_return(
+        persona_dir,
+        repaired=prior_repaired + repaired,
+        described=prior_described + described,
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/brain/mcp_server/tools.py
+++ b/brain/mcp_server/tools.py
@@ -118,13 +118,17 @@ def register_tools(
             # committed one in the invocation record. Mirrors tool_loop.py's
             # in-process outcome semantics exactly.
             refusal_error = result.get("error") if isinstance(result, dict) else None
+            # #175: a record_monologue the capture layer deduped is still a
+            # dispatch that happened — audit it, but marked, so the log no
+            # longer shows two "ok" captures per turn.
+            deduped = isinstance(result, dict) and result.get("deduped") is True
             log_invocation(
                 persona_dir,
                 name=name,
                 arguments=arguments,
                 result_summary=_summarize(payload),
                 error=refusal_error,
-                outcome="refused" if refusal_error else "ok",
+                outcome="refused" if refusal_error else ("deduped" if deduped else "ok"),
                 monologue_text=monologue_text,
             )
             return [TextContent(type="text", text=payload)]

--- a/brain/tools/dispatch.py
+++ b/brain/tools/dispatch.py
@@ -192,6 +192,10 @@ def _dispatch_record_monologue(
             feed_digest=feed_digest,
             surface=surface,
         )
+        if captured is None:
+            # #175: deduped by capture_monologue (recruit-on-reach rerun). No
+            # monologue_text on purpose — see tool_loop._find_monologue_text.
+            return {"ok": True, "deduped": True}
         return {"ok": True, "monologue_text": captured}
     except CaptureRejected as exc:
         return {"error": str(exc)}

--- a/tests/unit/brain/chat/test_monologue_capture.py
+++ b/tests/unit/brain/chat/test_monologue_capture.py
@@ -171,3 +171,24 @@ def test_a_different_monologue_still_captures(tmp_path: Path):
     _promote_pending(tmp_path)
 
     assert len(store.list_by_type(MONOLOGUE_TRACE_TYPE, active_only=True)) == 2
+
+
+def test_deduped_capture_returns_none(tmp_path: Path):
+    """#175: the caller must be able to tell a dedupe from a capture.
+
+    Returning the monologue string on the dedupe branch made dispatch emit
+    ``monologue_text`` for the duplicate too — so the audit row (and anything
+    keyed on monologue_text, e.g. the pass-2 trigger) saw two captures.
+    """
+    from brain.chat.monologue_capture import capture_monologue
+
+    store = _store(tmp_path)
+    thought = "A name I could not place, and it bothered me."
+    first = capture_monologue(
+        persona_dir=tmp_path, store=store, monologue=thought, feed_digest="d"
+    )
+    second = capture_monologue(
+        persona_dir=tmp_path, store=store, monologue=thought, feed_digest="d"
+    )
+    assert first == thought
+    assert second is None

--- a/tests/unit/brain/health/test_vocab_repair.py
+++ b/tests/unit/brain/health/test_vocab_repair.py
@@ -68,8 +68,11 @@ def test_should_run_true_when_stubs_present_no_state(tmp_path: Path) -> None:
     assert should_run_vocab_repair(tmp_path) is True
 
 
-def test_should_run_false_when_state_complete(tmp_path: Path) -> None:
-    """Complete state file → should_run returns False regardless of vocab."""
+def test_should_run_true_when_state_complete_but_placeholder_remains(tmp_path: Path) -> None:
+    """Complete state file no longer silences should_run while a placeholder
+    description remains (#173). The old assertion ("False regardless of vocab")
+    was the bug: nothing ever backfilled placeholders minted after the one-time
+    repair."""
     from brain.health.vocab_repair import should_run_vocab_repair
 
     _write_vocab(tmp_path, [_stub_entry("body_grief")])
@@ -80,7 +83,7 @@ def test_should_run_false_when_state_complete(tmp_path: Path) -> None:
         "completed_at": "2026-06-10T00:00:00Z",
     }
     (tmp_path / "vocab_repair_state.json").write_text(json.dumps(state), encoding="utf-8")
-    assert should_run_vocab_repair(tmp_path) is False
+    assert should_run_vocab_repair(tmp_path) is True
 
 
 def test_should_run_false_when_no_stubs(tmp_path: Path) -> None:
@@ -131,8 +134,9 @@ def test_repair_bumps_only_stub_entries(tmp_path: Path) -> None:
 
 
 def test_repair_idempotent(tmp_path: Path) -> None:
-    """Complete state file → run_vocab_repair returns early without touching the vocab file."""
-    from brain.health.vocab_repair import run_vocab_repair, should_run_vocab_repair
+    """Complete state + no provider → run_vocab_repair returns early without
+    touching the vocab file (Step 1 is done; Step 2 needs a provider)."""
+    from brain.health.vocab_repair import run_vocab_repair
 
     _write_vocab(tmp_path, [_stub_entry("body_grief")])
     state = {
@@ -144,8 +148,6 @@ def test_repair_idempotent(tmp_path: Path) -> None:
     state_path = tmp_path / "vocab_repair_state.json"
     state_path.write_text(json.dumps(state), encoding="utf-8")
     orig_vocab_mtime = (tmp_path / "emotion_vocabulary.json").stat().st_mtime
-
-    assert should_run_vocab_repair(tmp_path) is False
 
     store = _make_store(tmp_path)
     try:
@@ -322,3 +324,69 @@ def test_repair_no_stubs_noop(tmp_path: Path) -> None:
 
     state = json.loads((tmp_path / "vocab_repair_state.json").read_text(encoding="utf-8"))
     assert state["repaired"] == 0
+
+
+# ---------------------------------------------------------------------------
+# #173 — placeholders minted AFTER the one-time repair are never backfilled
+# ---------------------------------------------------------------------------
+
+def _new_placeholder_entry(name: str) -> dict:
+    """An entry as reconstruct.py / persona_loader.py mint it TODAY: placeholder
+    description with the already-correct 14.0 half-life."""
+    return {
+        "name": name,
+        "description": PLACEHOLDER_DESCRIPTION,
+        "category": "persona_extension",
+        "decay_half_life_days": 14.0,
+        "intensity_clamp": 10.0,
+    }
+
+
+def _complete_state(tmp_path: Path, *, repaired: int = 1, described: int = 0) -> None:
+    state = {
+        "status": "complete",
+        "repaired": repaired,
+        "described": described,
+        "completed_at": "2026-06-10T00:00:00Z",
+    }
+    (tmp_path / "vocab_repair_state.json").write_text(json.dumps(state), encoding="utf-8")
+
+
+def test_should_run_true_for_new_placeholder_after_state_complete(tmp_path: Path) -> None:
+    """A 14.0-half-life placeholder minted after the one-time repair completed
+    still needs a description — should_run must say so."""
+    from brain.health.vocab_repair import should_run_vocab_repair
+
+    _write_vocab(tmp_path, [_new_placeholder_entry("quiet_dread"), _proper_entry("love")])
+    _complete_state(tmp_path)
+    assert should_run_vocab_repair(tmp_path) is True
+
+
+def test_repair_describes_new_placeholders_after_state_complete(tmp_path: Path) -> None:
+    """Step 2 (describe) runs for every placeholder regardless of half-life or
+    prior completion; Step 1 (the 1.0 → 14.0 bump) stays one-time."""
+    from brain.health.vocab_repair import run_vocab_repair
+
+    _write_vocab(tmp_path, [_new_placeholder_entry("quiet_dread"), _proper_entry("love")])
+    _complete_state(tmp_path, repaired=1, described=1)
+    provider = _FakeProvider(response=json.dumps({"quiet_dread": "a low hum of unease"}))
+
+    store = _make_store(tmp_path)
+    store.create(Memory.create_new(
+        content="memory referencing quiet_dread",
+        memory_type="conversation",
+        domain="us",
+        emotions={"quiet_dread": 5.0},
+    ))
+    try:
+        report = run_vocab_repair(tmp_path, store=store, provider=provider)
+    finally:
+        store.close()
+
+    assert report.repaired == 1  # unchanged — Step 1 did not re-run
+    assert report.described == 2  # prior 1 + this run's 1
+    data = json.loads((tmp_path / "emotion_vocabulary.json").read_text(encoding="utf-8"))
+    by_name = {e["name"]: e for e in data["emotions"]}
+    assert by_name["quiet_dread"]["description"] == "a low hum of unease"
+    assert by_name["quiet_dread"]["decay_half_life_days"] == 14.0
+    assert by_name["love"]["description"] == "a real description"

--- a/tests/unit/brain/mcp_server/test_tools.py
+++ b/tests/unit/brain/mcp_server/test_tools.py
@@ -330,3 +330,28 @@ def _call_request(name: str, arguments: dict):
         method="tools/call",
         params=CallToolRequestParams(name=name, arguments=arguments),
     )
+
+
+def test_register_tools_logs_deduped_outcome_for_duplicate_monologue(
+    persona_dir: Path, fake_stores, monkeypatch
+) -> None:
+    """#175: a deduped record_monologue is audited as outcome="deduped", not a
+    second "ok" row carrying monologue_text. The audit trail still records that
+    the dispatch happened — it is marked, not suppressed."""
+    from mcp.server import Server
+
+    from brain.mcp_server.tools import register_tools
+
+    monkeypatch.delenv("NELL_MCP_SESSION_ID", raising=False)
+    store, hebbian = fake_stores
+    server = Server("brain-tools")
+
+    with patch("brain.mcp_server.tools.dispatch", return_value={"ok": True, "deduped": True}):
+        register_tools(server, persona_dir=persona_dir, store=store, hebbian=hebbian)
+        call_handler = _get_call_handler(server)
+        asyncio.run(call_handler(_call_request("record_monologue", {"monologue": "t", "feed_digest": "d"})))
+
+    rec = json.loads((persona_dir / "tool_invocations.log.jsonl").read_text(encoding="utf-8"))
+    assert rec["name"] == "record_monologue"
+    assert rec["outcome"] == "deduped"
+    assert not rec.get("monologue_text")

--- a/tests/unit/brain/tools/test_dispatch_record_monologue.py
+++ b/tests/unit/brain/tools/test_dispatch_record_monologue.py
@@ -79,3 +79,26 @@ def test_dispatch_record_monologue_rejected_returns_error_dict(tmp_path: Path):
     finally:
         store.close()
         hebbian.close()
+
+
+def test_dispatch_record_monologue_marks_duplicate_without_monologue_text(tmp_path: Path):
+    """#175: the recruit-on-reach rerun dispatches record_monologue twice; the
+    second is deduped by capture_monologue and must NOT come back carrying
+    ``monologue_text`` (that key is what the audit row + pass-2 trigger key on)."""
+    from brain.memory.hebbian import HebbianMatrix
+    from brain.memory.store import MemoryStore
+    from brain.tools.dispatch import dispatch
+
+    persona_dir = tmp_path / "personas" / "nell"
+    persona_dir.mkdir(parents=True)
+    store = MemoryStore(persona_dir / "memories.db")
+    hebbian = HebbianMatrix(persona_dir / "hebbian.db")
+    args = {"monologue": "thought", "feed_digest": "digest"}
+    try:
+        first = dispatch("record_monologue", args, store=store, hebbian=hebbian, persona_dir=persona_dir)
+        second = dispatch("record_monologue", args, store=store, hebbian=hebbian, persona_dir=persona_dir)
+        assert first == {"ok": True, "monologue_text": "thought"}
+        assert second == {"ok": True, "deduped": True}
+    finally:
+        store.close()
+        hebbian.close()


### PR DESCRIPTION
## Summary
Two small monologue/vocab hygiene defects, both verified at HEAD.

- **#175** `capture_monologue` returned the monologue string on the dedupe branch as well, so `dispatch` emitted `monologue_text` for the duplicate and the audit log carried two `ok` captures per turn. Now: dedupe returns `None`, dispatch returns `{"ok": true, "deduped": true}` without `monologue_text`, and the MCP audit row is `outcome="deduped"`. The dispatch is still logged because the log is an audit trail. Side effect worth knowing: `monologue_text` is also what the pass-2 trigger keys on, so the duplicate no longer looks like a second capture there either.
- **#173** `vocab_repair` matched only the legacy 1.0-half-life stub shape, and its completed-state file silenced `should_run` forever. Every placeholder minted since (already at 14.0) was never described. Step 1 (the half-life bump) stays one-time. Step 2 (describe) now targets every placeholder and can run again whenever one exists. The supervisor only asks at startup, so retries are once per bridge start, capped at `_DESCRIBE_BATCH` per run.

## Verification
- Root causes read at HEAD.
- **Test-first**: 5 tests red before the change (dedupe returned the string; dispatch returned `monologue_text` for the duplicate; audit outcome `ok`; `should_run` False with a 14.0 placeholder; `described` not incremented). 
- One existing test asserted the bug (`should_run` False "regardless of vocab" with a placeholder still present). Renamed and flipped, with the reason in its docstring. The idempotency test still holds: complete state + no provider touches nothing.

## Gate
- `uv run pytest`: 4675 passed, 6 failed. Same 6 as `main` @ db0fec1a (2× live claude-cli in the agent shell, 2× local dangling `.claude/skills/caveman*` symlinks, #205, #206 which #209 fixes).
- `ruff check .` clean. `pnpm test` + `pnpm build` clean. Pre-existing `ruff format` drift on these files left untouched.

Closes #175
Closes #173

🤖 Generated with [Claude Code](https://claude.com/claude-code)