### PR TITLE
fix(gui): gate the claude login step on the persona's provider (#172)

### DIFF
--- a/app/src/App.brainLogin.test.tsx
+++ b/app/src/App.brainLogin.test.tsx
@@ -248,6 +248,55 @@ describe("App brain-login banner", () => {
     expect(screen.getByTestId("chat-messages")).toBeInTheDocument();
   });
 
+  // #172: the login step is claude-code specific. A persona on any other
+  // provider must never see it — and must not even be probed for it.
+  it("skips the claude login probe and offer when the persona's provider is not claude-cli", async () => {
+    brainLoginStatus.mockResolvedValue({ authorized: false });
+    fetchPersonaState.mockResolvedValue({
+      persona: "nell",
+      emotions: {},
+      body: null,
+      interior: { dream: null, research: null, heartbeat: null, reflex: null },
+      soul_highlight: null,
+      connection: { provider: "ollama", model: null, last_heartbeat_at: null },
+      mode: "live",
+      recovering: false,
+      felt_time_recovered: false,
+    });
+
+    render(<App />);
+
+    await waitFor(() => expect(screen.getByTestId("chat-messages")).toBeInTheDocument());
+    await waitFor(() => expect(fetchPersonaState).toHaveBeenCalled());
+    // Give any (wrong) probe a chance to land before asserting its absence.
+    await new Promise((r) => setTimeout(r, 50));
+    expect(screen.queryByRole("button", { name: /authorize/i })).not.toBeInTheDocument();
+    expect(brainLoginStatus).not.toHaveBeenCalled();
+  });
+
+  it("still probes when the state poll fails, so the offer stays reachable with the bridge down", async () => {
+    brainLoginStatus.mockResolvedValue({ authorized: false });
+    fetchPersonaState.mockRejectedValue(new Error("bridge unreachable"));
+
+    render(<App />);
+
+    await waitFor(() => expect(brainLoginStatus).toHaveBeenCalled());
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /authorize/i })).toBeInTheDocument(),
+    );
+  });
+
+  it("still probes and offers login for a claude-cli persona", async () => {
+    brainLoginStatus.mockResolvedValue({ authorized: false });
+
+    render(<App />);
+
+    await waitFor(() => expect(brainLoginStatus).toHaveBeenCalled());
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /authorize/i })).toBeInTheDocument(),
+    );
+  });
+
   it("swallows brainLoginStatus failures — treated as no banner, chat still renders", async () => {
     brainLoginStatus.mockRejectedValue(new Error("boom"));
 

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -343,8 +343,32 @@ function Ready({ config, setConfig, persona }: ReadyProps) {
   const [brainPromptDismissed, setBrainPromptDismissed] = useState(false);
   const restartBridge = useRestartBridge(persona, state?.mode ?? "live");
 
+  // #172: the login step is claude-code specific. Probe only once the
+  // persona's state reports provider === "claude-cli", or when the state
+  // poll has failed (bridge unreachable — keep the offer reachable rather
+  // than hide it behind a state we can't read). While state is still
+  // loading: hold (null → no banner). Any other provider: never probed.
+  const stateProvider = state?.connection?.provider ?? null;
+  const loginProbe: "probe" | "skip" | "hold" =
+    stateProvider === "claude-cli" || stateError !== null
+      ? "probe"
+      : stateProvider === null
+        ? "hold"
+        : "skip";
+
   useEffect(() => {
     let cancelled = false;
+    if (loginProbe === "hold") {
+      return () => {
+        cancelled = true;
+      };
+    }
+    if (loginProbe === "skip") {
+      setBrainAuthorized(true);
+      return () => {
+        cancelled = true;
+      };
+    }
     brainLoginStatus()
       .then((res) => {
         if (!cancelled) setBrainAuthorized(res.authorized);
@@ -357,7 +381,7 @@ function Ready({ config, setConfig, persona }: ReadyProps) {
     return () => {
       cancelled = true;
     };
-  }, [persona]);
+  }, [persona, loginProbe]);
 
   const refetchState = useCallback(async () => {
     try {


### PR DESCRIPTION
## Summary
`App.tsx` probed claude-code auth on every launch keyed only on the persona, never reading `state.connection.provider`, which the state response already carries. The banner is now:

- **probed** once state reports `claude-cli`, or when the state poll failed (bridge unreachable, so the offer stays reachable);
- **held** (no banner) while state is still loading;
- **skipped**, auth marked satisfied, for any other provider.

Frontend-only. The Tauri auth commands in `lib.rs` are untouched; they remain claude-specific, which is fine once nothing calls them for other providers.

## Verification
- Root cause read at HEAD: the effect's dependency list was `[persona]` and the body never referenced the state.
- **Test-first**: the ollama-persona test was red before the change (offer rendered). A first fix that probed while state was unknown still failed it (probe fired before state loaded), which is what drove the hold state. A claude-cli regression guard and a state-poll-failure guard were added; the latter passes on old code too, it is a guard not a red test.
- Not browser-verified: `brainLoginStatus` is a Tauri invoke, so outside the Tauri shell it rejects and the banner never appears regardless. Vitest covers the three branches.

## Gate
- `pnpm test`: 351 passed. `pnpm build` (tsc + vite): clean.
- `uv run pytest`: 4670 passed, 6 failed, the same 6 as `main` @ db0fec1a (2× live claude-cli in the agent shell, 2× local dangling `.claude/skills/caveman*` symlinks, #205, #206 which #209 fixes). `ruff check .` clean.

## Batch E siblings, not in this PR
- #181: cannot reproduce from code; asked the reporter for config files before/after restart (comment on the issue).
- #171: needs a Linux repro of `claude auth login` output; asked on the issue. With this PR, non-claude personas never reach that flow.

Closes #172

🤖 Generated with [Claude Code](https://claude.com/claude-code)