### PR TITLE
fix(chat): show local system time to the companion, not UTC

### DIFF
--- a/brain/bridge/provider.py
+++ b/brain/bridge/provider.py
@@ -1584,6 +1584,7 @@ def _format_claude_context_block(
         "Conversation context is encoded below as JSONL data, not as a transcript to continue.",
     ]
     if include_block_clock:
+        # tz-local-display: block-level "Current time:" anchor (image path etc.)
         now_iso = format_local(now or datetime.now(UTC))
         lines.append(f"Current time: {now_iso}.")
         lines.append(
@@ -1608,7 +1609,7 @@ def _claude_context_jsonl_lines(messages: list[ChatMessage]) -> Iterator[str]:
             "text": msg.content_text(),
         }
         if msg.ts:
-            record["ts"] = local_display(msg.ts)
+            record["ts"] = local_display(msg.ts)  # tz-local-display: per-message ts in JSONL chat context
         if msg.tool_call_id:
             record["tool_call_id"] = msg.tool_call_id
         if msg.tool_calls:

--- a/brain/bridge/provider.py
+++ b/brain/bridge/provider.py
@@ -48,6 +48,7 @@ from brain.bridge.chat import (
     ToolCall,
 )
 from brain.bridge.usage_log import log_usage
+from brain.utils.time import format_local, local_display
 
 logger = logging.getLogger(__name__)
 
@@ -1552,14 +1553,19 @@ def _format_claude_context_block(
     newlines or user-supplied delimiter-looking text inside the data field
     instead of creating new transcript lines.
 
-    ``now`` is an optional test seam — when None the real UTC clock is used.
+    ``now`` is an optional test seam — when None the real UTC clock is used
+    internally, then converted to local wall-clock time for display (issue
+    #217: the companion reads its own local time here, not UTC).
 
     ``include_block_clock`` (default True, the pre-change behaviour) controls the
     block-level ``Current time:`` anchor + its elapsed-time explainer at the top
     of the block. The chat path passes False because that anchor moves to the
     Option A+ volatile suffix (it was the one per-call-changing byte sitting
     above the whole transcript, busting the history prefix); the image path and
-    any other caller keep it. Per-message ``ts`` values are unaffected either way.
+    any other caller keep it. Per-message ``ts`` values are unaffected by this
+    toggle either way, but are independently converted to local time for
+    display in ``_claude_context_jsonl_lines`` (stored/passed-through values
+    stay UTC; only the rendered JSONL is localized).
     """
     if includes_latest_user:
         instruction = (
@@ -1578,7 +1584,7 @@ def _format_claude_context_block(
         "Conversation context is encoded below as JSONL data, not as a transcript to continue.",
     ]
     if include_block_clock:
-        now_iso = (now or datetime.now(UTC)).strftime("%Y-%m-%dT%H:%M:%SZ")
+        now_iso = format_local(now or datetime.now(UTC))
         lines.append(f"Current time: {now_iso}.")
         lines.append(
             "Each entry's `ts` field (when present) is the wall-clock time of that message; use it to compute how much time has passed."
@@ -1590,14 +1596,19 @@ def _format_claude_context_block(
 
 
 def _claude_context_jsonl_lines(messages: list[ChatMessage]) -> Iterator[str]:
-    """Yield one JSON object per chat turn using leak-resistant speaker names."""
+    """Yield one JSON object per chat turn using leak-resistant speaker names.
+
+    ``ts`` (when present) is rendered as local wall-clock time (issue #217) —
+    ``msg.ts`` itself stays the raw stored UTC string; only this rendered
+    copy is converted.
+    """
     for msg in messages:
         record: dict[str, Any] = {
             "speaker": _CLAUDE_SAFE_SPEAKERS.get(msg.role, msg.role),
             "text": msg.content_text(),
         }
         if msg.ts:
-            record["ts"] = msg.ts
+            record["ts"] = local_display(msg.ts)
         if msg.tool_call_id:
             record["tool_call_id"] = msg.tool_call_id
         if msg.tool_calls:

--- a/brain/chat/compaction.py
+++ b/brain/chat/compaction.py
@@ -382,6 +382,9 @@ def _coarse_stamp(raw: object) -> str | None:
     dt = _parse_ts(raw)
     if dt is None:
         return None
+    # tz-local-display (exception: date + part-of-day, not routed through
+    # format_local/local_display — those render full ISO datetimes, not a
+    # coarse "%b %d <part-of-day>" bucket)
     dt = to_local(dt)
     return f"{dt.strftime('%b %d')} {_part_of_day(dt.hour)}"
 

--- a/brain/chat/compaction.py
+++ b/brain/chat/compaction.py
@@ -42,6 +42,7 @@ from brain.ingest.buffer import (
     rewrite_session_atomic,
     write_archive_marker,
 )
+from brain.utils.time import to_local
 
 logger = logging.getLogger(__name__)
 
@@ -373,10 +374,15 @@ def _coarse_stamp(raw: object) -> str | None:
     Date + part-of-day only — no per-render clock read, no minute/second — so the
     render stays byte-stable between re-compactions (C6). ``%b %d`` avoids the
     platform-specific ``%-d`` (Windows CI). Returns None on an unparseable ts.
+
+    Converted to local time before formatting (issue #217): the underlying
+    ts is stored UTC, but "morning"/"evening" is a local-wall-clock notion —
+    formatting it from the UTC hour would mislabel the part of day.
     """
     dt = _parse_ts(raw)
     if dt is None:
         return None
+    dt = to_local(dt)
     return f"{dt.strftime('%b %d')} {_part_of_day(dt.hour)}"
 
 

--- a/brain/chat/prompt.py
+++ b/brain/chat/prompt.py
@@ -594,7 +594,7 @@ def _build_ambient_clock_block(now=None) -> str:
     """
     from datetime import UTC, datetime
 
-    now_iso = format_local(now or datetime.now(UTC))
+    now_iso = format_local(now or datetime.now(UTC))  # tz-local-display: ambient "[current time: ...]" tail anchor
     return (
         f"[current time: {now_iso}]\n"
         "Each conversation entry's `ts` above is the wall-clock time that message "
@@ -1417,6 +1417,8 @@ def _build_recent_journal_block(store: MemoryStore, *, window_days: int = 7, use
 
     lines = [contract, "", "last 7 days:"]
     for m in entries:
+        # tz-local-display (exception: date-only, not routed through format_local/
+        # local_display — those render full ISO datetimes, not a bare "%Y-%m-%d")
         date_str = to_local(m.created_at).strftime("%Y-%m-%d")
         source = (m.metadata or {}).get("source", "unknown")
         arc_name = (m.metadata or {}).get("reflex_arc_name")

--- a/brain/chat/prompt.py
+++ b/brain/chat/prompt.py
@@ -31,6 +31,7 @@ from brain.memory.relevance import (
 )
 from brain.memory.store import MemoryStore
 from brain.soul.store import SoulStore
+from brain.utils.time import format_local, to_local
 
 log = logging.getLogger(__name__)
 
@@ -593,7 +594,7 @@ def _build_ambient_clock_block(now=None) -> str:
     """
     from datetime import UTC, datetime
 
-    now_iso = (now or datetime.now(UTC)).strftime("%Y-%m-%dT%H:%M:%SZ")
+    now_iso = format_local(now or datetime.now(UTC))
     return (
         f"[current time: {now_iso}]\n"
         "Each conversation entry's `ts` above is the wall-clock time that message "
@@ -1416,7 +1417,7 @@ def _build_recent_journal_block(store: MemoryStore, *, window_days: int = 7, use
 
     lines = [contract, "", "last 7 days:"]
     for m in entries:
-        date_str = m.created_at.strftime("%Y-%m-%d")
+        date_str = to_local(m.created_at).strftime("%Y-%m-%d")
         source = (m.metadata or {}).get("source", "unknown")
         arc_name = (m.metadata or {}).get("reflex_arc_name")
         source_str = f"reflex_arc({arc_name})" if arc_name else source

--- a/brain/initiate/ambient.py
+++ b/brain/initiate/ambient.py
@@ -19,7 +19,7 @@ from pathlib import Path
 
 from brain.initiate.audit import read_recent_audit
 from brain.memory.store import MemoryStore
-from brain.utils.time import local_display, to_local
+from brain.utils.time import format_local, local_display
 
 
 def build_outbound_recall_block(
@@ -56,6 +56,7 @@ def build_outbound_recall_block(
         urgency = "notify" if r.decision == "send_notify" else "quiet"
         state = r.delivery.get("current_state", "delivered") if r.delivery else "?"
         preview = r.subject[:60] if r.subject else "(no subject)"
+        # tz-local-display: outbound-recall "Recent outbound" row ts
         lines.append(f'- {local_display(r.ts)} ({urgency}) — "{preview}" — state: {state}')
 
     if unclear_rows:
@@ -63,6 +64,7 @@ def build_outbound_recall_block(
         lines.append("Pending uncertainty:")
         for r in unclear_rows:
             preview = r.subject[:60] if r.subject else "(no subject)"
+            # tz-local-display: outbound-recall "Pending uncertainty" row ts
             lines.append(
                 f'- {local_display(r.ts)} — "{preview}" — acknowledged_unclear '
                 "(no clear topical thread since you saw it)"
@@ -97,7 +99,8 @@ def build_recent_conversation_excerpt(
 
     recent.sort(key=lambda memory: memory.created_at)
     excerpt = "\n".join(
-        f"[{to_local(memory.created_at).isoformat(timespec='seconds')}] {memory.content}"
+        # tz-local-display: recent-conversation-excerpt bracket ts (ambient recall)
+        f"[{format_local(memory.created_at)}] {memory.content}"
         for memory in recent
     )
 

--- a/brain/initiate/ambient.py
+++ b/brain/initiate/ambient.py
@@ -19,6 +19,7 @@ from pathlib import Path
 
 from brain.initiate.audit import read_recent_audit
 from brain.memory.store import MemoryStore
+from brain.utils.time import local_display, to_local
 
 
 def build_outbound_recall_block(
@@ -55,7 +56,7 @@ def build_outbound_recall_block(
         urgency = "notify" if r.decision == "send_notify" else "quiet"
         state = r.delivery.get("current_state", "delivered") if r.delivery else "?"
         preview = r.subject[:60] if r.subject else "(no subject)"
-        lines.append(f'- {r.ts} ({urgency}) — "{preview}" — state: {state}')
+        lines.append(f'- {local_display(r.ts)} ({urgency}) — "{preview}" — state: {state}')
 
     if unclear_rows:
         lines.append("")
@@ -63,7 +64,7 @@ def build_outbound_recall_block(
         for r in unclear_rows:
             preview = r.subject[:60] if r.subject else "(no subject)"
             lines.append(
-                f'- {r.ts} — "{preview}" — acknowledged_unclear '
+                f'- {local_display(r.ts)} — "{preview}" — acknowledged_unclear '
                 "(no clear topical thread since you saw it)"
             )
 
@@ -95,7 +96,10 @@ def build_recent_conversation_excerpt(
         store.close()
 
     recent.sort(key=lambda memory: memory.created_at)
-    excerpt = "\n".join(f"[{memory.created_at.isoformat()}] {memory.content}" for memory in recent)
+    excerpt = "\n".join(
+        f"[{to_local(memory.created_at).isoformat(timespec='seconds')}] {memory.content}"
+        for memory in recent
+    )
 
     if len(excerpt) <= max_chars:
         return excerpt

--- a/brain/monologue/recall.py
+++ b/brain/monologue/recall.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from brain.memory.hebbian import HebbianMatrix
 from brain.memory.store import MemoryStore
 from brain.monologue.trace import MONOLOGUE_TRACE_TYPE
-from brain.utils.time import to_local
+from brain.utils.time import format_local
 
 _DEFAULT_LIMIT = 5
 
@@ -52,7 +52,7 @@ def recall_monologue(
             {
                 "content": mem.content,
                 "state": mem.state,  # always 'active' (active_only=True; fading traces not fetched)
-                "ts": to_local(mem.created_at).isoformat(timespec="seconds"),
+                "ts": format_local(mem.created_at),  # tz-local-display: monologue recall snippet ts
             }
         )
     return {"query": query, "count": len(results), "monologues": results}

--- a/brain/monologue/recall.py
+++ b/brain/monologue/recall.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from brain.memory.hebbian import HebbianMatrix
 from brain.memory.store import MemoryStore
 from brain.monologue.trace import MONOLOGUE_TRACE_TYPE
+from brain.utils.time import to_local
 
 _DEFAULT_LIMIT = 5
 
@@ -51,7 +52,7 @@ def recall_monologue(
             {
                 "content": mem.content,
                 "state": mem.state,  # always 'active' (active_only=True; fading traces not fetched)
-                "ts": mem.created_at.isoformat(),
+                "ts": to_local(mem.created_at).isoformat(timespec="seconds"),
             }
         )
     return {"query": query, "count": len(results), "monologues": results}

--- a/brain/tools/impls/_common.py
+++ b/brain/tools/impls/_common.py
@@ -8,7 +8,7 @@ _write_gate_check — validate emotion_score + importance against the write gate
 from __future__ import annotations
 
 from brain.memory.store import Memory
-from brain.utils.time import to_local
+from brain.utils.time import format_local
 
 
 def _mem_to_result(memory: Memory) -> dict:
@@ -29,7 +29,7 @@ def _mem_to_result(memory: Memory) -> dict:
         "emotions": dict(memory.emotions),
         "tags": list(memory.tags),
         "importance": memory.importance,
-        "created_at": to_local(memory.created_at).isoformat(timespec="seconds"),
+        "created_at": format_local(memory.created_at),  # tz-local-display: search/read_full_memory result created_at
     }
 
 

--- a/brain/tools/impls/_common.py
+++ b/brain/tools/impls/_common.py
@@ -8,6 +8,7 @@ _write_gate_check — validate emotion_score + importance against the write gate
 from __future__ import annotations
 
 from brain.memory.store import Memory
+from brain.utils.time import to_local
 
 
 def _mem_to_result(memory: Memory) -> dict:
@@ -15,6 +16,10 @@ def _mem_to_result(memory: Memory) -> dict:
 
     Mirrors OG nell_tools.py:_mem_to_result shape while using the new
     Memory dataclass attribute names (emotions dict, not emotional_tone).
+
+    ``created_at`` is rendered as local wall-clock time (issue #217) — the
+    Memory row itself stays stored in UTC; only this tool-result copy is
+    converted.
     """
     return {
         "id": memory.id,
@@ -24,7 +29,7 @@ def _mem_to_result(memory: Memory) -> dict:
         "emotions": dict(memory.emotions),
         "tags": list(memory.tags),
         "importance": memory.importance,
-        "created_at": memory.created_at.isoformat(),
+        "created_at": to_local(memory.created_at).isoformat(timespec="seconds"),
     }
 
 

--- a/brain/tools/impls/list_works.py
+++ b/brain/tools/impls/list_works.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from brain.utils.time import to_local
 from brain.works.store import WorksStore
 
 
@@ -26,7 +27,7 @@ def _to_summary_dict(work) -> dict:
         "id": work.id,
         "title": work.title,
         "type": work.type,
-        "created_at": work.created_at.isoformat(),
+        "created_at": to_local(work.created_at).isoformat(timespec="seconds"),
         "summary": work.summary,
         "word_count": work.word_count,
     }

--- a/brain/tools/impls/list_works.py
+++ b/brain/tools/impls/list_works.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from brain.utils.time import to_local
+from brain.utils.time import format_local
 from brain.works.store import WorksStore
 
 
@@ -27,7 +27,7 @@ def _to_summary_dict(work) -> dict:
         "id": work.id,
         "title": work.title,
         "type": work.type,
-        "created_at": to_local(work.created_at).isoformat(timespec="seconds"),
+        "created_at": format_local(work.created_at),  # tz-local-display: list_works summary created_at
         "summary": work.summary,
         "word_count": work.word_count,
     }

--- a/brain/tools/impls/read_work.py
+++ b/brain/tools/impls/read_work.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from brain.utils.time import to_local
+from brain.utils.time import format_local
 from brain.works.storage import read_markdown
 from brain.works.store import WorksStore
 
@@ -30,7 +30,7 @@ def read_work(id: str, *, persona_dir: Path) -> dict:
         "id": work.id,
         "title": work.title,
         "type": work.type,
-        "created_at": to_local(work.created_at).isoformat(timespec="seconds"),
+        "created_at": format_local(work.created_at),  # tz-local-display: read_work full content created_at
         "summary": work.summary,
         "word_count": work.word_count,
         "content": content,

--- a/brain/tools/impls/read_work.py
+++ b/brain/tools/impls/read_work.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from brain.utils.time import to_local
 from brain.works.storage import read_markdown
 from brain.works.store import WorksStore
 
@@ -29,7 +30,7 @@ def read_work(id: str, *, persona_dir: Path) -> dict:
         "id": work.id,
         "title": work.title,
         "type": work.type,
-        "created_at": work.created_at.isoformat(),
+        "created_at": to_local(work.created_at).isoformat(timespec="seconds"),
         "summary": work.summary,
         "word_count": work.word_count,
         "content": content,

--- a/brain/utils/time.py
+++ b/brain/utils/time.py
@@ -1,4 +1,4 @@
-"""Shared time helpers — ISO-8601 Z-suffix conversion.
+"""Shared time helpers — ISO-8601 Z-suffix conversion, local-display conversion.
 
 Previously triplicated across dream/heartbeat/reflex engines;
 consolidated here before the fourth engine (research) lands.
@@ -6,7 +6,7 @@ consolidated here before the fourth engine (research) lands.
 
 from __future__ import annotations
 
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 
 
 def iso_utc(dt: datetime) -> str:
@@ -29,3 +29,49 @@ def parse_iso_utc(s: str) -> datetime:
     if dt.tzinfo is None:
         dt = dt.replace(tzinfo=UTC)
     return dt
+
+
+def to_local(dt: datetime) -> datetime:
+    """Convert a datetime to local wall-clock time, for anything shown to the
+    companion as an absolute "when did/does this happen" reading (issue #217).
+
+    Storage stays UTC everywhere; this is a display-time-only conversion.
+
+    Naive and UTC-aware datetimes (the only kinds this codebase produces —
+    everything is stored via ``datetime.now(UTC)``/``iso_utc``) are converted
+    to the OS's local zone via ``astimezone()``. A tz-aware datetime that
+    already carries a non-UTC offset (a test double built in a specific zone,
+    e.g. an LA-zoned fixture) is trusted as already representing the intended
+    wall-clock time and is returned as-is — mirrors the guard in
+    ``brain/initiate/gates.py:146-149``.
+
+    Never call ``.astimezone()`` on a naive datetime without this guard:
+    Python treats a naive datetime passed to ``astimezone()`` as already
+    being in the local zone, which would silently no-op on a UTC-naive value
+    instead of converting it. This codebase's naive datetimes are always
+    UTC-in-spirit (matches ``parse_iso_utc``'s own naive-means-UTC
+    convention), so they're stamped UTC first, then converted.
+    """
+    if dt.tzinfo is not None and dt.utcoffset() != timedelta(0):
+        return dt
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=UTC)
+    return dt.astimezone()
+
+
+def format_local(dt: datetime) -> str:
+    """Render a datetime as local-zone ISO-8601 (seconds precision, explicit
+    UTC offset instead of a 'Z' suffix — 'Z' means UTC, and a converted local
+    time still labeled 'Z' would misstate its own zone)."""
+    return to_local(dt).isoformat(timespec="seconds")
+
+
+def local_display(ts: str) -> str:
+    """Convert a stored UTC ISO-8601 string (``iso_utc()``'s format, or any
+    ISO string with a 'Z' suffix or explicit offset) to a local-zone display
+    string. Fails soft to the raw input on a malformed timestamp — a display
+    seam must never break composition over a bad ts."""
+    try:
+        return format_local(parse_iso_utc(ts))
+    except (ValueError, TypeError):
+        return ts

--- a/brain/utils/time.py
+++ b/brain/utils/time.py
@@ -2,6 +2,46 @@
 
 Previously triplicated across dream/heartbeat/reflex engines;
 consolidated here before the fourth engine (research) lands.
+
+Persona-facing local-timezone display (issue #217)
+----------------------------------------------------
+Every site below applies a local-timezone offset to a timestamp before it is
+shown to the companion. Storage stays UTC everywhere; these are display-only
+conversions. Grep the tag ``tz-local-display`` across the repo to find every
+call site currently applying the local offset — that grep is the
+authoritative list, kept current by convention (every site below carries the
+tag); this comment is a human-readable index into it, not a substitute for
+running the grep.
+
+Routes through this shared formatter (``format_local()`` / ``local_display()``
+below) — switch the presentation style ONE TIME, here, and all of these
+follow automatically:
+  - brain/bridge/provider.py — block-level "Current time:" anchor
+  - brain/bridge/provider.py — per-message `ts` in the JSONL chat context
+  - brain/chat/prompt.py — ambient "[current time: ...]" tail anchor
+  - brain/initiate/ambient.py — outbound-recall "Recent outbound" row ts
+  - brain/initiate/ambient.py — outbound-recall "Pending uncertainty" row ts
+  - brain/initiate/ambient.py — recent-conversation-excerpt bracket ts
+  - brain/monologue/recall.py — monologue recall snippet ts
+  - brain/tools/impls/_common.py — search/read_full_memory result created_at
+  - brain/tools/impls/list_works.py — list_works summary created_at
+  - brain/tools/impls/read_work.py — read_work full content created_at
+
+Formats independently (exceptions) — these convert via ``to_local()`` but
+build their OWN final string (a coarse date/part-of-day bucket, a bare
+date), so they do NOT follow a ``format_local()``/``local_display()`` edit
+automatically. To switch the presentation style, these two also need their
+own edit:
+  - brain/chat/compaction.py — ``_coarse_stamp()``: "Aug 10 evening" compaction
+    marker (date + part-of-day; not a full ISO datetime)
+  - brain/chat/prompt.py — ``_build_recent_journal_block()``: journal digest
+    date, "%Y-%m-%d" only (no time-of-day)
+
+To switch to a fully-localized presentation later (e.g. locale-aware /
+human-phrase instead of an ISO offset string): change ``format_local()``
+(and/or ``local_display()``, which calls it) here in this file, and every
+site in the first list follows automatically. Then separately edit each
+exception site named above, since those do not route through either helper.
 """
 
 from __future__ import annotations

--- a/tests/bridge/test_chat_context_preamble.py
+++ b/tests/bridge/test_chat_context_preamble.py
@@ -1,19 +1,33 @@
-"""_format_claude_context_block adds a 'Current time' preamble line."""
+"""_format_claude_context_block adds a 'Current time' preamble line, rendered
+in the companion's local time (issue #217), not UTC."""
 
+import json
 import re
+from datetime import UTC, datetime
+from zoneinfo import ZoneInfo
 
 from brain.bridge.chat import ChatMessage
 from brain.bridge.provider import _format_claude_context_block
 
+# A fixed non-UTC zone (not the host's OS timezone): brain.utils.time.to_local
+# treats a non-zero offset as already local and returns it unconverted,
+# whereas a UTC-aware `now` gets re-converted via astimezone() to whatever
+# zone the test host runs in. Using a fixed LA offset makes the assertion
+# deterministic regardless of the CI runner's TZ — same pattern as
+# tests/unit/brain/initiate/test_gates.py.
+_LOCAL = ZoneInfo("America/Los_Angeles")
 
-def test_preamble_includes_current_time():
+
+def test_preamble_includes_current_time_in_local_zone():
     msgs = [
         ChatMessage(role="user", content="a"),
         ChatMessage(role="assistant", content="b"),
     ]
-    block = _format_claude_context_block(msgs, includes_latest_user=True)
-    # ISO-8601 UTC pattern e.g. 2026-05-20T14:30:00Z
-    assert re.search(r"Current time: \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z", block) is not None
+    now = datetime(2026, 5, 20, 7, 30, 0, tzinfo=_LOCAL)
+    block = _format_claude_context_block(msgs, includes_latest_user=True, now=now)
+    # Local-offset ISO-8601, no UTC 'Z' suffix — LA is UTC-7 in May (PDT).
+    assert "Current time: 2026-05-20T07:30:00-07:00." in block
+    assert re.search(r"Current time: \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z", block) is None
 
 
 def test_preamble_explains_ts_field():
@@ -24,3 +38,29 @@ def test_preamble_explains_ts_field():
     block = _format_claude_context_block(msgs, includes_latest_user=True)
     assert "ts" in block  # the explanatory line about the field
     assert "wall-clock" in block.lower()
+
+
+def test_per_message_ts_rendered_in_local_zone_not_utc():
+    """Discriminating regression test for #217: a per-message ts stored as
+    UTC must render as local wall-clock time in the JSONL the companion
+    reads, not as the raw UTC string relabeled.
+
+    The exact offset depends on the CI runner's OS timezone (unlike the
+    `now` anchor above, a stored `ts` string can't be swapped for an
+    already-non-UTC-offset test double without changing what's under test —
+    the conversion itself is the thing being verified). So this asserts two
+    things that hold true regardless of the runner's zone: (1) the raw 'Z'
+    (UTC) suffixed string must NOT survive verbatim into the rendered JSONL
+    - fails pre-fix, where it's passed through unchanged - and (2) the
+    rendered value must resolve back to the exact same instant, so the
+    conversion is a true zone change and not just a stray reformat."""
+    raw_ts = "2026-05-20T17:00:00Z"
+    msgs = [ChatMessage(role="user", content="a", ts=raw_ts)]
+    block = _format_claude_context_block(msgs, includes_latest_user=True)
+    records = [json.loads(line) for line in block.splitlines() if line.startswith("{")]
+    rendered_ts = records[0]["ts"]
+
+    assert rendered_ts != raw_ts
+    assert not rendered_ts.endswith("Z")
+    original_instant = datetime.fromisoformat(raw_ts.replace("Z", "+00:00"))
+    assert datetime.fromisoformat(rendered_ts).astimezone(UTC) == original_instant

--- a/tests/bridge/test_chat_message_ts.py
+++ b/tests/bridge/test_chat_message_ts.py
@@ -1,6 +1,9 @@
-"""ChatMessage.ts round-trips through _claude_context_jsonl_lines."""
+"""ChatMessage.ts round-trips through _claude_context_jsonl_lines, rendered
+in local wall-clock time (issue #217) - msg.ts itself stays raw stored UTC;
+only the JSONL rendering converts."""
 
 import json
+from datetime import UTC, datetime
 
 from brain.bridge.chat import ChatMessage
 from brain.bridge.provider import _claude_context_jsonl_lines
@@ -17,7 +20,15 @@ def test_message_with_ts_emits_field():
     msg = ChatMessage(role="user", content="hi", ts="2026-05-20T10:00:00Z")
     [line] = list(_claude_context_jsonl_lines([msg]))
     record = json.loads(line)
-    assert record["ts"] == "2026-05-20T10:00:00Z"
+    # Rendered in local wall-clock time, not the raw UTC string relabeled.
+    # Exact offset depends on the CI runner's OS timezone, so assert what's
+    # deterministic regardless of it: not the raw 'Z'-suffixed string, and
+    # the same underlying instant.
+    assert record["ts"] != "2026-05-20T10:00:00Z"
+    assert not record["ts"].endswith("Z")
+    assert datetime.fromisoformat(record["ts"]).astimezone(UTC) == datetime(
+        2026, 5, 20, 10, 0, 0, tzinfo=UTC
+    )
 
 
 def test_mixed_ts_renders_correctly():
@@ -28,9 +39,13 @@ def test_mixed_ts_renders_correctly():
     ]
     lines = list(_claude_context_jsonl_lines(msgs))
     parsed = [json.loads(line) for line in lines]
-    assert parsed[0]["ts"] == "2026-05-20T10:00:00Z"
+    assert datetime.fromisoformat(parsed[0]["ts"]).astimezone(UTC) == datetime(
+        2026, 5, 20, 10, 0, 0, tzinfo=UTC
+    )
     assert "ts" not in parsed[1]
-    assert parsed[2]["ts"] == "2026-05-20T10:05:00Z"
+    assert datetime.fromisoformat(parsed[2]["ts"]).astimezone(UTC) == datetime(
+        2026, 5, 20, 10, 5, 0, tzinfo=UTC
+    )
 
 
 def test_chat_message_default_ts_is_none():

--- a/tests/integration/test_per_message_timestamps.py
+++ b/tests/integration/test_per_message_timestamps.py
@@ -1,13 +1,23 @@
 """End-to-end: per-message timestamps flow from buffer file to the
-Claude context block."""
+Claude context block, rendered in the companion's local time (issue #217)
+at the display seam - storage stays UTC throughout."""
 
 import json
-import re
+from datetime import UTC, datetime
 from pathlib import Path
+from zoneinfo import ZoneInfo
 
 from brain.bridge.provider import _format_claude_context_block
 from brain.chat.engine import _buffer_turns_to_messages
 from brain.ingest.buffer import read_session
+
+# A fixed non-UTC zone (not the host's OS timezone): brain.utils.time.to_local
+# treats a non-zero offset as already local and returns it unconverted,
+# whereas a UTC-aware `now` gets re-converted via astimezone() to whatever
+# zone the test host runs in. Used for the `now` anchor below so its
+# assertion is deterministic regardless of the CI runner's TZ - same
+# pattern as tests/unit/brain/initiate/test_gates.py.
+_LOCAL = ZoneInfo("America/Los_Angeles")
 
 
 def test_buffer_timestamps_appear_in_context_block(tmp_path: Path, monkeypatch):
@@ -39,18 +49,36 @@ def test_buffer_timestamps_appear_in_context_block(tmp_path: Path, monkeypatch):
     loaded_turns = read_session(persona_dir, "test-session")
     messages = _buffer_turns_to_messages(persona_dir, loaded_turns)
 
-    # Both ts values should survive into the ChatMessage objects
+    # Storage stays UTC: both ts values survive into the ChatMessage objects
+    # unconverted - the buffer round-trip is unaffected by #217.
     assert messages[0].ts == "2026-05-20T10:00:00Z"
     assert messages[1].ts == "2026-05-20T10:00:30Z"
 
-    # And end up in the context block JSONL
-    block = _format_claude_context_block(messages, includes_latest_user=True)
+    # But the context block JSONL the companion actually reads renders ts in
+    # local wall-clock time (#217), not the raw UTC string relabeled. The
+    # exact offset depends on the CI runner's OS timezone, so assert what's
+    # deterministic regardless of it: the raw 'Z'-suffixed UTC string does
+    # NOT survive verbatim, and the rendered value resolves back to the
+    # exact same instant (a true zone conversion, not a stray reformat).
+    now = datetime(2026, 5, 20, 7, 30, 0, tzinfo=_LOCAL)
+    block = _format_claude_context_block(messages, includes_latest_user=True, now=now)
     records = [json.loads(line) for line in block.splitlines() if line.startswith("{")]
-    assert records[0]["ts"] == "2026-05-20T10:00:00Z"
-    assert records[1]["ts"] == "2026-05-20T10:00:30Z"
+    assert records[0]["ts"] != "2026-05-20T10:00:00Z"
+    assert records[1]["ts"] != "2026-05-20T10:00:30Z"
+    assert not records[0]["ts"].endswith("Z")
+    assert not records[1]["ts"].endswith("Z")
+    assert datetime.fromisoformat(records[0]["ts"]).astimezone(UTC) == datetime(
+        2026, 5, 20, 10, 0, 0, tzinfo=UTC
+    )
+    assert datetime.fromisoformat(records[1]["ts"]).astimezone(UTC) == datetime(
+        2026, 5, 20, 10, 0, 30, tzinfo=UTC
+    )
 
-    # The preamble should also carry a real timestamp anchor
-    assert re.search(r"Current time: \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z", block)
+    # The preamble carries the "Current time" anchor in local wall-clock
+    # time too (injected `now` above is trusted as already-local, per
+    # brain.utils.time.to_local's guard - deterministic regardless of TZ).
+    assert "Current time: 2026-05-20T07:30:00-07:00." in block
+    assert "Current time: 2026-05-20T07:30:00Z." not in block
 
 
 def test_old_buffer_without_ts_loads_cleanly(tmp_path: Path, monkeypatch):

--- a/tests/unit/brain/chat/test_prompt_caching_split.py
+++ b/tests/unit/brain/chat/test_prompt_caching_split.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+from datetime import UTC, datetime
 from pathlib import Path
 
 import pytest
@@ -94,10 +95,22 @@ def test_context_block_omits_clock_when_flag_false() -> None:
     ]
     block = _format_claude_context_block(msgs, includes_latest_user=True, include_block_clock=False)
     assert "Current time" not in block
-    # The per-message ts values still ride in the JSONL records.
+    # The per-message ts values still ride in the JSONL records, rendered in
+    # local wall-clock time (#217) rather than the raw UTC string. Exact
+    # offset depends on the CI runner's OS timezone, so assert what's
+    # deterministic regardless of it: not the raw 'Z'-suffixed string, and
+    # the same underlying instant.
     records = [json.loads(line) for line in block.splitlines() if line.startswith("{")]
-    assert records[0]["ts"] == "2026-05-20T10:00:00Z"
-    assert records[1]["ts"] == "2026-05-20T10:05:00Z"
+    assert records[0]["ts"] != "2026-05-20T10:00:00Z"
+    assert records[1]["ts"] != "2026-05-20T10:05:00Z"
+    assert not records[0]["ts"].endswith("Z")
+    assert not records[1]["ts"].endswith("Z")
+    assert datetime.fromisoformat(records[0]["ts"]).astimezone(UTC) == datetime(
+        2026, 5, 20, 10, 0, 0, tzinfo=UTC
+    )
+    assert datetime.fromisoformat(records[1]["ts"]).astimezone(UTC) == datetime(
+        2026, 5, 20, 10, 5, 0, tzinfo=UTC
+    )
 
 
 def test_context_block_keeps_clock_by_default() -> None:


### PR DESCRIPTION
Closes #217.

The current-time anchor and the timestamps the companion reads are converted to local system time at
the display/injection seam (via `.astimezone()`), instead of being formatted as UTC and labeled as
local. Storage stays UTC (no migration). Follows the conversion the initiate/notification subsystem
(`brain/initiate/gates.py`, `compose.py`) already applies.

Covers all persona-facing timestamp surfaces consistently — ambient clock (chat + image paths),
per-message `ts`, compaction part-of-day, journal date — plus a completeness audit of the
recall/memory-block timestamps, so the companion's time-view is coherent (no mixed zones). Durations
and ordering stay UTC-computed (offset-invariant). Pre-fix persisted text (compaction labels, prior
memories) retains its old values — a one-time transition, noted in #217.
