### PR TITLE
fix(supervisor): cut per-tick DB overhead driving idle-CPU/lag (#132)

### DIFF
--- a/brain/bridge/server.py
+++ b/brain/bridge/server.py
@@ -841,7 +841,7 @@ def build_app(
     persona_dir: Path,
     client_origin: str = "cli",
     tick_interval_s: float = 60.0,
-    silence_minutes: float = 5.0,
+    silence_minutes: float = 10.0,
     idle_shutdown_seconds: float | None = None,
     auth_token: str | None = None,
     shutdown_controller: BridgeShutdownController | None = None,

--- a/brain/bridge/supervisor.py
+++ b/brain/bridge/supervisor.py
@@ -131,7 +131,7 @@ def run_folded(
     provider: LLMProvider,
     event_bus: EventBus,
     tick_interval_s: float = 60.0,
-    silence_minutes: float = 5.0,
+    silence_minutes: float = 10.0,
     heartbeat_interval_s: float | None = 900.0,
     soul_review_interval_s: float | None = 6 * 3600.0,
     finalize_after_hours: float = 24.0,
@@ -336,11 +336,19 @@ def run_folded(
         logger.warning("self-model repair failed during startup: %s", exc)
 
     while not stop_event.is_set():
+        # store is opened here (per-tick, this thread only — H-A hardening) and reused by
+        # the maker/notes ticks below in this same iteration, instead of each opening its
+        # own separate connection (#132: 3 memories.db opens/tick -> 1). It is NOT closed by
+        # the ExitStack below (no stack.callback(store.close)) — it survives past that
+        # block and is closed once, in the `finally` after the notes tick (search
+        # "per-tick store close" below), guaranteeing cleanup even if something in between
+        # raises uncaught. Reset to None every iteration so a failed open this iteration
+        # can never fall through to a stale/closed object from the previous one.
+        store: MemoryStore | None = None
         try:
+            store = MemoryStore(persona_dir / "memories.db", integrity_check=False)
             with ExitStack() as stack:
-                store = MemoryStore(persona_dir / "memories.db")
-                stack.callback(store.close)
-                hebbian = HebbianMatrix(persona_dir / "hebbian.db")
+                hebbian = HebbianMatrix(persona_dir / "hebbian.db", integrity_check=False)
                 stack.callback(hebbian.close)
                 embeddings = EmbeddingCache(
                     persona_dir / "embeddings.db",
@@ -391,298 +399,336 @@ def run_folded(
         except Exception:
             logger.exception("supervisor tick raised")
 
-        # Heartbeat cadence — independent of session-cleanup cadence.
-        # Fault-isolated so a heartbeat failure can't take down the
-        # session-cleanup loop or cascade into bridge shutdown.
-        # INTENTIONALLY STILL MONOTONIC (defer #21 residual — NOT an oversight):
-        # _heartbeat_and_felt_time consumes last_heartbeat_at to compute the
-        # felt-time wall_s elapsed-since-last (line ~701), whose monotonic basis
-        # is a deliberately-conservative bias (it underweights activity across a
-        # system sleep rather than overweighting it — see that function's
-        # docstring). The 15-min interval also fires within a typical session, so
-        # the restart-reset bite is lowest of all cadences. Converting it would
-        # need the felt-time elapsed reworked off a persisted last-fire; not worth
-        # the risk on the highest-fan-out cadence. Persist this ONLY alongside a
-        # felt-time-elapsed redesign.
-        if (
-            heartbeat_interval_s is not None
-            and last_heartbeat_at is not None
-            and time.monotonic() - last_heartbeat_at >= heartbeat_interval_s
-        ):
-            _last_intensity_drivers = _heartbeat_and_felt_time(
-                persona_dir, provider, event_bus, last_heartbeat_at
-            )
-            last_heartbeat_at = time.monotonic()
-
-        # Soul-review cadence — slowest of the three. Each pass is up to
-        # 5 LLM calls (one per candidate). Fault-isolated so a model
-        # outage doesn't take the supervisor down.
-        # This tick, and voice-reflection/maker/notes below, each build their
-        # OWN `background-generative` tier provider (#154) rather than reusing
-        # the bare ambient `provider` — same model (`MODEL_MEDIUM`) it already
-        # resolves to, so this is routing-only, not a model change.
-        # Soul-review cadence — PERSISTED + self-pacing. Unlike the monotonic
-        # timers, soul_review_state.json survives restart/sleep, so the 6h
-        # interval can't be reset to zero by an app quit/reboot (the defect that
-        # let candidates pile up). Self-paces by outcome: backlog → 30-min
-        # catch-up; model failures (429) → escalating backoff; clean → 6h.
-        if soul_review_interval_s is not None and soul_cadence.is_due(
-            soul_cadence_state, now=datetime.now(UTC)
-        ):
-            model_failures = 0
-            eligible_pending = 0
-            try:
-                model_failures, eligible_pending = _run_soul_review_tick(
-                    persona_dir,
-                    build_tier_provider(persona_dir, TIER_BACKGROUND_GENERATIVE),
-                    event_bus,
+        try:
+            # Heartbeat cadence — independent of session-cleanup cadence.
+            # Fault-isolated so a heartbeat failure can't take down the
+            # session-cleanup loop or cascade into bridge shutdown.
+            # INTENTIONALLY STILL MONOTONIC (defer #21 residual — NOT an oversight):
+            # _heartbeat_and_felt_time consumes last_heartbeat_at to compute the
+            # felt-time wall_s elapsed-since-last (line ~701), whose monotonic basis
+            # is a deliberately-conservative bias (it underweights activity across a
+            # system sleep rather than overweighting it — see that function's
+            # docstring). The 15-min interval also fires within a typical session, so
+            # the restart-reset bite is lowest of all cadences. Converting it would
+            # need the felt-time elapsed reworked off a persisted last-fire; not worth
+            # the risk on the highest-fan-out cadence. Persist this ONLY alongside a
+            # felt-time-elapsed redesign.
+            if (
+                heartbeat_interval_s is not None
+                and last_heartbeat_at is not None
+                and time.monotonic() - last_heartbeat_at >= heartbeat_interval_s
+            ):
+                _last_intensity_drivers = _heartbeat_and_felt_time(
+                    persona_dir, provider, event_bus, last_heartbeat_at
                 )
-            except Exception:
-                logger.exception("supervisor soul-review tick raised")
-                model_failures = 1  # a crashed tick counts as a failure → backoff
-            soul_cadence_state = soul_cadence.compute_next_state(
-                now=datetime.now(UTC),
-                model_failures=model_failures,
-                eligible_pending=eligible_pending,
-                normal_interval_s=soul_review_interval_s,
-                prev_failures=soul_cadence_state.consecutive_failures,
-            )
-            soul_cadence.save_cadence_state(persona_dir, soul_cadence_state)
+                last_heartbeat_at = time.monotonic()
 
-        # Maintenance cadence — forgetting + narrative, PERSISTED wall-clock on
-        # the same interval value as soul review but its OWN state file (defer
-        # #21), decoupled from soul review above so a soul-review catch-up burst
-        # doesn't run narrative's LLM calls every 30 min. Decoupling is safe:
-        # forgetting already exempts under-review soul-linked memories, so pass
-        # order relative to soul review doesn't matter.
-        if maintenance_cadence_state is not None and persisted_cadence.is_due(
-            maintenance_cadence_state, now=datetime.now(UTC)
-        ):
-            try:
-                forgetting_run_pass(
-                    persona_dir,
-                    event_bus=event_bus,
-                    intensity_drivers=_last_intensity_drivers,
+            # Soul-review cadence — slowest of the three. Each pass is up to
+            # 5 LLM calls (one per candidate). Fault-isolated so a model
+            # outage doesn't take the supervisor down.
+            # This tick, and voice-reflection/maker/notes below, each build their
+            # OWN `background-generative` tier provider (#154) rather than reusing
+            # the bare ambient `provider` — same model (`MODEL_MEDIUM`) it already
+            # resolves to, so this is routing-only, not a model change.
+            # Soul-review cadence — PERSISTED + self-pacing. Unlike the monotonic
+            # timers, soul_review_state.json survives restart/sleep, so the 6h
+            # interval can't be reset to zero by an app quit/reboot (the defect that
+            # let candidates pile up). Self-paces by outcome: backlog → 30-min
+            # catch-up; model failures (429) → escalating backoff; clean → 6h.
+            if soul_review_interval_s is not None and soul_cadence.is_due(
+                soul_cadence_state, now=datetime.now(UTC)
+            ):
+                model_failures = 0
+                eligible_pending = 0
+                try:
+                    model_failures, eligible_pending = _run_soul_review_tick(
+                        persona_dir,
+                        build_tier_provider(persona_dir, TIER_BACKGROUND_GENERATIVE),
+                        event_bus,
+                    )
+                except Exception:
+                    logger.exception("supervisor soul-review tick raised")
+                    model_failures = 1  # a crashed tick counts as a failure → backoff
+                soul_cadence_state = soul_cadence.compute_next_state(
+                    now=datetime.now(UTC),
+                    model_failures=model_failures,
+                    eligible_pending=eligible_pending,
+                    normal_interval_s=soul_review_interval_s,
+                    prev_failures=soul_cadence_state.consecutive_failures,
                 )
-            except Exception:
-                logger.exception("supervisor forgetting pass raised")
-            # Narrative-memory arc-update runs AFTER forgetting so a memory
-            # forgetting just dropped doesn't enter an arc born this tick.
-            try:
-                _run_narrative_memory_pass(persona_dir, provider, event_bus)
-            except Exception:
-                logger.exception("supervisor narrative-memory pass raised")
-            # Expire stale pending file-write proposals (24h TTL) so a confirm
-            # card the user never acted on stops surfacing on /persona/state.
-            # Fail-isolated: a sweep error must not skip the rest of the tick.
-            try:
-                from brain.files import pending as _file_pending
+                soul_cadence.save_cadence_state(persona_dir, soul_cadence_state)
 
-                _file_pending.sweep_expired(persona_dir, now=datetime.now(UTC))
-            except Exception:
-                logger.exception("supervisor pending-write sweep raised")
-            # Reap aged .lock.stale-* / .corrupt-* forensic residue (#176).
-            # Fail-isolated for the same reason as the sweep above.
-            try:
-                from brain.health import sidecar_sweep as _sidecar_sweep
+            # Maintenance cadence — forgetting + narrative, PERSISTED wall-clock on
+            # the same interval value as soul review but its OWN state file (defer
+            # #21), decoupled from soul review above so a soul-review catch-up burst
+            # doesn't run narrative's LLM calls every 30 min. Decoupling is safe:
+            # forgetting already exempts under-review soul-linked memories, so pass
+            # order relative to soul review doesn't matter.
+            #
+            # Throttled behind cli_throttle.background_slot() (mirrors interest-sweep
+            # below): forgetting/narrative are the expensive, LLM-touching work in
+            # this block; a denied slot means neither runs THIS firing (deferred to
+            # the next 6h cadence, not lost — accepted tradeoff, see 1-spec.md #132).
+            # The two try/except blocks below stay independent under the slot check,
+            # exactly as they were before this throttle was added — a forgetting
+            # failure must not also skip narrative.
+            if maintenance_cadence_state is not None and persisted_cadence.is_due(
+                maintenance_cadence_state, now=datetime.now(UTC)
+            ):
+                try:
+                    with cli_throttle.background_slot() as _maint_slot:
+                        if _maint_slot:
+                            try:
+                                forgetting_run_pass(
+                                    persona_dir,
+                                    event_bus=event_bus,
+                                    intensity_drivers=_last_intensity_drivers,
+                                )
+                            except Exception:
+                                logger.exception("supervisor forgetting pass raised")
+                            # Narrative-memory arc-update runs AFTER forgetting so a
+                            # memory forgetting just dropped doesn't enter an arc born
+                            # this tick.
+                            try:
+                                _run_narrative_memory_pass(persona_dir, provider, event_bus)
+                            except Exception:
+                                logger.exception("supervisor narrative-memory pass raised")
+                except Exception:
+                    # Mirrors interest-sweep's enclosing try/except (cli_throttle
+                    # fails open internally and shouldn't raise here, but this
+                    # keeps the two blocks' fault-isolation shape identical rather
+                    # than relying on that internal guarantee alone).
+                    logger.exception("supervisor maintenance throttle raised")
+                # Expire stale pending file-write proposals (24h TTL) so a confirm
+                # card the user never acted on stops surfacing on /persona/state.
+                # Fail-isolated: a sweep error must not skip the rest of the tick.
+                try:
+                    from brain.files import pending as _file_pending
 
-                _sidecar_sweep.sweep_stale_sidecars(persona_dir, now=datetime.now(UTC))
-            except Exception:
-                logger.exception("supervisor sidecar sweep raised")
-            # End-of-block advance+save (not a finally): every statement above is
-            # inside its own try/except, so the block body cannot raise — the
-            # advance is unconditionally reached. (defer #21)
-            maintenance_cadence_state = persisted_cadence.advance(
-                now=datetime.now(UTC), interval_s=soul_review_interval_s
-            )
-            persisted_cadence.save_cadence(
-                persona_dir, "maintenance_cadence.json", maintenance_cadence_state
-            )
+                    _file_pending.sweep_expired(persona_dir, now=datetime.now(UTC))
+                except Exception:
+                    logger.exception("supervisor pending-write sweep raised")
+                # Reap aged .lock.stale-* / .corrupt-* forensic residue (#176).
+                # Fail-isolated for the same reason as the sweep above.
+                try:
+                    from brain.health import sidecar_sweep as _sidecar_sweep
 
-        # Interest sweep — weekly, persisted wall-clock (Task 10). Safety net
-        # behind the per-turn extractor inlet (spec 2026-07-13 §6.3): proposes
-        # <=3 new interests + <=3 retirements from recent lived material.
-        # run_sweep_tick is a leaf engine call (not a supervisor _run_X_tick
-        # wrapper) that owns neither cadence nor throttle by design — this
-        # block owns both. Own per-tick MemoryStore (ExitStack, mirrors the
-        # maker/notes store-ownership pattern) since run_sweep_tick takes
-        # store= directly. Throttled via cli_throttle.background_slot; the
-        # returned dict (spawned/retired/error) is caller-facing only, so it
-        # is ignored here.
-        if interest_sweep_cadence_state is not None and persisted_cadence.is_due(
-            interest_sweep_cadence_state, now=datetime.now(UTC)
-        ):
-            try:
-                with (
-                    ExitStack() as _sweep_stack,
-                    cli_throttle.background_slot() as _sweep_slot,
-                ):
-                    if _sweep_slot:
-                        _sweep_store = MemoryStore(persona_dir / "memories.db")
-                        _sweep_stack.callback(_sweep_store.close)
-                        interest_sweep.run_sweep_tick(
-                            store=_sweep_store,
-                            provider=build_tier_provider(persona_dir, TIER_BACKGROUND_HOUSEKEEPING),
-                            interests_path=persona_dir / "interests.json",
-                            default_interests_path=(
-                                Path(__file__).resolve().parent.parent
-                                / "engines"
-                                / "default_interests.json"
-                            ),
-                            now=datetime.now(UTC),
-                        )
-            except Exception:
-                logger.exception("supervisor interest-sweep tick raised")
-            # End-of-block advance+save: body above is fully wrapped, so this
-            # is unconditionally reached (cadence invariant, defer #21 pattern).
-            interest_sweep_cadence_state = persisted_cadence.advance(
-                now=datetime.now(UTC),
-                interval_s=interest_sweep_interval_s,
-            )
-            persisted_cadence.save_cadence(
-                persona_dir, interest_sweep.SWEEP_CADENCE_FILE, interest_sweep_cadence_state
-            )
-
-        # Finalize cadence — 24h silence (default) or explicit. Each pass
-        # runs at most one final snapshot per stale session, then deletes
-        # buffer + cursor + registry entry. Slow cadence (hourly default)
-        # because the threshold is days, not minutes.
-        if finalize_cadence_state is not None and persisted_cadence.is_due(
-            finalize_cadence_state, now=datetime.now(UTC)
-        ):
-            try:
-                _run_finalize_tick(
-                    persona_dir,
-                    build_tier_provider(persona_dir, TIER_BACKGROUND_HOUSEKEEPING),
-                    event_bus,
-                    finalize_after_hours=finalize_after_hours,
-                )
-            except Exception:
-                logger.exception("supervisor finalize tick raised")
-            finally:
-                finalize_cadence_state = persisted_cadence.advance(
-                    now=datetime.now(UTC), interval_s=finalize_interval_s
+                    _sidecar_sweep.sweep_stale_sidecars(persona_dir, now=datetime.now(UTC))
+                except Exception:
+                    logger.exception("supervisor sidecar sweep raised")
+                # End-of-block advance+save (not a finally): every statement above is
+                # inside its own try/except, so the block body cannot raise — the
+                # advance is unconditionally reached. (defer #21)
+                maintenance_cadence_state = persisted_cadence.advance(
+                    now=datetime.now(UTC), interval_s=soul_review_interval_s
                 )
                 persisted_cadence.save_cadence(
-                    persona_dir, "finalize_cadence.json", finalize_cadence_state
+                    persona_dir, "maintenance_cadence.json", maintenance_cadence_state
                 )
 
-        # Log-rotation cadence — hourly default. Bounded JSONL archives so
-        # heartbeats/dreams/emotion_growth don't grow forever; yearly
-        # archive for soul_audit (every decision must remain reachable).
-        # Fault-isolated per-log inside the tick function.
-        if log_rotation_cadence_state is not None and persisted_cadence.is_due(
-            log_rotation_cadence_state, now=datetime.now(UTC)
-        ):
-            try:
-                _run_log_rotation_tick(persona_dir, event_bus)
-            except Exception:
-                logger.exception("supervisor log-rotation tick raised")
-            finally:
-                log_rotation_cadence_state = persisted_cadence.advance(
-                    now=datetime.now(UTC), interval_s=log_rotation_interval_s
+            # Interest sweep — weekly, persisted wall-clock (Task 10). Safety net
+            # behind the per-turn extractor inlet (spec 2026-07-13 §6.3): proposes
+            # <=3 new interests + <=3 retirements from recent lived material.
+            # run_sweep_tick is a leaf engine call (not a supervisor _run_X_tick
+            # wrapper) that owns neither cadence nor throttle by design — this
+            # block owns both. Own per-tick MemoryStore (ExitStack, mirrors the
+            # maker/notes store-ownership pattern) since run_sweep_tick takes
+            # store= directly. Throttled via cli_throttle.background_slot; the
+            # returned dict (spawned/retired/error) is caller-facing only, so it
+            # is ignored here.
+            if interest_sweep_cadence_state is not None and persisted_cadence.is_due(
+                interest_sweep_cadence_state, now=datetime.now(UTC)
+            ):
+                try:
+                    with (
+                        ExitStack() as _sweep_stack,
+                        cli_throttle.background_slot() as _sweep_slot,
+                    ):
+                        if _sweep_slot:
+                            _sweep_store = MemoryStore(persona_dir / "memories.db")
+                            _sweep_stack.callback(_sweep_store.close)
+                            interest_sweep.run_sweep_tick(
+                                store=_sweep_store,
+                                provider=build_tier_provider(persona_dir, TIER_BACKGROUND_HOUSEKEEPING),
+                                interests_path=persona_dir / "interests.json",
+                                default_interests_path=(
+                                    Path(__file__).resolve().parent.parent
+                                    / "engines"
+                                    / "default_interests.json"
+                                ),
+                                now=datetime.now(UTC),
+                            )
+                except Exception:
+                    logger.exception("supervisor interest-sweep tick raised")
+                # End-of-block advance+save: body above is fully wrapped, so this
+                # is unconditionally reached (cadence invariant, defer #21 pattern).
+                interest_sweep_cadence_state = persisted_cadence.advance(
+                    now=datetime.now(UTC),
+                    interval_s=interest_sweep_interval_s,
                 )
                 persisted_cadence.save_cadence(
-                    persona_dir, "log_rotation_cadence.json", log_rotation_cadence_state
+                    persona_dir, interest_sweep.SWEEP_CADENCE_FILE, interest_sweep_cadence_state
                 )
 
-        # Initiate review cadence — mirrors soul_review. Per-pass cost cap
-        # (3 candidates max). Fault-isolated.
-        if initiate_review_cadence_state is not None and persisted_cadence.is_due(
-            initiate_review_cadence_state, now=datetime.now(UTC)
-        ):
-            try:
-                _run_initiate_review_tick(persona_dir, provider, event_bus)
-            except Exception:
-                logger.exception("supervisor initiate-review tick raised")
-            finally:
-                initiate_review_cadence_state = persisted_cadence.advance(
-                    now=datetime.now(UTC), interval_s=initiate_review_interval_s
-                )
-                persisted_cadence.save_cadence(
-                    persona_dir, "initiate_review_cadence.json", initiate_review_cadence_state
-                )
+            # Finalize cadence — 24h silence (default) or explicit. Each pass
+            # runs at most one final snapshot per stale session, then deletes
+            # buffer + cursor + registry entry. Slow cadence (hourly default)
+            # because the threshold is days, not minutes.
+            if finalize_cadence_state is not None and persisted_cadence.is_due(
+                finalize_cadence_state, now=datetime.now(UTC)
+            ):
+                try:
+                    _run_finalize_tick(
+                        persona_dir,
+                        build_tier_provider(persona_dir, TIER_BACKGROUND_HOUSEKEEPING),
+                        event_bus,
+                        finalize_after_hours=finalize_after_hours,
+                    )
+                except Exception:
+                    logger.exception("supervisor finalize tick raised")
+                finally:
+                    finalize_cadence_state = persisted_cadence.advance(
+                        now=datetime.now(UTC), interval_s=finalize_interval_s
+                    )
+                    persisted_cadence.save_cadence(
+                        persona_dir, "finalize_cadence.json", finalize_cadence_state
+                    )
 
-        # Voice-reflection cadence — daily by default. Gathers last 7 days
-        # of crystallizations + dreams + message tones and may emit a
-        # voice-edit candidate (gated by >=3 evidence items inside the
-        # reflection tick itself). Fault-isolated.
-        if voice_cadence_state is not None and persisted_cadence.is_due(
-            voice_cadence_state, now=datetime.now(UTC)
-        ):
-            try:
-                _run_voice_reflection_tick(
-                    persona_dir,
-                    build_tier_provider(persona_dir, TIER_BACKGROUND_GENERATIVE),
-                    event_bus,
-                )
-            except Exception:
-                logger.exception("supervisor voice-reflection tick raised")
-            finally:
-                voice_cadence_state = persisted_cadence.advance(
-                    now=datetime.now(UTC), interval_s=voice_reflection_interval_s
-                )
-                persisted_cadence.save_cadence(
-                    persona_dir, "voice_reflection_cadence.json", voice_cadence_state
-                )
+            # Log-rotation cadence — hourly default. Bounded JSONL archives so
+            # heartbeats/dreams/emotion_growth don't grow forever; yearly
+            # archive for soul_audit (every decision must remain reachable).
+            # Fault-isolated per-log inside the tick function.
+            if log_rotation_cadence_state is not None and persisted_cadence.is_due(
+                log_rotation_cadence_state, now=datetime.now(UTC)
+            ):
+                try:
+                    _run_log_rotation_tick(persona_dir, event_bus)
+                except Exception:
+                    logger.exception("supervisor log-rotation tick raised")
+                finally:
+                    log_rotation_cadence_state = persisted_cadence.advance(
+                        now=datetime.now(UTC), interval_s=log_rotation_interval_s
+                    )
+                    persisted_cadence.save_cadence(
+                        persona_dir, "log_rotation_cadence.json", log_rotation_cadence_state
+                    )
 
-        # Self-model reflection cadence — its OWN persisted-cadence block,
-        # mirroring soul review's decoupling from the monotonic timers. The
-        # tick gates itself internally on a persisted wall-clock cadence
-        # (self_model_cadence_state.json, which survives restart/sleep), so
-        # this enable flag only switches the block on/off — the pacing lives
-        # in the tick. Fault-isolated so a reflection crash can't take the
-        # supervisor down (Organ DoD — the producer fires on the live path).
-        # Cost: pinned to SELF_MODEL_MODEL (haiku) via build_self_model_provider
-        # — the tick's only model call is the articulate note (a one-sentence
-        # housekeeping call), so it must not inherit the persona chat provider.
-        if self_model_interval_s is not None:
-            try:
-                from brain.self_model.articulate import build_self_model_provider
-                _run_self_model_tick(
-                    persona_dir,
-                    provider=build_self_model_provider(persona_dir),
-                    event_bus=event_bus,
-                )
-            except Exception:
-                logger.exception("supervisor self-model tick raised")
+            # Initiate review cadence — mirrors soul_review. Per-pass cost cap
+            # (3 candidates max). Fault-isolated.
+            if initiate_review_cadence_state is not None and persisted_cadence.is_due(
+                initiate_review_cadence_state, now=datetime.now(UTC)
+            ):
+                try:
+                    _run_initiate_review_tick(persona_dir, provider, event_bus)
+                except Exception:
+                    logger.exception("supervisor initiate-review tick raised")
+                finally:
+                    initiate_review_cadence_state = persisted_cadence.advance(
+                        now=datetime.now(UTC), interval_s=initiate_review_interval_s
+                    )
+                    persisted_cadence.save_cadence(
+                        persona_dir, "initiate_review_cadence.json", initiate_review_cadence_state
+                    )
 
-        # Maker (autonomous making) tick — fail-isolated. The tick gates itself
-        # internally on the persisted creative charge (maker_charge.json); this
-        # block only switches the organ on/off. Opens a per-tick MemoryStore
-        # inside this thread (the charge readers need it), mirroring the
-        # store-ownership pattern of the soul-review/self-model ticks.
-        if maker_enabled:  # default True; gate exists for tests/builds
-            try:
-                with ExitStack() as _maker_stack:
-                    _maker_store = MemoryStore(persona_dir / "memories.db")
-                    _maker_stack.callback(_maker_store.close)
+            # Voice-reflection cadence — daily by default. Gathers last 7 days
+            # of crystallizations + dreams + message tones and may emit a
+            # voice-edit candidate (gated by >=3 evidence items inside the
+            # reflection tick itself). Fault-isolated.
+            if voice_cadence_state is not None and persisted_cadence.is_due(
+                voice_cadence_state, now=datetime.now(UTC)
+            ):
+                try:
+                    _run_voice_reflection_tick(
+                        persona_dir,
+                        build_tier_provider(persona_dir, TIER_BACKGROUND_GENERATIVE),
+                        event_bus,
+                    )
+                except Exception:
+                    logger.exception("supervisor voice-reflection tick raised")
+                finally:
+                    voice_cadence_state = persisted_cadence.advance(
+                        now=datetime.now(UTC), interval_s=voice_reflection_interval_s
+                    )
+                    persisted_cadence.save_cadence(
+                        persona_dir, "voice_reflection_cadence.json", voice_cadence_state
+                    )
+
+            # Self-model reflection cadence — its OWN persisted-cadence block,
+            # mirroring soul review's decoupling from the monotonic timers. The
+            # tick gates itself internally on a persisted wall-clock cadence
+            # (self_model_cadence_state.json, which survives restart/sleep), so
+            # this enable flag only switches the block on/off — the pacing lives
+            # in the tick. Fault-isolated so a reflection crash can't take the
+            # supervisor down (Organ DoD — the producer fires on the live path).
+            # Cost: pinned to SELF_MODEL_MODEL (haiku) via build_self_model_provider
+            # — the tick's only model call is the articulate note (a one-sentence
+            # housekeeping call), so it must not inherit the persona chat provider.
+            if self_model_interval_s is not None:
+                try:
+                    from brain.self_model.articulate import build_self_model_provider
+                    _run_self_model_tick(
+                        persona_dir,
+                        provider=build_self_model_provider(persona_dir),
+                        event_bus=event_bus,
+                    )
+                except Exception:
+                    logger.exception("supervisor self-model tick raised")
+
+            # Maker (autonomous making) tick — fail-isolated. The tick gates itself
+            # internally on the persisted creative charge (maker_charge.json); this
+            # block only switches the organ on/off. Reuses the per-tick `store`
+            # opened at the top of this iteration (the charge readers need it)
+            # instead of opening its own separate connection (#132).
+            if maker_enabled and store is not None:  # default True; gate exists for tests/builds
+                try:
                     _maybe_run_maker_tick(
                         persona_dir,
-                        store=_maker_store,
+                        store=store,
                         provider=build_tier_provider(persona_dir, TIER_BACKGROUND_GENERATIVE),
                     )
-            except Exception:
-                logger.exception("supervisor maker store-open raised")
+                except Exception:
+                    logger.exception("supervisor maker tick raised")
+            elif maker_enabled:
+                logger.debug("supervisor maker tick skipped: per-tick store unavailable this tick")
 
-        # Notes (autonomous persona notes) tick — fail-isolated. The tick gates
-        # itself internally on consent + away-time + cooldown + budget
-        # (notes_state.json / notes_budget.json); this block only switches the
-        # organ on/off. Opens a per-tick MemoryStore inside this thread (the
-        # runner reads dreams/emotion), mirroring the maker tick's store
-        # ownership. Organ DoD — the producer fires on the live path.
-        if notes_enabled:  # default True; gate exists for tests/builds
-            try:
-                with ExitStack() as _notes_stack:
-                    _notes_store = MemoryStore(persona_dir / "memories.db")
-                    _notes_stack.callback(_notes_store.close)
+            # Notes (autonomous persona notes) tick — fail-isolated. The tick gates
+            # itself internally on consent + away-time + cooldown + budget
+            # (notes_state.json / notes_budget.json); this block only switches the
+            # organ on/off. Reuses the per-tick `store` opened at the top of this
+            # iteration (the `store` kwarg is accepted but currently unused by the
+            # notes runner itself) instead of opening its own separate connection
+            # (#132). Organ DoD — the producer fires on the live path.
+            if notes_enabled and store is not None:  # default True; gate exists for tests/builds
+                try:
                     _maybe_run_notes_tick(
                         persona_dir,
-                        store=_notes_store,
+                        store=store,
                         provider=build_tier_provider(persona_dir, TIER_BACKGROUND_GENERATIVE),
                     )
-            except Exception:
-                logger.exception("supervisor notes store-open raised")
+                except Exception:
+                    logger.exception("supervisor notes tick raised")
+            elif notes_enabled:
+                logger.debug("supervisor notes tick skipped: per-tick store unavailable this tick")
+        finally:
+            if store is not None:
+                try:
+                    # Belt-and-suspenders; read BEFORE close. Every MemoryStore
+                    # mutator used in this loop commits before returning (see
+                    # store.py), so the shared connection should always be at
+                    # rest here — this only logs if that invariant is ever
+                    # violated. Guarded by the same try as the close below so a
+                    # closed/invalid connection can't turn this safety check
+                    # itself into an uncaught exception.
+                    if store._conn.in_transaction:  # noqa: SLF001
+                        logger.warning(
+                            "supervisor per-tick store had an open transaction "
+                            "at tick close (unexpected — every MemoryStore "
+                            "mutator in this loop commits before returning); "
+                            "closing anyway"
+                        )
+                    store.close()
+                except Exception:
+                    logger.exception("supervisor per-tick store close raised")
 
         # Kindled-link tick — fail-isolated. The tick self-paces via its own
         # persisted cadence (kindled_tick_cadence.json); this block only

--- a/brain/ingest/pipeline.py
+++ b/brain/ingest/pipeline.py
@@ -496,7 +496,7 @@ def extract_session_snapshot(
 def snapshot_stale_sessions(
     persona_dir: Path,
     *,
-    silence_minutes: float = 5.0,
+    silence_minutes: float = 10.0,
     store: MemoryStore,
     hebbian: HebbianMatrix,
     provider: LLMProvider,

--- a/tests/unit/brain/bridge/test_supervisor_db_overhead.py
+++ b/tests/unit/brain/bridge/test_supervisor_db_overhead.py
@@ -1,0 +1,632 @@
+"""Tests for issue #132 — supervisor per-tick DB overhead + two small tick fixes.
+
+Part A: sweep/maker/notes share ONE MemoryStore/HebbianMatrix connection per tick
+(instead of 3 memories.db opens), integrity_check=False at the per-tick sites.
+Part B: session-silence threshold bumped 5 -> 10 minutes (behavioral gate test lives
+in tests/unit/brain/ingest/test_pipeline.py; the default/wiring checks live here).
+Part C: the 6h forgetting/narrative maintenance pass is throttled behind
+cli_throttle.background_slot(), matching interest-sweep's existing idiom.
+
+All Part-A tests drive run_folded() SYNCHRONOUSLY, single-threaded, no polling or
+event-timing — see _drive_ticks below. Termination is bounded deterministically by
+hooking the sweep's MemoryStore construction (reached every iteration, success or
+failure), not by any later call in the tick body or by a wall-clock timeout.
+"""
+
+from __future__ import annotations
+
+import inspect
+import threading
+from contextlib import contextmanager
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import brain.bridge.server as server
+import brain.bridge.supervisor as supervisor
+import brain.health.self_model_repair
+import brain.ingest.pipeline as pipeline
+import brain.memory.hebbian
+import brain.memory.store
+from brain.bridge.provider import FakeProvider
+from tests.unit.brain.bridge.test_supervisor import _CapturingBus, _persona_dir
+
+# ---------------------------------------------------------------------------
+# Part A — the synchronous, bounded-termination test primitive
+# ---------------------------------------------------------------------------
+
+
+class _TickCounter:
+    """Shared, externally-readable construction ordinal."""
+
+    def __init__(self) -> None:
+        self.n = 0
+
+
+class _DriveResult:
+    def __init__(self, bus, constructions, closes, maker_calls, notes_calls) -> None:
+        self.bus = bus
+        self.constructions = constructions
+        self.closes = closes
+        self.maker_calls = maker_calls
+        self.notes_calls = notes_calls
+
+
+def _isolating_kwargs(**overrides):
+    """The Part-A isolating configuration: every cadence other than sweep/maker/notes
+    disabled, so only the three targeted sites can construct a MemoryStore."""
+    kwargs = {
+        "tick_interval_s": 0.05,
+        "maker_enabled": True,
+        "notes_enabled": True,
+        "heartbeat_interval_s": None,
+        "soul_review_interval_s": None,
+        "finalize_interval_s": None,
+        "log_rotation_interval_s": None,
+        "initiate_review_interval_s": None,
+        "voice_reflection_interval_s": None,
+        "self_model_interval_s": None,
+        "compaction_interval_s": None,
+        "interest_sweep_interval_s": None,
+        "kindled_link_enabled": False,
+    }
+    kwargs.update(overrides)
+    return kwargs
+
+
+def _drive_ticks(
+    persona_dir: Path,
+    *,
+    num_ticks: int = 1,
+    bus=None,
+    memstore_raises_on_tick=None,
+    on_notes_call=None,
+    **extra,
+):
+    """Run run_folded synchronously, single-threaded, terminating deterministically
+    after exactly num_ticks constructions of the sweep's MemoryStore — whether that
+    construction succeeds or is made to raise. Hooking the SWEEP's construction
+    (reached every iteration, success or failure) is what makes termination
+    unconditional; tick_interval_s=0.05 keeps the one intentional stop_event.wait()
+    between ticks fast (not a correctness dependency — termination is by the
+    counter, not the timer).
+    """
+    stop_event = threading.Event()
+    bus = bus or _CapturingBus()
+    counter = _TickCounter()
+    constructions: list[dict] = []
+    closes: list[dict] = []
+    maker_calls: list[dict] = []
+    notes_calls: list[dict] = []
+
+    real_memory_store = brain.memory.store.MemoryStore
+    real_hebbian_matrix = brain.memory.hebbian.HebbianMatrix
+    real_maybe_maker = supervisor._maybe_run_maker_tick
+    real_maybe_notes = supervisor._maybe_run_notes_tick
+
+    class _CountingStore(real_memory_store):
+        def close(self):
+            closes.append({"tick": counter.n, "obj": self})
+            super().close()
+
+    def _make_memory_store(*args, **kwargs):
+        counter.n += 1
+        this_tick = counter.n
+        if this_tick >= num_ticks:
+            stop_event.set()
+        if memstore_raises_on_tick and this_tick in memstore_raises_on_tick:
+            raise RuntimeError(f"simulated store-open failure on tick {this_tick}")
+        obj = _CountingStore(*args, **kwargs)
+        constructions.append({"kind": "MemoryStore", "tick": this_tick, "kwargs": kwargs, "obj": obj})
+        return obj
+
+    def _make_hebbian(*args, **kwargs):
+        obj = real_hebbian_matrix(*args, **kwargs)
+        constructions.append({"kind": "HebbianMatrix", "tick": counter.n, "kwargs": kwargs, "obj": obj})
+        return obj
+
+    def _spy_maker(*a, **kw):
+        maker_calls.append({"tick": counter.n, "store": kw.get("store")})
+        return real_maybe_maker(*a, **kw)
+
+    def _spy_notes(*a, **kw):
+        notes_calls.append({"tick": counter.n, "store": kw.get("store")})
+        if on_notes_call is not None:
+            on_notes_call(counter.n, kw.get("store"))
+        return real_maybe_notes(*a, **kw)
+
+    with (
+        patch.object(supervisor, "MemoryStore", side_effect=_make_memory_store),
+        patch("brain.memory.store.MemoryStore", side_effect=_make_memory_store),
+        patch.object(supervisor, "HebbianMatrix", side_effect=_make_hebbian),
+        patch.object(supervisor, "_maybe_run_maker_tick", side_effect=_spy_maker),
+        patch.object(supervisor, "_maybe_run_notes_tick", side_effect=_spy_notes),
+        patch.object(supervisor, "_attunement_should_run_backfill", return_value=False),
+        patch.object(supervisor, "_attunement_should_run_supplementary_backfill", return_value=False),
+        patch.object(supervisor, "_emotion_backfill_should_run", return_value=False),
+        patch.object(supervisor, "_vocab_repair_should_run", return_value=False),
+        patch.object(supervisor, "_soul_candidate_repair_should_run", return_value=False),
+        patch(
+            "brain.health.self_model_repair.should_run_self_model_repair",
+            return_value=False,
+        ),
+    ):
+        kwargs = _isolating_kwargs(**extra)
+        supervisor.run_folded(
+            stop_event,
+            persona_dir=persona_dir,
+            provider=FakeProvider(),
+            event_bus=bus,
+            **kwargs,
+        )
+    return _DriveResult(bus, constructions, closes, maker_calls, notes_calls)
+
+
+def _mem_constructions(result: _DriveResult) -> list[dict]:
+    return [c for c in result.constructions if c["kind"] == "MemoryStore"]
+
+
+def _hebbian_constructions(result: _DriveResult) -> list[dict]:
+    return [c for c in result.constructions if c["kind"] == "HebbianMatrix"]
+
+
+# ---------------------------------------------------------------------------
+# C1 / C2 / C3 — one connection per tick, no per-tick integrity_check
+# ---------------------------------------------------------------------------
+
+
+def test_run_folded_opens_memories_db_once_per_tick_sweep_maker_notes(tmp_path):
+    """C1: sweep/maker/notes share one memories.db connection per tick."""
+    persona_dir = _persona_dir(tmp_path)
+    result = _drive_ticks(persona_dir, num_ticks=1)
+    assert len(_mem_constructions(result)) == 1
+
+
+def test_run_folded_opens_hebbian_db_once_per_tick(tmp_path):
+    """C2 (regression guard): hebbian.db opened at most once per tick."""
+    persona_dir = _persona_dir(tmp_path)
+    result = _drive_ticks(persona_dir, num_ticks=1)
+    assert len(_hebbian_constructions(result)) == 1
+
+
+def test_run_folded_per_tick_opens_skip_integrity_check(tmp_path):
+    """C3: the per-tick memories.db/hebbian.db opens pass integrity_check=False."""
+    persona_dir = _persona_dir(tmp_path)
+    result = _drive_ticks(persona_dir, num_ticks=1)
+    mem = _mem_constructions(result)
+    heb = _hebbian_constructions(result)
+    assert len(mem) == 1 and mem[0]["kwargs"].get("integrity_check") is False
+    assert len(heb) == 1 and heb[0]["kwargs"].get("integrity_check") is False
+
+
+def test_maker_and_notes_reuse_the_sweeps_live_store_object(tmp_path):
+    """C1/C3 strengthened (round-5 MAJOR-2/MAJOR-4): maker and notes are called with
+    the EXACT store object the sweep constructed, not merely *a* connection — this
+    directly rules out a mis-build where the shared store is closed too early
+    (maker/notes would then hold a dead connection) while still passing a naive
+    open-count assertion.
+    """
+    persona_dir = _persona_dir(tmp_path)
+    result = _drive_ticks(persona_dir, num_ticks=1)
+    mem = _mem_constructions(result)
+    assert len(mem) == 1
+    shared_obj = mem[0]["obj"]
+    assert len(result.maker_calls) == 1
+    assert len(result.notes_calls) == 1
+    assert result.maker_calls[0]["store"] is shared_obj
+    assert result.notes_calls[0]["store"] is shared_obj
+    # And it must still be usable (not closed) at the point maker/notes received it —
+    # by the time _drive_ticks returns the tick has finished and store IS closed, but
+    # confirm close() was only called once, after both consumers ran.
+    assert len(result.closes) == 1
+    assert result.closes[0]["obj"] is shared_obj
+
+
+def test_startup_repair_sites_unchanged(tmp_path):
+    """C4 (regression guard): the two one-shot startup MemoryStore opens (vocab-repair,
+    soul-candidate-repair) still pass integrity_check=False, unaffected by this change.
+    Anchored on the `while not stop_event.is_set():` structural marker, not a line
+    number, so this survives surrounding edits — and runs entirely against the
+    working tree (no external git ref needed, unlike an origin/main diff, which
+    cannot run in this repo's shallow-checkout CI).
+    """
+    source = Path(supervisor.__file__).read_text(encoding="utf-8")
+    anchor = "while not stop_event.is_set():"
+    assert anchor in source
+    prefix = source.split(anchor, 1)[0]
+    assert prefix.count("integrity_check=False") == 2
+    assert "_vocab_repair_should_run(persona_dir)" in prefix
+    assert "_soul_candidate_repair_should_run(persona_dir)" in prefix
+    assert 'MemoryStore(str(db_path), integrity_check=False)' in prefix
+
+
+# ---------------------------------------------------------------------------
+# C8 — fail-soft: a shared-store open failure skips maker/notes for that tick only
+# ---------------------------------------------------------------------------
+
+
+def test_maker_notes_skip_cleanly_when_shared_store_open_fails(tmp_path):
+    persona_dir = _persona_dir(tmp_path)
+    result = _drive_ticks(persona_dir, num_ticks=2, memstore_raises_on_tick={1})
+    assert not any(c["tick"] == 1 for c in result.maker_calls)
+    assert not any(c["tick"] == 1 for c in result.notes_calls)
+    assert [c["tick"] for c in result.maker_calls] == [2]
+    assert [c["tick"] for c in result.notes_calls] == [2]
+    mem = _mem_constructions(result)
+    tick2_store = next(c["obj"] for c in mem if c["tick"] == 2)
+    assert result.maker_calls[0]["store"] is tick2_store
+    assert result.notes_calls[0]["store"] is tick2_store
+
+
+# ---------------------------------------------------------------------------
+# C11 — shared-connection visibility is unchanged
+# ---------------------------------------------------------------------------
+
+
+def test_shared_store_sees_commits_from_independent_connection(tmp_path):
+    from brain.memory.store import Memory, MemoryStore
+
+    persona_dir = _persona_dir(tmp_path)
+    shared = MemoryStore(persona_dir / "memories.db", integrity_check=False)
+    try:
+        other = MemoryStore(persona_dir / "memories.db", integrity_check=False)
+        try:
+            memory = Memory.create_new(content="hello", memory_type="meta", domain="test")
+            other.create(memory)
+        finally:
+            other.close()
+        fetched = shared.get(memory.id, bump=False)
+        assert fetched is not None
+        assert fetched.id == memory.id
+    finally:
+        shared.close()
+
+
+# ---------------------------------------------------------------------------
+# C12 — no connection leak across ticks, including on an uncaught mid-tick exception
+# ---------------------------------------------------------------------------
+
+
+def test_store_construct_close_count_matches_across_ticks(tmp_path):
+    """C12 test 1 (regression guard, explicitly labeled): true both pre- and post-fix."""
+    persona_dir = _persona_dir(tmp_path)
+    result = _drive_ticks(persona_dir, num_ticks=3)
+    mem = _mem_constructions(result)
+    assert len(mem) == len(result.closes) == 3
+    constructed_objs = {c["obj"] for c in mem}
+    closed_objs = {c["obj"] for c in result.closes}
+    assert constructed_objs == closed_objs
+
+
+def test_store_closed_before_uncaught_exception_propagates(tmp_path):
+    """C12 test 2 (claim-bearing): the shared store is closed before an exception
+    raised elsewhere in the tick body (soul_cadence.save_cadence_state, genuinely
+    unguarded pre-fix and post-fix) propagates out of run_folded.
+    """
+    persona_dir = _persona_dir(tmp_path)
+    stop_event = threading.Event()
+    closes: list[int] = []
+    real_memory_store = brain.memory.store.MemoryStore
+
+    class _CloseSpyingStore(real_memory_store):
+        def close(self):
+            closes.append(1)
+            super().close()
+
+    with (
+        patch.object(
+            supervisor, "MemoryStore", side_effect=lambda *a, **kw: _CloseSpyingStore(*a, **kw)
+        ),
+        patch.object(
+            supervisor.soul_cadence, "save_cadence_state", side_effect=RuntimeError("boom")
+        ),
+        patch.object(supervisor, "_attunement_should_run_backfill", return_value=False),
+        patch.object(supervisor, "_attunement_should_run_supplementary_backfill", return_value=False),
+        patch.object(supervisor, "_emotion_backfill_should_run", return_value=False),
+        patch.object(supervisor, "_vocab_repair_should_run", return_value=False),
+        patch.object(supervisor, "_soul_candidate_repair_should_run", return_value=False),
+        patch(
+            "brain.health.self_model_repair.should_run_self_model_repair",
+            return_value=False,
+        ),
+    ):
+        with pytest.raises(RuntimeError, match="boom"):
+            supervisor.run_folded(
+                stop_event,
+                persona_dir=persona_dir,
+                provider=FakeProvider(),
+                event_bus=_CapturingBus(),
+                tick_interval_s=0.05,
+                maker_enabled=True,
+                notes_enabled=True,
+                heartbeat_interval_s=None,
+                soul_review_interval_s=0.0,
+                finalize_interval_s=None,
+                log_rotation_interval_s=None,
+                initiate_review_interval_s=None,
+                voice_reflection_interval_s=None,
+                self_model_interval_s=None,
+                compaction_interval_s=None,
+                interest_sweep_interval_s=None,
+                kindled_link_enabled=False,
+            )
+    assert closes == [1]
+
+
+# ---------------------------------------------------------------------------
+# C16 — the widened connection lifetime coexists with a real second connection
+# ---------------------------------------------------------------------------
+
+
+def test_shared_store_coexists_with_finalize_on_same_tick(tmp_path):
+    """C16: finalize fires on the same tick (its own cadence state also treats a
+    missing next_at as due), opening its OWN independent MemoryStore to the same
+    file WHILE the shared store from the sweep is still held open — nothing
+    deadlocks or raises, and the shared connection survives the encounter usable.
+
+    Corrected (stage-6 round 1, MAJOR-2): the shared store's lifetime does overlap
+    finalize's — both are open simultaneously during _run_finalize_tick's body —
+    but `_run_finalize_tick` closes its OWN connection (via its own ExitStack)
+    before returning, well before the notes block where the liveness probe below
+    fires. So the probe proves the shared connection is still healthy AFTER a
+    second connection to the same file was opened, used, and closed during this
+    tick — not that the two were simultaneously queried at the same instant. The
+    substantive "did the two connections coexist without a lock conflict" claim
+    is what `len(mem) == 2` plus `run_folded` returning without raising already
+    proves; the probe adds "and the shared connection wasn't left in a broken
+    state by that encounter."
+    """
+    persona_dir = _persona_dir(tmp_path)
+    live_probe_results = []
+
+    def _probe(tick, store_obj):
+        # Called from the notes block, after finalize's own tick (and its own,
+        # already-closed connection to the same file) has run earlier in this
+        # same iteration — confirms the shared connection is still usable.
+        if store_obj is not None:
+            row = store_obj._conn.execute("SELECT 1").fetchone()  # noqa: SLF001
+            live_probe_results.append(tuple(row))
+
+    result = _drive_ticks(
+        persona_dir, num_ticks=1, finalize_interval_s=0.0, on_notes_call=_probe
+    )
+    mem = _mem_constructions(result)
+    # Two independent MemoryStore connections open on this tick: the sweep's shared
+    # one (reused by maker/notes) and finalize's own, separate one — exactly the
+    # "widened lifetime overlapping a real second connection" scenario this
+    # criterion targets. The sweep's is always constructed first each iteration.
+    # run_folded returning normally (no exception) is itself part of the proof
+    # that the two same-thread connections coexisted without a lock conflict.
+    assert len(mem) == 2
+    shared_obj = mem[0]["obj"]
+    assert len(result.maker_calls) == 1
+    assert result.maker_calls[0]["store"] is shared_obj
+    assert len(result.notes_calls) == 1
+    assert result.notes_calls[0]["store"] is shared_obj
+    # The shared connection is still live and queryable after finalize's
+    # independent connection to the same file was opened and closed earlier in
+    # this same tick.
+    assert live_probe_results == [(1,)]
+
+
+# ---------------------------------------------------------------------------
+# Part B — session-silence threshold defaults + wiring
+# ---------------------------------------------------------------------------
+
+
+def test_silence_minutes_defaults_are_ten_minutes():
+    """C14 test 1 (claim-bearing)."""
+    assert inspect.signature(supervisor.run_folded).parameters["silence_minutes"].default == 10.0
+    assert inspect.signature(server.build_app).parameters["silence_minutes"].default == 10.0
+    assert (
+        inspect.signature(pipeline.snapshot_stale_sessions).parameters["silence_minutes"].default
+        == 10.0
+    )
+
+
+def test_build_app_default_reaches_run_folded():
+    """C14 test 3: build_app's own silence_minutes PARAMETER is what actually gets
+    threaded into run_folded's kwargs dict (not a separately-hardcoded value) —
+    proves the composed production path, not just three independently-agreeing
+    signatures.
+
+    Corrected (stage-6 round 1, BLOCKER-1): the original version walked the WHOLE
+    module for any ast.keyword named silence_minutes, which spuriously matched
+    _drain_sessions_blocking's unrelated keyword argument at server.py — a
+    different function this change explicitly does NOT touch — and could never
+    have matched the real target, the sp7-supervisor kwargs={...} DICT LITERAL
+    inside build_app, which is an ast.Dict, not an ast.keyword. That made the
+    test vacuous: it would pass even if the dict literal were hardcoded to 5.0.
+    This version scopes the walk to build_app's own FunctionDef body and looks
+    for the actual dict entry.
+    """
+    import ast
+
+    source = Path(server.__file__).read_text(encoding="utf-8")
+    tree = ast.parse(source)
+
+    build_app_node = next(
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.FunctionDef) and node.name == "build_app"
+    )
+
+    found = False
+    for node in ast.walk(build_app_node):
+        if not isinstance(node, ast.Dict):
+            continue
+        for key, value in zip(node.keys, node.values, strict=False):
+            if (
+                isinstance(key, ast.Constant)
+                and key.value == "silence_minutes"
+                and isinstance(value, ast.Name)
+                and value.id == "silence_minutes"
+            ):
+                found = True
+                break
+        if found:
+            break
+
+    assert found, (
+        "build_app's own sp7-supervisor kwargs dict must forward its own "
+        "silence_minutes parameter, not a separately hardcoded value"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Part C — maintenance pass throttled behind cli_throttle.background_slot()
+# ---------------------------------------------------------------------------
+
+
+def _drive_one_maintenance_tick(persona_dir: Path, *, throttle_grants: bool):
+    stop_event = threading.Event()
+    real_memory_store = brain.memory.store.MemoryStore
+
+    def _stop_after_sweep(*a, **kw):
+        stop_event.set()
+        return real_memory_store(*a, **kw)
+
+    # A shared call-order list, not just two independent MagicMocks — two
+    # independent mocks cannot observe RELATIVE order between them, which C15's
+    # "forgetting before narrative, unchanged from pre-fix" claim requires
+    # (stage-6 round 1, MAJOR-3: the original version only asserted each was
+    # called once, which cannot catch an order regression).
+    call_order: list[str] = []
+    forgetting_spy = MagicMock(side_effect=lambda *a, **kw: call_order.append("forgetting"))
+    narrative_spy = MagicMock(side_effect=lambda *a, **kw: call_order.append("narrative"))
+    pending_spy = MagicMock()
+    sidecar_spy = MagicMock()
+
+    @contextmanager
+    def _fake_slot(*, now=None):
+        yield throttle_grants
+
+    with (
+        patch.object(supervisor, "MemoryStore", side_effect=_stop_after_sweep),
+        patch("brain.memory.store.MemoryStore", side_effect=_stop_after_sweep),
+        patch.object(supervisor, "HebbianMatrix"),
+        patch.object(supervisor.cli_throttle, "background_slot", side_effect=_fake_slot),
+        patch.object(supervisor, "forgetting_run_pass", forgetting_spy),
+        patch.object(supervisor, "_run_narrative_memory_pass", narrative_spy),
+        patch("brain.files.pending.sweep_expired", pending_spy),
+        patch("brain.health.sidecar_sweep.sweep_stale_sidecars", sidecar_spy),
+        patch.object(supervisor, "_attunement_should_run_backfill", return_value=False),
+        patch.object(supervisor, "_attunement_should_run_supplementary_backfill", return_value=False),
+        patch.object(supervisor, "_emotion_backfill_should_run", return_value=False),
+        patch.object(supervisor, "_vocab_repair_should_run", return_value=False),
+        patch.object(supervisor, "_soul_candidate_repair_should_run", return_value=False),
+        patch(
+            "brain.health.self_model_repair.should_run_self_model_repair",
+            return_value=False,
+        ),
+    ):
+        supervisor.run_folded(
+            stop_event,
+            persona_dir=persona_dir,
+            provider=FakeProvider(),
+            event_bus=_CapturingBus(),
+            tick_interval_s=0.05,
+            maker_enabled=False,
+            notes_enabled=False,
+            heartbeat_interval_s=None,
+            soul_review_interval_s=0.0,
+            finalize_interval_s=None,
+            log_rotation_interval_s=None,
+            initiate_review_interval_s=None,
+            voice_reflection_interval_s=None,
+            self_model_interval_s=None,
+            compaction_interval_s=None,
+            interest_sweep_interval_s=None,
+            kindled_link_enabled=False,
+        )
+    return forgetting_spy, narrative_spy, pending_spy, sidecar_spy, call_order
+
+
+def test_maintenance_pass_defers_expensive_work_when_throttle_denies(tmp_path):
+    persona_dir = _persona_dir(tmp_path)
+    forgetting_spy, narrative_spy, pending_spy, sidecar_spy, _order = _drive_one_maintenance_tick(
+        persona_dir, throttle_grants=False
+    )
+    forgetting_spy.assert_not_called()
+    narrative_spy.assert_not_called()
+    pending_spy.assert_called_once()
+    sidecar_spy.assert_called_once()
+    cadence_state = supervisor.persisted_cadence.load_cadence(
+        persona_dir, "maintenance_cadence.json"
+    )
+    assert cadence_state.next_at is not None
+
+
+def test_maintenance_pass_runs_expensive_work_when_throttle_grants(tmp_path):
+    persona_dir = _persona_dir(tmp_path)
+    forgetting_spy, narrative_spy, pending_spy, sidecar_spy, order = _drive_one_maintenance_tick(
+        persona_dir, throttle_grants=True
+    )
+    forgetting_spy.assert_called_once()
+    narrative_spy.assert_called_once()
+    pending_spy.assert_called_once()
+    sidecar_spy.assert_called_once()
+    # C15's stated claim: forgetting before narrative, unchanged from pre-fix.
+    assert order == ["forgetting", "narrative"]
+
+
+def test_forgetting_failure_does_not_skip_narrative_pass(tmp_path):
+    """The two try/except blocks under the throttle stay independent — a forgetting
+    exception must not also skip narrative for that cycle (round-5 finding: an
+    earlier draft merged them into one handler, which this test would have caught).
+    """
+    persona_dir = _persona_dir(tmp_path)
+    stop_event = threading.Event()
+    real_memory_store = brain.memory.store.MemoryStore
+
+    def _stop_after_sweep(*a, **kw):
+        stop_event.set()
+        return real_memory_store(*a, **kw)
+
+    narrative_spy = MagicMock()
+
+    @contextmanager
+    def _granting_slot(*, now=None):
+        yield True
+
+    with (
+        patch.object(supervisor, "MemoryStore", side_effect=_stop_after_sweep),
+        patch("brain.memory.store.MemoryStore", side_effect=_stop_after_sweep),
+        patch.object(supervisor, "HebbianMatrix"),
+        patch.object(supervisor.cli_throttle, "background_slot", side_effect=_granting_slot),
+        patch.object(supervisor, "forgetting_run_pass", side_effect=RuntimeError("boom")),
+        patch.object(supervisor, "_run_narrative_memory_pass", narrative_spy),
+        patch("brain.files.pending.sweep_expired"),
+        patch("brain.health.sidecar_sweep.sweep_stale_sidecars"),
+        patch.object(supervisor, "_attunement_should_run_backfill", return_value=False),
+        patch.object(supervisor, "_attunement_should_run_supplementary_backfill", return_value=False),
+        patch.object(supervisor, "_emotion_backfill_should_run", return_value=False),
+        patch.object(supervisor, "_vocab_repair_should_run", return_value=False),
+        patch.object(supervisor, "_soul_candidate_repair_should_run", return_value=False),
+        patch(
+            "brain.health.self_model_repair.should_run_self_model_repair",
+            return_value=False,
+        ),
+    ):
+        # Must not raise — forgetting's exception is caught locally, exactly as pre-fix.
+        supervisor.run_folded(
+            stop_event,
+            persona_dir=persona_dir,
+            provider=FakeProvider(),
+            event_bus=_CapturingBus(),
+            tick_interval_s=0.05,
+            maker_enabled=False,
+            notes_enabled=False,
+            heartbeat_interval_s=None,
+            soul_review_interval_s=0.0,
+            finalize_interval_s=None,
+            log_rotation_interval_s=None,
+            initiate_review_interval_s=None,
+            voice_reflection_interval_s=None,
+            self_model_interval_s=None,
+            compaction_interval_s=None,
+            interest_sweep_interval_s=None,
+            kindled_link_enabled=False,
+        )
+    narrative_spy.assert_called_once()

--- a/tests/unit/brain/ingest/test_pipeline.py
+++ b/tests/unit/brain/ingest/test_pipeline.py
@@ -814,6 +814,45 @@ def test_snapshot_stale_sessions_skips_fresh_sessions(
     assert reports == []
 
 
+def test_snapshot_stale_sessions_respects_ten_minute_threshold(
+    tmp_path: Path,
+    store: MemoryStore,
+    hebbian: HebbianMatrix,
+    tracking_provider: _TrackingProvider,
+) -> None:
+    """Issue #132 Part B (C14 test 2, regression guard): a fixture session idle 9
+    minutes must NOT be extracted; one idle just over 10 minutes must. This
+    exercises snapshot_stale_sessions's pre-existing, unchanged gate-comparison
+    logic — it does not itself prove the production default changed (that is
+    `test_silence_minutes_defaults_are_ten_minutes` in
+    tests/unit/brain/bridge/test_supervisor_db_overhead.py); it confirms the
+    mechanism the new default now feeds into still works correctly.
+    """
+    fresh_sid = "sess_nine_min"
+    fresh_ts = (datetime.now(UTC) - timedelta(minutes=9)).isoformat()
+    ingest_turn(
+        tmp_path, {"session_id": fresh_sid, "speaker": "user", "text": "still here", "ts": fresh_ts}
+    )
+
+    stale_sid = "sess_ten_min"
+    stale_ts = (datetime.now(UTC) - timedelta(minutes=10, seconds=5)).isoformat()
+    ingest_turn(
+        tmp_path,
+        {"session_id": stale_sid, "speaker": "user", "text": "long gone", "ts": stale_ts},
+    )
+
+    reports = snapshot_stale_sessions(
+        tmp_path,
+        silence_minutes=10.0,
+        store=store,
+        hebbian=hebbian,
+        provider=tracking_provider,
+    )
+
+    assert [r.session_id for r in reports] == [stale_sid]
+    assert tracking_provider.call_count == 1
+
+
 def test_snapshot_stale_sessions_cleans_ghost_buffer(
     tmp_path: Path,
     store: MemoryStore,


### PR DESCRIPTION
Addresses #132. Cuts the supervisor's per-tick DB overhead that the lag investigation identified
as the sustained idle-CPU driver — confirmed via the churn logger's cmdline capture
(`brain.cli … supervisor run` holds the DB read-locks) and the churn analysis (~98% SQLite
WAL/SHM cycling; `memories.db-wal` created-and-destroyed roughly every 1.6 s).

**Scope note (updated from the original brief):** the third original item —
gating `compute_user_presence`'s full-history rescan behind a cooldown — was pulled
out of this PR after 3 rounds of a guarded-change red-team loop kept finding
"stale cached value silently produces a wrong decision" bugs in it (an hour-of-day
gate flip, a returning-user staleness window, a file-removal edge case in the
invalidation logic). Rather than patch it a 4th time under this PR's time pressure,
it's moved to its own follow-up: #225. Two small, separately-reviewed items were
added in its place (see below).

## What's in this PR

1. **Per-tick DB connection reuse** (`run_folded` in `brain/bridge/supervisor.py`): the sweep,
   maker, and notes sub-ticks used to each open their own `memories.db` connection (3 opens/tick;
   the notes one was dead — its `store` kwarg was accepted but never read). Now the sweep's
   connection is reused by maker and notes, guaranteed closed via a `try/finally` spanning the
   tick body (this also closes a narrow pre-existing leak-on-uncaught-exception gap that didn't
   matter before, since the old per-block `with` closed each connection immediately). A
   sweep-store-open failure now also skips maker/notes for that tick — a new, accepted coupling,
   not preserved parity (stated explicitly, not hidden).
2. **Skip `PRAGMA integrity_check`** (a full-DB scan) on the per-tick opens above — kept only at
   the one-shot startup repair opens, which already had it.
3. **Session-idle threshold bumped 5 → 10 minutes** (`silence_minutes` in
   `brain/bridge/supervisor.py`, `brain/bridge/server.py`, `brain/ingest/pipeline.py`): 5 minutes
   was triggering session-snapshot extraction during a normal mid-conversation reading/composing
   pause; 10 minutes better matches real usage.
4. **Throttle the 6-hourly forgetting/narrative maintenance pass** behind
   `cli_throttle.background_slot()` (the same "was chat active in the last 5 min" check the
   existing interest-sweep block already uses) — it used to run its expensive, LLM-touching work
   unconditionally, including mid-conversation. A denied slot defers the pass to its next 6h
   firing rather than losing the work; session-cleanup itself is intentionally NOT throttled.

Behavior-preserving except the two explicitly-named new behaviors above (the maker/notes
sweep-failure coupling, and the intentional pacing changes from items 3/4). Storage format and
core logic unchanged.

**Does NOT close #132 on its own** — this verifies the mechanism reduction (fewer opens, no
per-tick integrity check, corrected pacing) via deterministic tests, not end-to-end host CPU/lag.
That needs confirming on production after deploy, with the now-working v2 churn logger.

Went through a full guarded-change red-team loop (spec/plan review, then built-code review) —
8 gate rounds total, including the presence-cache saga above and one wrongly-scoped AST test
caught and fixed during the built-code review. Full history in this branch's local working notes
(not tracked in git).
