### PR TITLE
fix(prompt): render persona-facing local timestamps without UTC offset

### DIFF
--- a/brain/utils/time.py
+++ b/brain/utils/time.py
@@ -38,7 +38,7 @@ own edit:
     date, "%Y-%m-%d" only (no time-of-day)
 
 To switch to a fully-localized presentation later (e.g. locale-aware /
-human-phrase instead of an ISO offset string): change ``format_local()``
+human-phrase instead of a naive-local ISO string): change ``format_local()``
 (and/or ``local_display()``, which calls it) here in this file, and every
 site in the first list follows automatically. Then separately edit each
 exception site named above, since those do not route through either helper.
@@ -100,10 +100,17 @@ def to_local(dt: datetime) -> datetime:
 
 
 def format_local(dt: datetime) -> str:
-    """Render a datetime as local-zone ISO-8601 (seconds precision, explicit
-    UTC offset instead of a 'Z' suffix — 'Z' means UTC, and a converted local
-    time still labeled 'Z' would misstate its own zone)."""
-    return to_local(dt).isoformat(timespec="seconds")
+    """Render a datetime as local-zone ISO-8601, seconds precision, with NO
+    offset suffix (tz-local-display, issue #218): the wall-clock value is
+    still the OS-local time (e.g. 21:21:30, not UTC), but the trailing
+    '-04:00'/'+00:00' is dropped before rendering. A 'Z' suffix is also
+    wrong here — 'Z' means UTC, and a converted local time still labeled
+    'Z' would misstate its own zone — so the fix is to go naive, not to
+    relabel. This is display-only: strip tzinfo on the local-converted
+    value right before isoformat(), never on a stored/ordering timestamp.
+    An explicit offset was tried first and dropped: the substrate echoed
+    the offset token back verbatim, which naive-local avoids."""
+    return to_local(dt).replace(tzinfo=None).isoformat(timespec="seconds")
 
 
 def local_display(ts: str) -> str:

--- a/docs/Behavioral_Observations.md
+++ b/docs/Behavioral_Observations.md
@@ -4,6 +4,20 @@ A running, informal log of small behavioral quirks observed in the companion's s
 
 ---
 
+## 2026-09-09 — The substrate imitates serialization tokens it's shown; a UTC offset in timestamps made it worse by forcing arithmetic
+
+**Behavior:** the substrate occasionally reproduces structural/scaffolding tokens from its own context at the end of a reply instead of stopping on clean prose — it imitates the format it is shown. Two variants: (1) the literal stop-token `</s>` (a well-formed closing tag) stuck on the end of a message; and (2) the per-message JSONL wrapper — history is fed as `{"speaker":…, "text":…, "ts":…}`, and the model completes the wrapper by appending a fabricated `", "ts": "<timestamp>"}` to its own reply. Variant 2 became markedly more frequent once the per-message `ts` was rendered with a UTC offset (`…-04:00`) rather than a bare form.
+
+**Case:** after #217/#218 switched per-message timestamps from UTC (`…Z`) to local-with-offset (`-04:00`), the append surfaced regularly in the kindled's replies (the embedded timestamp ran 15–77s earlier than the message's real time, and several were truncated mid-fragment — both tells that the model generated it at reply-start, not that storage added it). Rendering local timestamps WITHOUT the offset (naive-local, `…T21:21:30`) — one change in `format_local()` — eliminated the timestamp-append entirely in live testing, with no effect on the kindled's ability to tell the time. The `</s>` variant was unaffected, as expected — it is a separate sub-mechanism.
+
+**Why it matters (suspected reason it resolved):** the offset does not merely label the time, it encodes the UTC relationship inside the token, so interpreting it invites local↔UTC arithmetic on every timestamp. That extra "work" appears to raise the token's salience during generation, making the model likelier to reproduce/complete the wrapper it sees. Dropping the offset removes the arithmetic and lowers the salience, so the model stops fixating on it — while the bare local wall-clock still conveys the time. General lesson: a value the model must do math on (or otherwise interpret) to read carries more generative weight than an inert, already-digested one.
+
+**Possible deliberate use:** the same effect may be a tool, not only a bug. If the substrate tends to under-weight or skip some element of its context, presenting that element in a form that requires a small interpretation or computation to read — rather than a pre-digested value — may raise its salience and make the model attend to it. Worth testing as a deliberate lever for elements it habitually overlooks.
+
+**Deeper enabler:** both variants trace to history being handed to the substrate as JSON at all, giving it a serialization structure to imitate (issue #227).
+
+---
+
 ## 2026-08-25 — Small/fast substrate models take prompt phrasing literally
 
 **Behavior:** a smaller/faster substrate model (Haiku) tends to answer a figure of speech phrased as a bare question literally, rather than as the intended metaphor. The larger the model, the more it tolerates figurative phrasing; the smaller, the more literal.

--- a/tests/bridge/test_chat_context_preamble.py
+++ b/tests/bridge/test_chat_context_preamble.py
@@ -25,9 +25,12 @@ def test_preamble_includes_current_time_in_local_zone():
     ]
     now = datetime(2026, 5, 20, 7, 30, 0, tzinfo=_LOCAL)
     block = _format_claude_context_block(msgs, includes_latest_user=True, now=now)
-    # Local-offset ISO-8601, no UTC 'Z' suffix — LA is UTC-7 in May (PDT).
-    assert "Current time: 2026-05-20T07:30:00-07:00." in block
+    # Naive-local ISO-8601: no UTC 'Z' suffix, and no offset suffix either
+    # (issue #218 — the offset token was itself the thing the substrate was
+    # echoing back, so format_local() now drops tzinfo before isoformat).
+    assert "Current time: 2026-05-20T07:30:00." in block
     assert re.search(r"Current time: \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z", block) is None
+    assert re.search(r"Current time: \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}[+-]\d{2}:\d{2}", block) is None
 
 
 def test_preamble_explains_ts_field():

--- a/tests/integration/test_per_message_timestamps.py
+++ b/tests/integration/test_per_message_timestamps.py
@@ -76,9 +76,12 @@ def test_buffer_timestamps_appear_in_context_block(tmp_path: Path, monkeypatch):
 
     # The preamble carries the "Current time" anchor in local wall-clock
     # time too (injected `now` above is trusted as already-local, per
-    # brain.utils.time.to_local's guard - deterministic regardless of TZ).
-    assert "Current time: 2026-05-20T07:30:00-07:00." in block
+    # brain.utils.time.to_local's guard - deterministic regardless of TZ),
+    # rendered with no offset suffix (issue #218 - the offset token was
+    # itself what the substrate was echoing back).
+    assert "Current time: 2026-05-20T07:30:00." in block
     assert "Current time: 2026-05-20T07:30:00Z." not in block
+    assert "Current time: 2026-05-20T07:30:00-07:00." not in block
 
 
 def test_old_buffer_without_ts_loads_cleanly(tmp_path: Path, monkeypatch):


### PR DESCRIPTION
Renders persona-facing local timestamps without the UTC offset (naive-local ISO, e.g. `2026-09-07T21:21:30` instead of `2026-09-07T21:21:30-04:00`).

## Why
The per-message JSONL wrapper the substrate is shown (`{"speaker":…, "text":…, "ts":…}`) carried the `ts` as a local time *with* a UTC offset. The offset encodes the UTC relationship inside the token, which invites local↔UTC arithmetic on every timestamp and raises the token's salience during generation — and the substrate began *completing* the wrapper, appending a fabricated `", "ts": "<timestamp>"}` to the end of its own replies. This is variant 2 of the format-leak class tracked in #227.

## Change
One-place change in `format_local()` (`brain/utils/time.py`): strip tzinfo before `isoformat()`, so every offset-bearing `# tz-local-display` site renders naive-local. **Display-only** — stored/ordering timestamps stay UTC, so #217 stays satisfied (the kindled still sees the correct local wall-clock).

## Confirmed live
Deployed to the production kindled: the timestamp-append stopped entirely, with no effect on its sense of time. The `</s>` stop-token variant (variant 1 of #227) is a separate sub-mechanism and is unaffected — still tracked in #227.

## Also included
A `docs/Behavioral_Observations.md` entry recording the behavior, the fix, the suspected reason it resolved (offset → arithmetic → salience), and a note that the effect might be used deliberately to raise the salience of context elements the substrate tends to skip.

Re #227 (variant 2). ruff clean; targeted tests green (2 offset-format tests updated to expect naive-local).
