### PR TITLE
fix(harness): READY mtime slack — unblocks the v0.0.42 release validate job

### DIFF
--- a/tests/harness/foreground.py
+++ b/tests/harness/foreground.py
@@ -265,6 +265,14 @@ def boot_and_verify(
     )
 
 
+# READY freshness slack. Both branches compare READY's st_mtime against a
+# time.time() start; on Windows a just-written file can read slightly EARLIER
+# than that start (filesystem timestamp granularity, clock-source skew), so a
+# genuinely fresh READY was rejected as stale (#192). 2 s covers FAT/NTFS
+# worst-case granularity while still rejecting any leftover from a prior run.
+_READY_MTIME_SLACK_S = 2.0
+
+
 def _poll_for_ready_or_error(
     run_dir: Path, ready_timeout: float, error_markers: Sequence[str]
 ) -> None:
@@ -276,7 +284,7 @@ def _poll_for_ready_or_error(
         for marker in error_markers:
             if (run_dir / marker).exists():
                 return
-        if ready_path.exists() and ready_path.stat().st_mtime >= start:
+        if ready_path.exists() and ready_path.stat().st_mtime >= start - _READY_MTIME_SLACK_S:
             return
         time.sleep(_POLL_INTERVAL)
     raise ForegroundBootError(
@@ -290,10 +298,11 @@ def _require_fresh_ready(run_dir: Path, start: float) -> None:
 
     A successful (exit-0) ``boot_cmd`` is not itself proof the run booted -- a leftover
     ``READY`` file from a reused ``run_dir`` would otherwise be misread as this boot's own
-    confirmation. Require ``<run_dir>/READY`` to exist AND have an mtime ``>= start``.
+    confirmation. Require ``<run_dir>/READY`` to exist AND have an mtime ``>= start``
+    (minus :data:`_READY_MTIME_SLACK_S`).
     """
     ready_path = run_dir / _READY_NAME
-    if not ready_path.exists() or ready_path.stat().st_mtime < start:
+    if not ready_path.exists() or ready_path.stat().st_mtime < start - _READY_MTIME_SLACK_S:
         raise ForegroundBootError(
             f"boot_cmd exited 0 but {ready_path} is missing or stale (its mtime predates the "
             "boot's own start) -- refusing to treat a leftover READY in a reused run_dir as a "

--- a/tests/unit/harness/test_foreground.py
+++ b/tests/unit/harness/test_foreground.py
@@ -544,3 +544,68 @@ def test_boot_and_verify_error_does_not_leak_forwarded_token(
         fg.boot_and_verify(spec, boot_cmd=["false"], env={"CE_DROPIN_REPO": "x"})
 
     assert _SENTINEL not in str(excinfo.value)
+
+
+# --- #192: READY freshness must tolerate filesystem/clock granularity -----------------------------
+
+
+def test_boot_and_verify_boot_cmd_accepts_ready_within_mtime_slack(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """On Windows a just-written READY can carry an mtime slightly EARLIER than the
+    boot's ``time.time()`` start (filesystem timestamp granularity / clock source
+    skew). A READY within the slack window is this boot's own — accept it."""
+    import os
+
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+
+    def _fake_run(cmd, **kwargs):  # noqa: ANN001, ANN003
+        _write_ready(run_dir, {"brain_repo": "x"})
+        early = time.time() - 1.0  # inside the 2 s slack, but < boot_start
+        os.utime(run_dir / "READY", (early, early))
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(fg.subprocess, "run", _fake_run)
+    spec = fg.ArmBootSpec(arm="A", port=8931, run_dir=run_dir, ready_timeout=15.0)
+    fg.boot_and_verify(spec, boot_cmd=["true"])  # must not raise "missing or stale"
+
+
+def test_boot_and_verify_boot_cmd_still_rejects_ready_older_than_slack(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The slack is small: a leftover READY from a previous run is still rejected."""
+    import os
+
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    _write_ready(run_dir, {"brain_repo": "leftover"})
+    old = time.time() - 60.0
+    os.utime(run_dir / "READY", (old, old))
+
+    def _fake_run(cmd, **kwargs):  # noqa: ANN001, ANN003
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(fg.subprocess, "run", _fake_run)
+    spec = fg.ArmBootSpec(arm="A", port=8931, run_dir=run_dir, ready_timeout=15.0)
+    with pytest.raises(fg.ForegroundBootError, match="missing or stale"):
+        fg.boot_and_verify(spec, boot_cmd=["true"])
+
+
+def test_boot_and_verify_poll_mode_accepts_ready_within_mtime_slack(tmp_path: Path) -> None:
+    """Poll-branch counterpart: same slack applies to ``_poll_for_ready_or_error``."""
+    import os
+    import threading
+
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+
+    def _write_slightly_early() -> None:
+        time.sleep(0.05)
+        _write_ready(run_dir, {"brain_repo": "x"})
+        early = time.time() - 1.0
+        os.utime(run_dir / "READY", (early, early))
+
+    threading.Thread(target=_write_slightly_early, daemon=True).start()
+    spec = fg.ArmBootSpec(arm="C", port=8933, run_dir=run_dir, ready_timeout=5.0)
+    fg.boot_and_verify(spec, boot_cmd=None)  # must not time out waiting


### PR DESCRIPTION
The v0.0.42 release workflow's `validate` job (ubuntu-22.04) failed twice, identically, on:

- `tests/unit/harness/test_foreground.py::test_boot_and_verify_forwards_token_into_curated_launch_env`
- `tests/unit/harness/test_foreground.py::test_boot_and_verify_launch_env_unchanged_when_parent_lacks_token`

with `READY is missing or stale (its mtime predates the boot's own start)`. `st_mtime` comes from the kernel's coarse clock while `start` is `time.time()`, so a READY written right after `start` can carry an earlier timestamp. Deterministic on the 22.04 runner; the same race is the intermittent Windows failure in #192 / #232.

This is the **harness half of #212 only** (`tests/harness/foreground.py` + its three new tests): a 2 s freshness slack that still rejects a leftover READY from a prior run. #212's `attempt_heal.py` product change is left for its own review.

After merge: move the `v0.0.42` tag to the new `main` head and re-run the release workflow.

Refs #192
Refs #232

🤖 Generated with [Claude Code](https://claude.com/claude-code)