### PR TITLE
ci(release): validate on ubuntu-latest + preflight notes hint

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -125,7 +125,10 @@ jobs:
   validate:
     name: validate (tests + lint + frontend + cargo)
     needs: verify-version
-    runs-on: ubuntu-22.04
+    # Same image as test.yml's python matrix. A pinned 22.04 here let a
+    # READY-mtime test fail deterministically on the release gate while
+    # main CI (ubuntu-latest) stayed green (v0.0.42, #232).
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -36,7 +36,7 @@ Run these commands locally — same shape as CI runs on every PR (`uv`
 ## Packaging/versioning
 
 - Set the intended version in `pyproject.toml`.
-- Add or update `.public-sync/changelog-public.md` before tagging or sharing a build; local `CHANGELOG.md` is substituted at public sync time.
+- Add the release entry to `CHANGELOG.md` before tagging (the public-sync substitution was retired in v0.0.41; `CHANGELOG.md` is the published changelog). After the release workflow publishes, restore the curated notes over CI's auto-notes with `gh release edit <tag> --notes-file <that section>` — the preflight script prints the exact commands.
 - Review `docs/roadmap.md` and confirm known stubs/incomplete surfaces are documented.
 - Build the wheel/sdist only after tests and lint pass.
 - **Run `bash scripts/smoke_test_wheel.sh`** — builds the wheel + sdist,

--- a/scripts/release_preflight.sh
+++ b/scripts/release_preflight.sh
@@ -124,6 +124,8 @@ fi
 echo "✅ PREFLIGHT GREEN — safe to tag${TAG:+ $TAG}."
 echo
 echo "After the release workflow publishes the GitHub Release, CI's"
-echo "generate_release_notes OVERWRITES the curated changelog. Restore it with:"
-echo "    gh release edit ${TAG:-<tag>} --notes-file .public-sync/changelog-public.md"
+echo "generate_release_notes OVERWRITES the curated changelog. Restore it with the"
+echo "tag's own CHANGELOG.md section (extracted to a temp file):"
+echo "    awk '/^## ${TAG#v}/{f=1;next} /^## /{f=0} f' CHANGELOG.md > /tmp/notes-${TAG:-<tag>}.md"
+echo "    gh release edit ${TAG:-<tag>} --notes-file /tmp/notes-${TAG:-<tag>}.md"
 rm -rf "$LOG_DIR"


### PR DESCRIPTION
Two release-process fixes from the v0.0.42 cut.

- **`validate` runs on `ubuntu-latest`**, the same image as `test.yml`'s python matrix. It was pinned to `ubuntu-22.04`, on which `test_foreground`'s READY-mtime check failed deterministically (two attempts) while `main` CI stayed green — the release gate and the PR gate were testing different kernels. #237 fixed the test; this removes the divergence. `verify-version` (a bash grep) and the Linux build runner are left on 22.04 on purpose: the AppImage/deb should keep building against the older glibc.
- **Preflight post-release hint + release checklist** no longer reference the retired `.public-sync/changelog-public.md`. They now extract the tag's section from `CHANGELOG.md` into a temp file for `gh release edit --notes-file`.

Refs #232

🤖 Generated with [Claude Code](https://claude.com/claude-code)