### PR TITLE
fix(harness): live-service pre-check scans the real home; SandboxLeak names changed paths (#241)

### DIFF
--- a/tests/harness/sandbox.py
+++ b/tests/harness/sandbox.py
@@ -565,7 +565,7 @@ def _validate_editable_paths(paths: Iterable[Path] | None) -> list[Path]:
     return out
 
 
-def _live_bridges() -> list[tuple[int, str]]:
+def _live_bridges(home: Path | None = None) -> list[tuple[int, str]]:
     """Scan for RUNNING companion bridges (the load-bearing live-service detector, Phase 2).
 
     A live bridge writes ``bridge.json`` into its ``persona_dir`` carrying its ``pid``
@@ -580,6 +580,10 @@ def _live_bridges() -> list[tuple[int, str]]:
     accepted gap: a live bridge whose primary ``bridge.json`` is corrupt-but-``.bak``-recoverable is
     NOT detected here (backstopped by the post-run :class:`SandboxLeak`).
 
+    ``home`` is the REAL engine home, captured by ``sandbox()`` BEFORE it swaps ``KINDLED_HOME`` to
+    the tempdir (#241: scanning after the swap resolved to the empty sandbox and missed every
+    running bridge, so the run died at teardown with a misleading SandboxLeak). ``None`` ⇒ resolve now.
+
     Returns a list of ``(pid, persona_name)`` for each live bridge found (empty = none live).
     Tolerant: a missing home, a missing/corrupt/unreadable ``bridge.json`` is skipped, never raised.
     """
@@ -590,7 +594,7 @@ def _live_bridges() -> list[tuple[int, str]]:
 
     live: list[tuple[int, str]] = []
     try:
-        personas = get_home() / "personas"
+        personas = (home if home is not None else get_home()) / "personas"
         candidates = list(personas.glob("*/bridge.json"))
     except OSError:
         return live
@@ -633,7 +637,7 @@ def _probe_external_writer(snapshot_fn, wait_s: float) -> bool:
 
 
 def _run_live_check(
-    policy: str, snapshot_fn, *, probe: bool, probe_wait: float
+    policy: str, snapshot_fn, *, probe: bool, probe_wait: float, engine_home: Path | None = None
 ) -> str | None:
     """Run the live-service pre-check and dispatch by ``policy`` (stage-3 M1/L4).
 
@@ -652,7 +656,7 @@ def _run_live_check(
         return None
 
     parts: list[str] = []
-    bridges = _live_bridges()
+    bridges = _live_bridges(engine_home)
     if bridges:
         listed = ", ".join(f"pid {pid} (persona {name})" for pid, name in bridges)
         parts.append(
@@ -864,6 +868,14 @@ def sandbox(
         _agg._warned_unregistered.update(_saved_warned)
 
     try:
+        # #241: resolve the REAL engine home BEFORE the swap below — the live-service pre-check must
+        # scan where a running bridge actually writes its bridge.json, not the empty sandbox.
+        from brain.paths import get_home as _real_get_home
+
+        try:
+            real_engine_home: Path | None = _real_get_home()
+        except Exception:  # noqa: BLE001 — a broken resolver must not break the sandbox
+            real_engine_home = None
         os.environ["KINDLED_HOME"] = str(root)
         os.environ["CLAUDE_CONFIG_DIR"] = str(claude_config_dir)
         os.environ.pop("NELLBRAIN_HOME", None)  # a stray value would win the fallback (paths.py:60)
@@ -962,7 +974,7 @@ def sandbox(
         # + rmtree in the finally still run — no stale KINDLED_HOME leaks; P14). "warn" returns a
         # message we use to annotate a later SandboxLeak (P5); "off" is a no-op.
         live_note = _run_live_check(
-            live_check, _snapshot, probe=probe, probe_wait=probe_wait
+            live_check, _snapshot, probe=probe, probe_wait=probe_wait, engine_home=real_engine_home
         )
 
         before = _snapshot()
@@ -1018,9 +1030,20 @@ def sandbox(
             after = _snapshot()
             changed = [g for g in before if before[g] != after.get(g)]
             if changed:
+                # #241: name WHICH entries moved (first few per root) — a bare root name forced a
+                # manual fingerprint diff to learn the culprit was one live-bridge persona file.
+                _detail: list[str] = []
+                for g in changed:
+                    b_, a_ = before[g], after.get(g) or {}
+                    if isinstance(b_, dict) and isinstance(a_, dict):
+                        keys = sorted(k for k in set(b_) | set(a_) if b_.get(k) != a_.get(k))
+                        shown = ", ".join(str(k) for k in keys[:5])
+                        more = f" (+{len(keys) - 5} more)" if len(keys) > 5 else ""
+                        _detail.append(f"{g}: {shown}{more}")
                 msg = (
                     "guarded real-home root(s) mutated during a sandboxed run: "
                     + ", ".join(changed)
+                    + (" — changed entries: " + "; ".join(_detail) if _detail else "")
                 )
                 if live_note is not None:
                     # warn-mode pre-check saw a live service — attribute the leak correctly (P5).

--- a/tests/unit/harness/test_live_service_precheck.py
+++ b/tests/unit/harness/test_live_service_precheck.py
@@ -401,7 +401,7 @@ def test_pidfile_arm_is_load_bearing_executed_negative_control(
     _seed_fake_cred(monkeypatch, tmp_path)
     engine_home = tmp_path / "engine-home"
     _seed_bridge(monkeypatch, engine_home, pid=os.getpid())
-    monkeypatch.setattr(sandbox_mod, "_live_bridges", lambda: [])
+    monkeypatch.setattr(sandbox_mod, "_live_bridges", lambda *_a, **_k: [])
     with sandbox() as sb:  # must NOT raise now
         assert sb.root.exists()
 
@@ -561,3 +561,29 @@ def tempfile_gettempdir() -> str:
     import tempfile
 
     return tempfile.gettempdir()
+
+
+# ─────────────────────── #241 — detection must scan the REAL home, not the sandbox ───────────────────────
+
+
+def test_live_bridge_detected_with_real_dynamic_resolver(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """#241: `sandbox()` swaps KINDLED_HOME to the tempdir BEFORE the live check ran, so
+    `get_home()` resolved to the (empty) sandbox and a running bridge was never seen — the run then
+    died at teardown with a misleading SandboxLeak. Unlike P1, this test does NOT patch `get_home`
+    to a constant: it sets KINDLED_HOME like a real machine and lets the resolver be dynamic."""
+    _seed_fake_cred(monkeypatch, tmp_path)
+    engine_home = tmp_path / "engine-home"
+    persona_dir = engine_home / "personas" / "Canary"
+    persona_dir.mkdir(parents=True)
+    (persona_dir / "bridge.json").write_text(
+        json.dumps({"persona": "Canary", "pid": os.getpid(), "port": 8931})
+    )
+    monkeypatch.setenv("KINDLED_HOME", str(engine_home))
+    monkeypatch.delenv("NELLBRAIN_HOME", raising=False)
+
+    with pytest.raises(LiveServiceDetected) as ei:
+        with sandbox():
+            pass  # pragma: no cover - must NOT be reached
+    assert str(os.getpid()) in str(ei.value) and "Canary" in str(ei.value)

--- a/tests/unit/harness/test_sandbox_isolation.py
+++ b/tests/unit/harness/test_sandbox_isolation.py
@@ -805,3 +805,18 @@ def test_cli_housekeeping_constant_and_helper_pinned() -> None:
     excluded_names = {e.name for e in _claude_session_log_excludes()}
     for name in _CLAUDE_CLI_HOUSEKEEPING_FILES:
         assert name not in excluded_names, f"{name} must NOT be name-excluded (it is content-guarded)"
+
+
+def test_leak_message_names_the_changed_paths(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """#241: a bare root name forced a manual fingerprint diff to learn WHICH file moved."""
+    _seed_fake_cred(monkeypatch, tmp_path)
+    guarded = tmp_path / "guarded-root"
+    guarded.mkdir()
+    (guarded / "existing.txt").write_text("original")
+
+    with pytest.raises(SandboxLeak) as ei:
+        with sandbox(extra_guard_roots=[guarded]):
+            (guarded / "leaked.txt").write_text("this escaped the sandbox")
+    assert "leaked.txt" in str(ei.value)


### PR DESCRIPTION
## Root cause

`sandbox()` sets `KINDLED_HOME=<tempdir>` (line ~867) and runs the live-service pre-check ~100 lines later. `_live_bridges()` resolves `brain.paths.get_home()` at call time, so it scanned the empty sandbox's `personas/` and never saw the developer's running bridge. The run then burned its live turns and died at teardown with `SandboxLeak` on the real brain home — a correct detection of the wrong thing (the live bridge's own periodic `maker_charge.json` write).

The existing P1 test (`test_live_bridge_raises_live_service_detected_up_front`) patches `get_home` to a **constant** lambda, so the env swap could not affect it and the ordering bug hid behind a green test.

## Fix

- Capture the real engine home **before** the swap and pass it to `_live_bridges(home)` / `_run_live_check(..., engine_home=)`. Fail-soft if the resolver raises.
- `SandboxLeak` message now appends `— changed entries: <root>: a, b, c (+N more)` so the culprit is visible without a manual fingerprint diff.

## Tests (written first, watched fail)

- `test_live_bridge_detected_with_real_dynamic_resolver` — seeds `bridge.json` with our own pid, sets `KINDLED_HOME` like a real machine, does **not** patch `get_home`. Was `DID NOT RAISE`; now raises `LiveServiceDetected` before yielding.
- `test_leak_message_names_the_changed_paths` — mirrors the G1d negative control and asserts the leaked filename is in the message.
- One existing stub of `_live_bridges` widened to accept the new optional arg.

Harness unit suite: 266 passed, 1 skipped. On this Mac with Nell running, `tests/harness/examples/test_generic_run.py` now refuses in 0.18 s with `a live companion service was detected at pre-check: pid 3931 (persona nell)` instead of failing after three live turns.

Closes #241

🤖 Generated with [Claude Code](https://claude.com/claude-code)