### PR TITLE
fix(tests): de-flake systemd load, READY mid-write poll, Windows cadence budgets (#160 #220 #215 #210)

### DIFF
--- a/tests/bridge/test_supervisor_cadence_persisted.py
+++ b/tests/bridge/test_supervisor_cadence_persisted.py
@@ -16,6 +16,10 @@ import pytest
 
 from brain.bridge.supervisor import run_folded
 
+# #210: every test below stops the loop from inside its counted callback, so this is only a
+# ceiling for the failure path. 2 s was too tight for the windows-latest runner under load.
+_WATCHDOG_S = 10.0
+
 
 def _cadence_dir(persona_dir: Path) -> Path:
     """#178: cadence state lives under <persona>/cadence/."""
@@ -72,7 +76,7 @@ def test_finalize_fires_from_persisted_due_time_on_fresh_process(
 
     monkeypatch.setattr("brain.bridge.supervisor._run_finalize_tick", _counter)
 
-    watchdog = threading.Timer(2.0, stop.set)
+    watchdog = threading.Timer(_WATCHDOG_S, stop.set)
     watchdog.start()
     run_folded(
         stop,
@@ -120,7 +124,7 @@ def test_maintenance_fires_from_persisted_due_time_on_fresh_process(
 
     monkeypatch.setattr("brain.bridge.supervisor.forgetting_run_pass", _counter)
 
-    watchdog = threading.Timer(2.0, stop.set)
+    watchdog = threading.Timer(_WATCHDOG_S, stop.set)
     watchdog.start()
     run_folded(
         stop,
@@ -157,7 +161,7 @@ def test_voice_reflection_fires_from_persisted_due_time_on_fresh_process(
 
     monkeypatch.setattr("brain.bridge.supervisor._run_voice_reflection_tick", _counter)
 
-    watchdog = threading.Timer(2.0, stop.set)
+    watchdog = threading.Timer(_WATCHDOG_S, stop.set)
     watchdog.start()
     run_folded(
         stop,
@@ -200,7 +204,7 @@ def test_cadence_advances_even_when_tick_raises(
 
     monkeypatch.setattr("brain.bridge.supervisor._run_finalize_tick", _raiser)
 
-    watchdog = threading.Timer(2.0, stop.set)
+    watchdog = threading.Timer(_WATCHDOG_S, stop.set)
     watchdog.start()
     run_folded(
         stop,
@@ -246,7 +250,7 @@ def test_maintenance_advances_even_when_forgetting_raises(
 
     monkeypatch.setattr("brain.bridge.supervisor.forgetting_run_pass", _raiser)
 
-    watchdog = threading.Timer(2.0, stop.set)
+    watchdog = threading.Timer(_WATCHDOG_S, stop.set)
     watchdog.start()
     run_folded(
         stop,
@@ -281,7 +285,7 @@ def test_disabled_cadence_writes_no_state_file(
         lambda *a, **k: stop.set(),
     )
 
-    watchdog = threading.Timer(2.0, stop.set)
+    watchdog = threading.Timer(_WATCHDOG_S, stop.set)
     watchdog.start()
     run_folded(
         stop,
@@ -318,7 +322,7 @@ def test_initiate_review_fires_from_persisted_due_time_on_fresh_process(
 
     monkeypatch.setattr("brain.bridge.supervisor._run_initiate_review_tick", _counter)
 
-    watchdog = threading.Timer(2.0, stop.set)
+    watchdog = threading.Timer(_WATCHDOG_S, stop.set)
     watchdog.start()
     run_folded(
         stop,
@@ -356,7 +360,7 @@ def test_log_rotation_fires_from_persisted_due_time_on_fresh_process(
 
     monkeypatch.setattr("brain.bridge.supervisor._run_log_rotation_tick", _counter)
 
-    watchdog = threading.Timer(2.0, stop.set)
+    watchdog = threading.Timer(_WATCHDOG_S, stop.set)
     watchdog.start()
     run_folded(
         stop,

--- a/tests/harness/foreground.py
+++ b/tests/harness/foreground.py
@@ -284,13 +284,25 @@ def _poll_for_ready_or_error(
         for marker in error_markers:
             if (run_dir / marker).exists():
                 return
-        if ready_path.exists() and ready_path.stat().st_mtime >= start - _READY_MTIME_SLACK_S:
+        if (
+            ready_path.exists()
+            and ready_path.stat().st_mtime >= start - _READY_MTIME_SLACK_S
+            and _ready_parses(ready_path)
+        ):
             return
         time.sleep(_POLL_INTERVAL)
     raise ForegroundBootError(
         f"no READY (or error marker) appeared under {run_dir} within {ready_timeout}s "
         "(bounded poll timed out, did not hang)."
     )
+
+
+def _ready_parses(ready_path: Path) -> bool:
+    """#215: a READY observed mid-write (empty / partial JSON) is not ready yet -- keep polling."""
+    try:
+        return isinstance(json.loads(ready_path.read_text(encoding="utf-8")), dict)
+    except (OSError, ValueError):
+        return False
 
 
 def _require_fresh_ready(run_dir: Path, start: float) -> None:

--- a/tests/integration/test_systemd_install.py
+++ b/tests/integration/test_systemd_install.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 import os
 import subprocess
 import sys
+import time
 from pathlib import Path
 
 import pytest
@@ -64,6 +65,27 @@ def _systemd_user_available() -> bool:
         return False
 
 
+def _poll_unit_property(
+    prop: str, want: str, *, budget_s: float = 5.0
+) -> subprocess.CompletedProcess[str]:
+    """Poll ``systemctl --user show -p <prop>`` until it equals ``want`` or the budget lapses.
+
+    Returns the last CompletedProcess either way so the caller's assert carries stderr.
+    """
+    deadline = time.monotonic() + budget_s
+    while True:
+        result = subprocess.run(
+            ["systemctl", "--user", "show", "-p", prop, "--value", "companion-emergence-ci_test"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if result.stdout.strip() == want or time.monotonic() >= deadline:
+            return result
+        time.sleep(0.2)
+
+
+@pytest.mark.integration
 def test_install_creates_unit_file_and_systemd_loads_it(tmp_path: Path) -> None:
     """Round-trip: install → assert unit file + systemd loaded it → uninstall."""
     if not _systemd_user_available():
@@ -128,20 +150,9 @@ def test_install_creates_unit_file_and_systemd_loads_it(tmp_path: Path) -> None:
         #    reports "failed", a slow one is still "activating" — which is the
         #    intermittent failure in #160. Bridge boot-success is a different
         #    subject with different preconditions; it is not this test's claim.
-        load_state = subprocess.run(
-            [
-                "systemctl",
-                "--user",
-                "show",
-                "-p",
-                "LoadState",
-                "--value",
-                "companion-emergence-ci_test",
-            ],
-            capture_output=True,
-            text=True,
-            timeout=10,
-        )
+        #    (#220) Under full-suite load the manager can still be absorbing the
+        #    daemon-reload when we first ask, so poll briefly instead of asserting once.
+        load_state = _poll_unit_property("LoadState", "loaded")
         assert load_state.stdout.strip() == "loaded", (
             "systemd did not load the installed unit; "
             f"LoadState={load_state.stdout.strip()!r} stderr={load_state.stderr!r}"

--- a/tests/unit/brain/bridge/test_supervisor.py
+++ b/tests/unit/brain/bridge/test_supervisor.py
@@ -987,8 +987,10 @@ def test_run_folded_interest_sweep_advances_cadence_even_when_tick_raises(tmp_pa
     persona_dir = _persona_dir(tmp_path)
     bus = EventBus()
     stop = threading.Event()
+    fired = threading.Event()
 
     def fake_sweep(**kwargs):
+        fired.set()
         raise RuntimeError("boom")
 
     def runner():
@@ -1009,7 +1011,8 @@ def test_run_folded_interest_sweep_advances_cadence_even_when_tick_raises(tmp_pa
 
     t = threading.Thread(target=runner, daemon=True)
     t.start()
-    time.sleep(0.3)
+    # #210: wait for the tick itself rather than a fixed 0.3 s window (flaked on windows-latest).
+    assert fired.wait(timeout=5.0), "interest sweep tick never ran"
     stop.set()
     t.join(timeout=5.0)
     assert not t.is_alive(), "supervisor loop must not die from a tick exception"

--- a/tests/unit/harness/test_foreground.py
+++ b/tests/unit/harness/test_foreground.py
@@ -76,6 +76,32 @@ def test_boot_and_verify_poll_mode_picks_up_fresh_ready(tmp_path: Path) -> None:
     assert session.ready_payload == {"brain_repo": "y"}
 
 
+def test_boot_and_verify_poll_mode_tolerates_partial_ready_write(tmp_path: Path) -> None:
+    """#215: a READY seen mid-write (empty / not yet valid JSON) must be re-polled, not decode-failed.
+
+    Under full-suite load the poll can observe the file after create but before the JSON body
+    lands. The poll should keep waiting (within its timeout) until the file parses.
+    """
+    import threading
+
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    ready_path = run_dir / "READY"
+
+    def _two_step_write() -> None:
+        time.sleep(0.1)
+        ready_path.write_text("", encoding="utf-8")  # created, body not yet written
+        time.sleep(0.3)
+        _write_ready(run_dir, {"brain_repo": "z"})
+
+    threading.Thread(target=_two_step_write, daemon=True).start()
+    spec = fg.ArmBootSpec(arm="B", port=8933, run_dir=run_dir, ready_timeout=5.0)
+
+    session = fg.boot_and_verify(spec, boot_cmd=None)
+
+    assert session.ready_payload == {"brain_repo": "z"}
+
+
 def test_boot_and_verify_poll_mode_ignores_stale_ready(tmp_path: Path) -> None:
     """N3: a READY predating the poll start must be ignored, not read as a false confirmation."""
     run_dir = tmp_path / "run"


### PR DESCRIPTION
Batch fix for the load/timing-sensitive test flakes filed as #160, #220, #215 and #210. Test-only apart from one harness poll change.

## What changed

**#215 — READY read mid-write (`tests/harness/foreground.py`)**
`_poll_for_ready_or_error` returned as soon as `READY` existed and was fresh; `_read_ready_payload` then JSON-decoded it once and raised on an empty/partial file. The poll now also requires the file to parse as a JSON object before returning, so a mid-write observation keeps polling under the existing `ready_timeout`. New test `test_boot_and_verify_poll_mode_tolerates_partial_ready_write` writes an empty `READY`, then the real payload 0.3 s later. It failed with `READY ... is not valid JSON: ''` before the fix and passes after.

**#210 — Windows wall-clock budgets**
- `tests/bridge/test_supervisor_cadence_persisted.py`: all eight tests already `stop.set()` from inside their counted callback, so the `threading.Timer(2.0, ...)` was only a failure-path ceiling. Raised to a module constant `_WATCHDOG_S = 10.0`. Pass-path timing unchanged.
- `tests/unit/brain/bridge/test_supervisor.py::test_run_folded_interest_sweep_advances_cadence_even_when_tick_raises`: the patched raising tick now sets an event; the test waits on it (5 s ceiling) instead of `time.sleep(0.3)`.
- The other five `sleep(0.3)` sites in that file are negative "nothing fired" windows. They cannot false-fail and are not the flake; left as-is.

**#160 / #220 — systemd unit-load race (`tests/integration/test_systemd_install.py`)**
- Function-level `@pytest.mark.integration` added (the fold-in requested on #160) so `-m "not integration"` deselects it.
- `LoadState` is polled up to 5 s for `loaded` via `_poll_unit_property` instead of a single `systemctl show`.
- `test_install_creates_unit_file_and_starts` named in #160 no longer exists on `main`; the surviving test is the one #220 names. Both issues describe the same race on the same test.

## Verification
- `uv run pytest tests/unit/harness/test_foreground.py` — 38 passed.
- `uv run pytest tests/bridge/test_supervisor_cadence_persisted.py tests/unit/brain/bridge/test_supervisor.py tests/integration/test_systemd_install.py` — 37 passed, 1 skipped (systemd test, macOS).
- Full `uv run pytest -q -p no:randomly`: see final comment on this PR for the FAILED grep vs the known `main` baseline.
- `uv run ruff check .` clean. `pnpm test` 351 passed. `pnpm build` (tsc + vite) clean.
- The systemd change is reasoned, not executed here (module skips off Linux). Matches the standing "#160 real-machine validation" defer; the designated Linux validator can confirm on the next run.

Closes #160
Closes #220
Closes #215
Closes #210

🤖 Generated with [Claude Code](https://claude.com/claude-code)
