### PR TITLE
fix(emotion): canonical vocab names + variant merge + vocab-repair cadence (#173 #174)

### DIFF
--- a/brain/bridge/supervisor.py
+++ b/brain/bridge/supervisor.py
@@ -151,6 +151,7 @@ def run_folded(
     kindled_link_enabled: bool = True,
     compaction_interval_s: float | None = 86400.0,
     interest_sweep_interval_s: float | None = interest_sweep.SWEEP_INTERVAL_HOURS * 3600.0,
+    vocab_repair_interval_s: float | None = 6 * 3600.0,
     is_session_busy: Callable[[str], bool] | None = None,
 ) -> None:
     """Run supervisor + heartbeat + soul-review + finalize cadences until stop_event is set.
@@ -236,6 +237,11 @@ def run_folded(
         if compaction_interval_s is not None
         else None
     )
+    vocab_repair_cadence_state = (
+        persisted_cadence.load_cadence(persona_dir, "vocab_repair_cadence.json")
+        if vocab_repair_interval_s is not None
+        else None
+    )
 
     # One-shot startup: run the attunement backfill if this is a first-launch
     # (≥10 user turns + no completed backfill_state.json). Wrapped in
@@ -290,19 +296,7 @@ def run_folded(
     # Haiku (fail-soft — placeholders kept if provider unavailable/fails).
     # Runs adjacent to emotion backfill; independent of it (separate try/except).
     try:
-        if _vocab_repair_should_run(persona_dir):
-            from brain.memory.store import MemoryStore as _MemoryStore
-
-            db_path = persona_dir / "memories.db"
-            _store = _MemoryStore(str(db_path), integrity_check=False)
-            try:
-                _vocab_repair_run(
-                    persona_dir,
-                    store=_store,
-                    provider=build_tier_provider(persona_dir, TIER_BACKGROUND_CLASSIFIER),
-                )
-            finally:
-                _store.close()
+        _run_vocab_repair_tick(persona_dir)
     except Exception as exc:  # noqa: BLE001
         logger.warning("vocab repair failed during startup: %s", exc)
 
@@ -619,6 +613,26 @@ def run_folded(
                         persona_dir, "log_rotation_cadence.json", log_rotation_cadence_state
                     )
 
+            # Vocab-repair cadence (#173) — 6h default. The startup pass above
+            # only fires once per bridge start and can be throttle-deferred;
+            # this retries the placeholder-describer (and the #174 variant
+            # merge) on a persisted wall-clock cadence. Cheap when nothing is
+            # pending: should_run is a file scan, no provider is built.
+            if vocab_repair_cadence_state is not None and persisted_cadence.is_due(
+                vocab_repair_cadence_state, now=datetime.now(UTC)
+            ):
+                try:
+                    _run_vocab_repair_tick(persona_dir)
+                except Exception:
+                    logger.exception("supervisor vocab-repair tick raised")
+                finally:
+                    vocab_repair_cadence_state = persisted_cadence.advance(
+                        now=datetime.now(UTC), interval_s=vocab_repair_interval_s
+                    )
+                    persisted_cadence.save_cadence(
+                        persona_dir, "vocab_repair_cadence.json", vocab_repair_cadence_state
+                    )
+
             # Initiate review cadence — mirrors soul_review. Per-pass cost cap
             # (3 candidates max). Fault-isolated.
             if initiate_review_cadence_state is not None and persisted_cadence.is_due(
@@ -780,6 +794,27 @@ def run_folded(
         # Wait for the next tick or for stop_event, whichever comes first.
         stop_event.wait(timeout=tick_interval_s)
     logger.info("supervisor stopped persona=%s", persona_dir.name)
+
+
+def _run_vocab_repair_tick(persona_dir: Path) -> None:
+    """Repair emotion_vocabulary.json if it has placeholder or variant-twin entries (#173/#174).
+
+    Shared by the startup one-shot and the 6h cadence. Builds the Haiku-tier
+    provider only when there is something to describe.
+    """
+    if not _vocab_repair_should_run(persona_dir):
+        return
+    from brain.memory.store import MemoryStore as _MemoryStore
+
+    _store = _MemoryStore(str(persona_dir / "memories.db"), integrity_check=False)
+    try:
+        _vocab_repair_run(
+            persona_dir,
+            store=_store,
+            provider=build_tier_provider(persona_dir, TIER_BACKGROUND_CLASSIFIER),
+        )
+    finally:
+        _store.close()
 
 
 def _run_maker_tick(persona_dir, *, store, provider):

--- a/brain/emotion/persona_loader.py
+++ b/brain/emotion/persona_loader.py
@@ -215,7 +215,10 @@ def _heal_referenced_but_unregistered(path: Path, data: dict, store: MemoryStore
     seen: set[str] = set()
     new_entries: list[dict] = []
     for mem in store.list_active(limit=None):
-        for name in mem.emotions:
+        for raw_name in mem.emotions:
+            # #174: heal under the canonical spelling so a variant memory key
+            # (present-ness, Love_Grief_blend) never mints a twin entry.
+            name = vocabulary.canonical_name(raw_name)
             if name in seen or vocabulary.get(name) is not None:
                 continue
             seen.add(name)

--- a/brain/emotion/vocabulary.py
+++ b/brain/emotion/vocabulary.py
@@ -16,7 +16,7 @@ Decay half-lives per spec Section 10.1:
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import Literal
 
 # `nell_specific` retained for backwards-compat — pre-vocabulary-split persona
@@ -125,9 +125,26 @@ _BASELINE: tuple[Emotion, ...] = (
 _REGISTRY: dict[str, Emotion] = {e.name: e for e in _BASELINE}
 
 
+_BLEND_SUFFIX = "_blend"
+
+
+def canonical_name(name: str) -> str:
+    """Collapse spelling variants of one emotion channel to a single key (#174).
+
+    Lowercase, hyphens to underscores, surrounding whitespace dropped. A
+    two-part ``<a>_<b>_blend`` name has its parts sorted so ``love_grief_blend``
+    and ``grief_love_blend`` are the same channel.
+    """
+    key = name.strip().lower().replace("-", "_")
+    if key.endswith(_BLEND_SUFFIX):
+        parts = key[: -len(_BLEND_SUFFIX)].split("_")
+        key = "_".join(sorted(parts)) + _BLEND_SUFFIX
+    return key
+
+
 def get(name: str) -> Emotion | None:
-    """Return the Emotion with the given name, or None if unknown."""
-    return _REGISTRY.get(name)
+    """Return the Emotion with the given name (any spelling variant), or None."""
+    return _REGISTRY.get(canonical_name(name))
 
 
 def list_all() -> list[Emotion]:
@@ -145,9 +162,12 @@ def register(emotion: Emotion) -> None:
 
     Raises ValueError if an emotion with the same name is already registered.
     """
-    if emotion.name in _REGISTRY:
+    key = canonical_name(emotion.name)
+    if key in _REGISTRY:
         raise ValueError(f"Emotion {emotion.name!r} already registered")
-    _REGISTRY[emotion.name] = emotion
+    if key != emotion.name:
+        emotion = replace(emotion, name=key)
+    _REGISTRY[key] = emotion
 
 
 def _unregister(name: str) -> None:
@@ -155,4 +175,4 @@ def _unregister(name: str) -> None:
 
     The framework does not support runtime removal of vocabulary entries.
     """
-    _REGISTRY.pop(name, None)
+    _REGISTRY.pop(canonical_name(name), None)

--- a/brain/growth/crystallizers/vocabulary.py
+++ b/brain/growth/crystallizers/vocabulary.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+from brain.emotion.vocabulary import canonical_name
 from brain.growth.proposal import EmotionProposal
 from brain.memory.store import Memory, MemoryStore
 
@@ -39,16 +40,16 @@ def crystallize_vocabulary(
     returns at most one proposal per tick, matching the growth rate limit.
     """
     clusters = _cluster_active_memories(store.list_active())
-    current_names = {name.lower() for name in current_vocabulary_names}
+    current_names = {canonical_name(name) for name in current_vocabulary_names}
 
     proposals: list[EmotionProposal] = []
     for cluster in sorted(clusters.values(), key=_cluster_rank, reverse=True):
         if len(cluster.memories) < _MIN_EVIDENCE_MEMORIES:
             continue
         first, second = cluster.display_order
-        name = f"{first}_{second}_blend"
-        # #174: the reversed spelling names the same configuration.
-        if name in current_names or f"{second}_{first}_blend" in current_names:
+        # #174: mint the canonical spelling so a reversed pair can never be a new name.
+        name = canonical_name(f"{first}_{second}_blend")
+        if name in current_names:
             continue
         evidence = tuple(mem.id for mem in sorted(cluster.memories, key=lambda m: m.created_at))[
             :_MAX_EVIDENCE_MEMORIES

--- a/brain/health/reconstruct.py
+++ b/brain/health/reconstruct.py
@@ -25,7 +25,7 @@ def reconstruct_vocabulary_from_memories(store: MemoryStore) -> dict:
     seen_names: set[str] = set()
     for mem in store.list_active(limit=None):
         for name in mem.emotions:
-            seen_names.add(name)
+            seen_names.add(_vocabulary.canonical_name(name))  # #174
 
     entries: list[dict] = []
     # Framework baseline always — these are immutable identity.

--- a/brain/health/vocab_repair.py
+++ b/brain/health/vocab_repair.py
@@ -22,6 +22,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from brain import prompt_strings
+from brain.utils.llm_output import extract_json_object
 
 if TYPE_CHECKING:
     from brain.bridge.provider import LLMProvider
@@ -131,14 +132,6 @@ def run_vocab_repair(
     prior_complete = existing is not None and existing.get("status") == "complete"
     prior_repaired = int(existing.get("repaired", 0)) if prior_complete else 0
     prior_described = int(existing.get("described", 0)) if prior_complete else 0
-    if prior_complete and provider is None:
-        # Step 1 already done and Step 2 needs a provider: nothing to do.
-        return RepairReport(
-            repaired=prior_repaired,
-            described=prior_described,
-            status="complete",
-            completed_at=existing.get("completed_at", ""),
-        )
 
     vocab_path = persona_dir / "emotion_vocabulary.json"
     if not vocab_path.exists():
@@ -149,6 +142,25 @@ def run_vocab_repair(
     except (json.JSONDecodeError, ValueError) as exc:
         logger.warning("vocab_repair: cannot read vocab: %s — skipping", exc)
         return _write_and_return(persona_dir, repaired=0, described=0)
+
+    # ------------------------------------------------------------------
+    # Step 0 (#174, provider-free, every run): collapse spelling-variant twins
+    # (love_grief_blend / grief_love_blend, anticipatory-grief / Anticipatory_Grief)
+    # into one canonical entry. A twin with a real description beats a placeholder.
+    # ------------------------------------------------------------------
+    merged = _merge_variant_entries(data)
+    if merged:
+        _atomic_write_vocab(vocab_path, data)
+        logger.info("vocab_repair: merged %d variant twin(s): %s", len(merged), merged)
+
+    if prior_complete and provider is None:
+        # Step 1 already done and Step 2 needs a provider: nothing more to do.
+        return RepairReport(
+            repaired=prior_repaired,
+            described=prior_described,
+            status="complete",
+            completed_at=existing.get("completed_at", ""),
+        )
 
     emotions = data.get("emotions", [])
 
@@ -224,6 +236,46 @@ def _write_and_return(persona_dir: Path, *, repaired: int, described: int) -> Re
         status="complete",
         completed_at=completed_at,
     )
+
+
+def _merge_variant_entries(data: dict) -> list[tuple[str, str]]:
+    """Collapse entries whose names canonicalise to the same key (#174).
+
+    Mutates ``data["emotions"]`` in place. Returns ``(dropped_name, kept_name)``
+    pairs; empty when nothing changed. Survivor: the first entry with a real
+    description, else the first seen. The survivor is renamed to the canonical key.
+    """
+    from brain.emotion.vocabulary import canonical_name
+    from brain.health.reconstruct import PLACEHOLDER_DESCRIPTION
+
+    emotions = data.get("emotions", [])
+    survivors: dict[str, dict] = {}
+    order: list[str] = []
+    dropped: list[tuple[str, str]] = []
+    for entry in emotions:
+        if not isinstance(entry, dict) or not isinstance(entry.get("name"), str):
+            continue
+        key = canonical_name(entry["name"])
+        current = survivors.get(key)
+        if current is None:
+            survivors[key] = entry
+            order.append(key)
+            continue
+        current_is_stub = current.get("description") == PLACEHOLDER_DESCRIPTION
+        entry_is_stub = entry.get("description") == PLACEHOLDER_DESCRIPTION
+        if current_is_stub and not entry_is_stub:
+            dropped.append((current["name"], entry["name"]))
+            survivors[key] = entry
+        else:
+            dropped.append((entry["name"], current["name"]))
+
+    renamed = [(survivors[k]["name"], k) for k in order if survivors[k]["name"] != k]
+    if not dropped and not renamed:
+        return []
+    for key in order:
+        survivors[key]["name"] = key
+    data["emotions"] = [survivors[k] for k in order]
+    return dropped + renamed
 
 
 def _atomic_write_vocab(vocab_path: Path, data: dict) -> None:
@@ -312,7 +364,8 @@ def _describe_stubs(
                     )
                 except TypeError:
                     raw = provider.generate(user_prompt, system=_DESCRIBE_SYSTEM)
-                mapping: dict = json.loads(raw)
+                # #173: Haiku may fence its reply; use the shared tolerant extractor.
+                mapping: dict = json.loads(extract_json_object(raw))
             except Exception as exc:  # noqa: BLE001
                 logger.warning(
                     "vocab_repair: provider call or parse failed for batch %r: %s — "
@@ -338,6 +391,13 @@ def _describe_stubs(
                     entry["description"] = desc.strip()
                     patched += 1
 
+            if patched == 0:
+                logger.warning(
+                    "vocab_repair: provider reply parsed but matched no stub name "
+                    "(reply keys=%s, batch=%s) — keeping placeholders for this batch",
+                    sorted(mapping)[:10],
+                    batch,
+                )
             if patched > 0:
                 _atomic_write_vocab(vocab_path, data)
                 described += patched

--- a/tests/bridge/test_supervisor_cadence_persisted.py
+++ b/tests/bridge/test_supervisor_cadence_persisted.py
@@ -374,3 +374,43 @@ def test_log_rotation_fires_from_persisted_due_time_on_fresh_process(
     assert calls[0] >= 1, "persisted past-due log rotation must fire on a fresh process"
     saved = json.loads((_cadence_dir(persona_dir) / "log_rotation_cadence.json").read_text())
     assert datetime.fromisoformat(saved["next_at"]) > datetime.now(UTC) + timedelta(minutes=50)
+
+
+def test_vocab_repair_fires_from_persisted_due_time_on_fresh_process(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """#173: the placeholder-describer runs on a persisted cadence, not only at startup."""
+    persona_dir = tmp_path / "persona"
+    persona_dir.mkdir()
+    (_cadence_dir(persona_dir) / "vocab_repair_cadence.json").write_text(
+        json.dumps({"next_at": (datetime.now(UTC) - timedelta(hours=1)).isoformat()})
+    )
+    _neutralise(monkeypatch)
+    calls = [0]
+    stop = threading.Event()
+
+    def _counter(*a, **k):
+        calls[0] += 1
+        if calls[0] >= 2:  # 1st = startup one-shot; 2nd = the persisted cadence
+            stop.set()
+
+    monkeypatch.setattr("brain.bridge.supervisor._run_vocab_repair_tick", _counter)
+
+    watchdog = threading.Timer(10.0, stop.set)  # failure-path ceiling only (#210)
+    watchdog.start()
+    run_folded(
+        stop,
+        persona_dir=persona_dir,
+        provider=MagicMock(),
+        event_bus=MagicMock(),
+        tick_interval_s=0.05,
+        heartbeat_interval_s=None,
+        soul_review_interval_s=None,
+        finalize_interval_s=None,
+        vocab_repair_interval_s=6 * 3600.0,
+    )
+    watchdog.cancel()
+
+    assert calls[0] >= 2, "persisted past-due vocab repair must fire beyond the startup pass"
+    saved = json.loads((_cadence_dir(persona_dir) / "vocab_repair_cadence.json").read_text())
+    assert datetime.fromisoformat(saved["next_at"]) > datetime.now(UTC) + timedelta(hours=5)

--- a/tests/unit/brain/bridge/test_supervisor_db_overhead.py
+++ b/tests/unit/brain/bridge/test_supervisor_db_overhead.py
@@ -235,10 +235,15 @@ def test_startup_repair_sites_unchanged(tmp_path):
     anchor = "while not stop_event.is_set():"
     assert anchor in source
     prefix = source.split(anchor, 1)[0]
-    assert prefix.count("integrity_check=False") == 2
-    assert "_vocab_repair_should_run(persona_dir)" in prefix
+    # #173: the vocab-repair open moved into _run_vocab_repair_tick (shared by the
+    # startup pass and the 6h cadence); the soul-candidate open is still inline.
+    assert prefix.count("integrity_check=False") == 1
+    assert "_run_vocab_repair_tick(persona_dir)" in prefix
     assert "_soul_candidate_repair_should_run(persona_dir)" in prefix
     assert 'MemoryStore(str(db_path), integrity_check=False)' in prefix
+    tick_src = source.split("def _run_vocab_repair_tick", 1)[1].split("\ndef ", 1)[0]
+    assert "_vocab_repair_should_run(persona_dir)" in tick_src
+    assert "integrity_check=False" in tick_src
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/brain/emotion/test_persona_loader_vocab_recovery.py
+++ b/tests/unit/brain/emotion/test_persona_loader_vocab_recovery.py
@@ -83,3 +83,49 @@ def test_existing_file_heals_referenced_unregistered_emotion(tmp_path: Path):
     finally:
         store.close()
         _cleanup_emotion("warmth")
+
+
+def test_heal_mints_canonical_name_for_variant_memory_key(tmp_path: Path):
+    """#174: a memory keyed 'present-ness' heals as 'present_ness', not a hyphen twin."""
+    store = MemoryStore(":memory:")
+    try:
+        store.create(
+            Memory.create_new(
+                content="x",
+                memory_type="conversation",
+                domain="us",
+                emotions={"present-ness": 8.0},
+            )
+        )
+        _cleanup_emotion("present_ness")
+
+        vocab_path = tmp_path / "emotion_vocabulary.json"
+        vocab_path.write_text(json.dumps({"version": 1, "emotions": []}), encoding="utf-8")
+
+        load_persona_vocabulary_with_anomaly(vocab_path, store=store)
+
+        names = {e["name"] for e in json.loads(vocab_path.read_text())["emotions"]}
+        assert names == {"present_ness"}
+        assert vocabulary.get("present-ness") is not None
+    finally:
+        store.close()
+        _cleanup_emotion("present_ness")
+
+
+def test_reconstruct_mints_canonical_names(tmp_path: Path):
+    """#174: reconstruct_vocabulary_from_memories collapses variant keys to one entry."""
+    from brain.health.reconstruct import reconstruct_vocabulary_from_memories
+
+    store = MemoryStore(":memory:")
+    try:
+        for key in ("love_grief_blend", "grief-love_blend"):
+            store.create(
+                Memory.create_new(
+                    content="x", memory_type="conversation", domain="us", emotions={key: 8.0}
+                )
+            )
+        data = reconstruct_vocabulary_from_memories(store)
+        ext = [e["name"] for e in data["emotions"] if e["category"] == "persona_extension"]
+        assert ext == ["grief_love_blend"]
+    finally:
+        store.close()

--- a/tests/unit/brain/emotion/test_vocabulary.py
+++ b/tests/unit/brain/emotion/test_vocabulary.py
@@ -228,3 +228,60 @@ def test_body_emotions_loadable_via_state_set():
     for name in ("climax", "touch_hunger", "comfort_seeking", "rest_need"):
         s.set(name, 5.0)
         assert s.emotions[name] == 5.0
+
+
+# ---------------------------------------------------------------------------
+# #174: name normalisation
+# ---------------------------------------------------------------------------
+
+
+def test_canonical_name_lowercases_and_underscores() -> None:
+    from brain.emotion.vocabulary import canonical_name
+
+    assert canonical_name("Anticipatory-Grief") == "anticipatory_grief"
+    assert canonical_name(" present-ness ") == "present_ness"
+
+
+def test_canonical_name_sorts_blend_parts() -> None:
+    from brain.emotion.vocabulary import canonical_name
+
+    assert canonical_name("love_grief_blend") == "grief_love_blend"
+    assert canonical_name("grief_love_blend") == "grief_love_blend"
+    assert canonical_name("Love-Grief_blend") == "grief_love_blend"
+
+
+def test_get_resolves_variant_spellings_to_registered_entry() -> None:
+    from brain.emotion import vocabulary
+
+    e = vocabulary.Emotion(
+        name="anticipatory_grief",
+        description="x",
+        category="persona_extension",
+        decay_half_life_days=14.0,
+        intensity_clamp=10.0,
+    )
+    vocabulary.register(e)
+    try:
+        assert vocabulary.get("anticipatory-grief") is e
+        assert vocabulary.get("Anticipatory_Grief") is e
+    finally:
+        vocabulary._unregister("anticipatory_grief")
+
+
+def test_register_stores_under_canonical_name() -> None:
+    from brain.emotion import vocabulary
+
+    e = vocabulary.Emotion(
+        name="love_grief_blend",
+        description="x",
+        category="persona_extension",
+        decay_half_life_days=14.0,
+        intensity_clamp=10.0,
+    )
+    vocabulary.register(e)
+    try:
+        stored = vocabulary.get("grief_love_blend")
+        assert stored is not None
+        assert stored.name == "grief_love_blend"
+    finally:
+        vocabulary._unregister("grief_love_blend")

--- a/tests/unit/brain/growth/test_vocabulary_crystallizer.py
+++ b/tests/unit/brain/growth/test_vocabulary_crystallizer.py
@@ -44,7 +44,7 @@ def test_crystallizer_proposes_recurring_unnamed_emotional_configuration() -> No
 
         assert len(result) == 1
         proposal = result[0]
-        assert proposal.name == "love_grief_blend"
+        assert proposal.name == "grief_love_blend"  # #174: canonical sorted spelling
         assert "love" in proposal.description
         assert "grief" in proposal.description
         assert proposal.evidence_memory_ids == (first.id, second.id, third.id)
@@ -82,6 +82,38 @@ def test_crystallizer_treats_reversed_blend_name_as_existing() -> None:
 
         result = crystallize_vocabulary(
             store, current_vocabulary_names={"love", "grief", "grief_love_blend"}
+        )
+
+        assert result == []
+    finally:
+        store.close()
+
+
+def test_crystallizer_mints_blend_name_in_canonical_sorted_order() -> None:
+    """#174: never mint love_grief_blend — the canonical spelling sorts its parts."""
+    store = MemoryStore(":memory:")
+    try:
+        store.create(_mem("love and grief braided", {"love": 9, "grief": 8}))
+        store.create(_mem("another love-grief evening", {"love": 8, "grief": 7}))
+        store.create(_mem("grief softened by love", {"love": 9, "grief": 7}))
+
+        result = crystallize_vocabulary(store, current_vocabulary_names={"love", "grief"})
+
+        assert [p.name for p in result] == ["grief_love_blend"]
+    finally:
+        store.close()
+
+
+def test_crystallizer_treats_hyphen_and_case_variants_as_existing() -> None:
+    """#174 reopen: Grief-Love_blend already names this configuration."""
+    store = MemoryStore(":memory:")
+    try:
+        store.create(_mem("love and grief braided", {"love": 9, "grief": 8}))
+        store.create(_mem("another love-grief evening", {"love": 8, "grief": 7}))
+        store.create(_mem("grief softened by love", {"love": 9, "grief": 7}))
+
+        result = crystallize_vocabulary(
+            store, current_vocabulary_names={"love", "grief", "Love-Grief_blend"}
         )
 
         assert result == []

--- a/tests/unit/brain/health/test_vocab_repair.py
+++ b/tests/unit/brain/health/test_vocab_repair.py
@@ -390,3 +390,69 @@ def test_repair_describes_new_placeholders_after_state_complete(tmp_path: Path) 
     assert by_name["quiet_dread"]["description"] == "a low hum of unease"
     assert by_name["quiet_dread"]["decay_half_life_days"] == 14.0
     assert by_name["love"]["description"] == "a real description"
+
+
+# ---------------------------------------------------------------------------
+# #174 retroactive merge + #173 parse hardening
+# ---------------------------------------------------------------------------
+
+
+def test_repair_merges_variant_entries_keeping_the_described_one(tmp_path: Path) -> None:
+    """#174 reopen: permutation and hyphen/case twins collapse to one canonical entry.
+    The entry with a real description wins; a placeholder twin is dropped."""
+    from brain.health.vocab_repair import run_vocab_repair
+
+    _write_vocab(tmp_path, [
+        _stub_entry("love_grief_blend"),
+        _proper_entry("grief_love_blend", "braided"),
+        _proper_entry("anticipatory-grief", "dread ahead"),
+        _stub_entry("Anticipatory_Grief"),
+        _proper_entry("love"),
+    ])
+    store = _make_store(tmp_path)
+    try:
+        run_vocab_repair(tmp_path, store=store, provider=None)
+    finally:
+        store.close()
+
+    data = json.loads((tmp_path / "emotion_vocabulary.json").read_text(encoding="utf-8"))
+    by_name = {e["name"]: e for e in data["emotions"]}
+    assert set(by_name) == {"grief_love_blend", "anticipatory_grief", "love"}
+    assert by_name["grief_love_blend"]["description"] == "braided"
+    assert by_name["anticipatory_grief"]["description"] == "dread ahead"
+
+
+def test_repair_accepts_fenced_json_from_provider(tmp_path: Path) -> None:
+    """#173: a ```json-fenced reply must still describe the stubs (shared extract_json_object)."""
+    from brain.health.vocab_repair import run_vocab_repair
+
+    _write_vocab(tmp_path, [_stub_entry("body_grief")])
+    provider = _FakeProvider(response='```json\n{"body_grief": "the weight of it"}\n```')
+    store = _make_store(tmp_path)
+    try:
+        report = run_vocab_repair(tmp_path, store=store, provider=provider)
+    finally:
+        store.close()
+
+    assert report.described == 1
+    data = json.loads((tmp_path / "emotion_vocabulary.json").read_text(encoding="utf-8"))
+    assert data["emotions"][0]["description"] == "the weight of it"
+
+
+def test_repair_warns_when_provider_json_matches_no_stub(tmp_path: Path, caplog) -> None:
+    """#173: a parseable reply whose keys match nothing must not fail silently."""
+    import logging
+
+    from brain.health.vocab_repair import run_vocab_repair
+
+    _write_vocab(tmp_path, [_stub_entry("body_grief")])
+    provider = _FakeProvider(response=json.dumps({"descriptions": {"body_grief": "x"}}))
+    store = _make_store(tmp_path)
+    try:
+        with caplog.at_level(logging.WARNING, logger="brain.health.vocab_repair"):
+            report = run_vocab_repair(tmp_path, store=store, provider=provider)
+    finally:
+        store.close()
+
+    assert report.described == 0
+    assert any("matched no stub" in r.getMessage() for r in caplog.records)


### PR DESCRIPTION
Fixes the two reopened `emotion_vocabulary.json` issues together, since the retroactive merge for #174 rides on the same repair pass and cadence that #173 needs.

## Root cause for #173's reopen (verified on a live macOS persona)

The installed desktop app on this machine is **v0.0.41**. Its bundled `brain/health/vocab_repair.py` predates the 2026-09-06 re-run patch (`327b0284`), so `should_run_vocab_repair` still returns False once `vocab_repair_state.json` says `complete`. Evidence: state file stamped `2026-06-13T23:58:43Z` with `described: 0`; 42 of 73 entries still placeholders; vocab file mtime Jul 12; the 09-10 bridge restart logged no repair line. So `run_vocab_repair` has not executed since June, and the patched Step 2 has never run live for anyone yet. That answers the reopen's first question: on pre-patch binaries it never executes; on patched code it executes once per bridge start only.

Reading the patched code also found two further ways Step 2 can describe nothing:

- `json.loads(raw)` with no fence tolerance, while `brain/utils/llm_output.py::extract_json_object` already exists and three other engines use it.
- A parseable reply whose keys match no stub name patched zero entries and logged nothing.

## What changed

**#173 (`brain/health/vocab_repair.py`, `brain/bridge/supervisor.py`)**
- New `_run_vocab_repair_tick(persona_dir)` shared by the startup one-shot and a new **6 h persisted cadence** (`vocab_repair_cadence.json` under `<persona>/cadence/` via the existing `persisted_cadence` helper; `finally`-advance). `run_folded` gains `vocab_repair_interval_s` (default 6 h, `None` disables). A throttle-deferred startup pass now retries within 6 h instead of at the next reboot.
- Step 2 parses the provider reply through `extract_json_object`.
- WARNING when a reply parses but matches no stub name, listing the reply's keys.

**#174 (`brain/emotion/vocabulary.py`, crystallizer, loaders)**
- `canonical_name(name)`: lowercase, `-`→`_`, blend parts sorted before `_blend`. `register()` stores under the canonical key; `get()` and `_unregister()` canonicalise the lookup, so `present-ness` / `Anticipatory_Grief` / `love_grief_blend` all resolve to their one entry.
- Crystallizer mints the canonical name and checks existence canonically.
- `persona_loader._heal_referenced_but_unregistered` and `reconstruct_vocabulary_from_memories` mint canonical names.
- **Retroactive merge**: `run_vocab_repair` Step 0 (provider-free, every pass) collapses variant twins in the file to one canonical entry; a twin with a real description beats a placeholder. Logged at INFO with the merged pairs.

**Out of scope (owner ruling 2026-09-11):** rewriting historical `emotions_json` keys in `memories.db`. Canonical `get()` makes variant memory keys resolve to the merged vocab entry, but `aggregate_state` still pools variant keys as separate channels. That belongs to the emotion restructure (#240 / #222).

## Tests (all written first, watched fail)
- `test_vocabulary.py`: +4 (canonical_name, canonical get/register).
- `test_vocabulary_crystallizer.py`: +2 (canonical mint, hyphen/case existing). One pinned expectation updated from `love_grief_blend` to the canonical `grief_love_blend`.
- `test_persona_loader_vocab_recovery.py`: +2 (heal + reconstruct mint canonical).
- `test_vocab_repair.py`: +3 (variant merge keeps described twin; fenced JSON; matched-no-stub warning).
- `test_supervisor_cadence_persisted.py`: +1 through-`run_folded` cadence test (organ DoD).
- `test_supervisor_db_overhead.py::test_startup_repair_sites_unchanged`: source-text guard updated for the helper extraction; still asserts `integrity_check=False` on both startup opens.

## Verification
- `uv run ruff check .` clean. `pnpm test` 351 passed. `pnpm build` clean.
- Full `uv run pytest -q -p no:randomly`: see the final comment on this PR for the `^FAILED` grep vs baseline.

Closes #173
Closes #174

🤖 Generated with [Claude Code](https://claude.com/claude-code)
