### PR TITLE
feat(tools): read PDF text through read_file via pypdf (#126)

### DIFF
--- a/brain/tools/impls/read_file.py
+++ b/brain/tools/impls/read_file.py
@@ -22,6 +22,9 @@ _FILE_IMAGE_TYPES = tunables.register(
     "files.image_types", ["image/png", "image/jpeg", "image/webp", "image/gif"]
 )
 _FILE_IMAGE_MAX_BYTES = tunables.register("files.image_max_bytes", 20 * 1024 * 1024)
+# #126: PDFs are read as extracted text (pypdf, pure-Python). Cap matches /upload.
+_FILE_PDF_MAX_BYTES = tunables.register("files.pdf_max_bytes", 20 * 1024 * 1024)
+_PDF_MAGIC = b"%PDF-"
 _SUGGEST_MAX = 10
 _DEFAULT_HEAD_LINES = 400
 
@@ -36,6 +39,94 @@ def _image_types() -> list:
 
 def _image_max_bytes() -> int:
     return tunables.get_tunable("files.image_max_bytes", _FILE_IMAGE_MAX_BYTES)
+
+
+def _pdf_max_bytes() -> int:
+    return tunables.get_tunable("files.pdf_max_bytes", _FILE_PDF_MAX_BYTES)
+
+
+def _window_lines(
+    lines: list[str], *, max_lines: int | None, offset: int
+) -> tuple[str, int, int, bool]:
+    """Apply the ranged-read / head-cap policy shared by text and PDF reads.
+
+    Returns (sliced_text, start, window_len, truncated).
+    """
+    total = len(lines)
+    start = max(0, int(offset or 0))
+    if max_lines is not None:
+        window = lines[start : start + max(0, int(max_lines))]
+        truncated = (start + len(window)) < total or start > 0
+    elif total > _DEFAULT_HEAD_LINES:
+        window = lines[:_DEFAULT_HEAD_LINES]
+        truncated = True
+    else:
+        window = lines[start:] if start else lines
+        truncated = start > 0
+    return "".join(window), start, len(window), truncated
+
+
+def _read_pdf(
+    p: Path, *, raw: str, persona_dir: Path, max_lines: int | None, offset: int
+) -> dict:
+    """#126: return a PDF's text layer, page-marked and windowed like a text file.
+
+    No text layer (scan / image-only) -> an honest note with the page count.
+    Any pypdf failure -> fail-soft error dict. Page rendering is out of scope.
+    """
+    size = p.stat().st_size
+    cap = _pdf_max_bytes()
+    if size > cap:
+        _audit(persona_dir, tool="read_file", path=raw, resolved=str(p), bytes_=size, ok=False, error="too large")
+        return {"error": f"PDF too large ({size} bytes > {cap} cap) — not shown"}
+
+    _dedup_key = os.path.normcase(os.path.realpath(str(p)))
+    if _read_cache.seen_recently(_dedup_key):
+        _audit(persona_dir, tool="read_file", path=raw, resolved=str(p), bytes_=0, ok=True, error="deduped")
+        return {
+            "path": str(p),
+            "deduped": True,
+            "note": "you already read this file moments ago this turn — its content is above.",
+        }
+    _read_cache.mark(_dedup_key)
+
+    try:
+        from pypdf import PdfReader  # noqa: PLC0415 — only imported on the PDF path
+
+        reader = PdfReader(str(p))
+        if reader.is_encrypted:
+            try:
+                reader.decrypt("")  # owner-password-only PDFs open with the empty user password
+            except Exception:  # noqa: BLE001
+                pass
+        page_texts = [(page.extract_text() or "").strip() for page in reader.pages]
+    except Exception as exc:  # noqa: BLE001
+        _audit(persona_dir, tool="read_file", path=raw, resolved=str(p), bytes_=size, ok=False, error=f"pdf: {exc}")
+        return {"error": f"could not read PDF: {exc}"}
+
+    pages = len(page_texts)
+    if not any(page_texts):
+        _audit(persona_dir, tool="read_file", path=raw, resolved=str(p), bytes_=size, ok=True, error="pdf: no text layer")
+        return {
+            "path": str(p),
+            "pages": pages,
+            "note": f"PDF has no extractable text ({pages} page(s) — scanned or image-only); not shown",
+        }
+
+    joined = "".join(
+        (f"--- page {i} ---\n" if i > 1 else "") + text + "\n" for i, text in enumerate(page_texts, 1)
+    )
+    lines = joined.splitlines(keepends=True)
+    sliced, start, window_len, truncated = _window_lines(lines, max_lines=max_lines, offset=offset)
+    _audit(persona_dir, tool="read_file", path=raw, resolved=str(p), bytes_=size, ok=True)
+    out: dict = {"path": str(p), "content": sliced, "pages": pages, "total_lines": len(lines)}
+    if truncated:
+        out["truncated"] = True
+        out["note"] = (
+            f"showing lines {start}-{start + window_len} of {len(lines)} across {pages} page(s); "
+            "pass offset/max_lines to read more"
+        )
+    return out
 
 
 def _suggest(target: Path) -> list[str]:
@@ -199,6 +290,11 @@ def read_file(path: str, *, persona_dir: Path, max_lines: int | None = None,
             result["stored_image"] = stored_image
         return result
 
+    # PDF branch (#126) — also BEFORE the text cap: a PDF is binary-large but
+    # text-small, same cap-ordering reasoning as the image branch above.
+    if _prefix.startswith(_PDF_MAGIC):
+        return _read_pdf(p, raw=raw, persona_dir=persona_dir, max_lines=max_lines, offset=offset)
+
     cap = _file_read_max_bytes()
     size = p.stat().st_size
     if size > cap:
@@ -246,23 +342,15 @@ def read_file(path: str, *, persona_dir: Path, max_lines: int | None = None,
 
         lines = content.splitlines(keepends=True)
         total = len(lines)
-        start = max(0, int(offset or 0))
-        if max_lines is not None:
-            window = lines[start:start + max(0, int(max_lines))]
-            truncated = (start + len(window)) < total or start > 0
-        elif total > _DEFAULT_HEAD_LINES:
-            window = lines[:_DEFAULT_HEAD_LINES]
-            truncated = True
-        else:
-            window = lines[start:] if start else lines
-            truncated = start > 0
-        sliced = "".join(window)
+        sliced, start, window_len, truncated = _window_lines(
+            lines, max_lines=max_lines, offset=offset
+        )
         _audit(persona_dir, tool="read_file", path=raw, resolved=str(p), bytes_=size, ok=True)
         out: dict = {"path": str(p), "content": sliced, "total_lines": total}
         if truncated:
             out["truncated"] = True
             out["note"] = (
-                f"showing lines {start}-{start + len(window)} of {total}; "
+                f"showing lines {start}-{start + window_len} of {total}; "
                 "pass offset/max_lines to read more"
             )
         return out

--- a/brain/tools/schemas.py
+++ b/brain/tools/schemas.py
@@ -598,7 +598,8 @@ SCHEMAS: dict[str, dict] = {
         "name": "read_file",
         "description": (
             "Read a file from the user's computer. Text files return their contents; an image file "
-            "(PNG/JPEG/WebP/GIF) is returned as a viewable image you can actually see. When the user "
+            "(PNG/JPEG/WebP/GIF) is returned as a viewable image you can actually see; a PDF returns "
+            "its text, page-marked. When the user "
             "shares a file with you this turn, its path appears in their message as "
             "'[the user shared a file: <path>]' — you can read that path to see or read what they "
             "handed you. Otherwise, use this ONLY when the user explicitly asks you to read, open, or "

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
     "fastapi>=0.115",
     "uvicorn[standard]>=0.30",
     "tzdata>=2024.1",
+    "pypdf>=6",
 ]
 
 [project.optional-dependencies]

--- a/tests/unit/brain/tools/test_read_file_pdf.py
+++ b/tests/unit/brain/tools/test_read_file_pdf.py
@@ -1,0 +1,101 @@
+"""#126: read_file extracts text from PDFs (pypdf), page-marked, windowed like text."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from brain import tunables
+from brain.tools.impls.read_file import read_file
+
+
+def _make_pdf(page_texts):
+    """Minimal valid PDF, one page per entry; None => page with no text stream."""
+    objs = []  # list of bytes bodies, 1-indexed
+    def add(body):
+        objs.append(body)
+        return len(objs)
+    font = add(b"<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>")
+    page_ids = []
+    pages_placeholder = add(b"")  # will be replaced
+    for text in page_texts:
+        if text is None:
+            content = None
+        else:
+            esc = text.replace("\\", "\\\\").replace("(", "\\(").replace(")", "\\)").encode("latin-1")
+            stream = b"BT /F1 12 Tf 72 720 Td (" + esc + b") Tj ET"
+            content = add(b"<< /Length %d >>\nstream\n" % len(stream) + stream + b"\nendstream")
+        pg = b"<< /Type /Page /Parent %d 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 %d 0 R >> >>" % (pages_placeholder, font)
+        if content is not None:
+            pg += b" /Contents %d 0 R" % content
+        pg += b" >>"
+        page_ids.append(add(pg))
+    kids = b" ".join(b"%d 0 R" % i for i in page_ids)
+    objs[pages_placeholder - 1] = b"<< /Type /Pages /Kids [" + kids + b"] /Count %d >>" % len(page_ids)
+    catalog = add(b"<< /Type /Catalog /Pages %d 0 R >>" % pages_placeholder)
+    out = bytearray(b"%PDF-1.4\n")
+    offsets = []
+    for i, body in enumerate(objs, 1):
+        offsets.append(len(out))
+        out += b"%d 0 obj\n" % i + body + b"\nendobj\n"
+    xref = len(out)
+    out += b"xref\n0 %d\n" % (len(objs) + 1)
+    out += b"0000000000 65535 f \n"
+    for off in offsets:
+        out += b"%010d 00000 n \n" % off
+    out += b"trailer\n<< /Size %d /Root %d 0 R >>\nstartxref\n%d\n%%%%EOF\n" % (len(objs) + 1, catalog, xref)
+    return bytes(out)
+
+
+def test_read_file_pdf_returns_page_marked_text(tmp_path: Path) -> None:
+    f = tmp_path / "doc.pdf"
+    f.write_bytes(_make_pdf(["Hello PDF world", "Second page here"]))
+
+    out = read_file(path=str(f), persona_dir=tmp_path)
+
+    assert out["pages"] == 2
+    assert "Hello PDF world" in out["content"]
+    assert "Second page here" in out["content"]
+    assert "--- page 2 ---" in out["content"]
+    assert "binary" not in out.get("note", "")
+
+
+def test_read_file_pdf_without_text_layer_says_so(tmp_path: Path) -> None:
+    f = tmp_path / "scan.pdf"
+    f.write_bytes(_make_pdf([None, None]))
+
+    out = read_file(path=str(f), persona_dir=tmp_path)
+
+    assert "content" not in out
+    assert "no extractable text" in out["note"]
+    assert out["pages"] == 2
+
+
+def test_read_file_pdf_over_cap_is_refused(tmp_path: Path, monkeypatch) -> None:
+    f = tmp_path / "big.pdf"
+    f.write_bytes(_make_pdf(["x"]))
+    monkeypatch.setattr(tunables, "get_tunable", lambda key, default=None: 10 if key == "files.pdf_max_bytes" else default)
+
+    out = read_file(path=str(f), persona_dir=tmp_path)
+
+    assert "error" in out and "content" not in out
+
+
+def test_read_file_pdf_ranged_read_windows_lines(tmp_path: Path) -> None:
+    f = tmp_path / "two.pdf"
+    f.write_bytes(_make_pdf(["alpha", "beta"]))
+
+    out = read_file(path=str(f), persona_dir=tmp_path, max_lines=1, offset=0)
+
+    assert out["truncated"] is True
+    assert "alpha" in out["content"]
+    assert "beta" not in out["content"]
+    assert "%PDF" not in out["content"]  # extracted text, not the raw bytes
+
+
+def test_read_file_corrupt_pdf_fails_soft(tmp_path: Path) -> None:
+    f = tmp_path / "bad.pdf"
+    f.write_bytes(b"%PDF-1.4\ngarbage with no xref")
+
+    out = read_file(path=str(f), persona_dir=tmp_path)
+
+    assert "error" in out and "content" not in out

--- a/uv.lock
+++ b/uv.lock
@@ -140,6 +140,7 @@ dependencies = [
     { name = "mcp" },
     { name = "numpy" },
     { name = "platformdirs" },
+    { name = "pypdf" },
     { name = "tzdata" },
     { name = "uvicorn", extra = ["standard"] },
 ]
@@ -165,6 +166,7 @@ requires-dist = [
     { name = "mcp", specifier = ">=1.0.0,<2.0.0" },
     { name = "numpy", specifier = ">=1.26" },
     { name = "platformdirs", specifier = ">=4.2" },
+    { name = "pypdf", specifier = ">=6" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=5.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.5" },
@@ -831,6 +833,15 @@ wheels = [
 [package.optional-dependencies]
 crypto = [
     { name = "cryptography" },
+]
+
+[[package]]
+name = "pypdf"
+version = "6.18.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4f/c2/e537e78a8282b51ed47031566be118debbc34c04782a9afd8739672eb07d/pypdf-6.18.1.tar.gz", hash = "sha256:2441fc839053745638d9b9ddb38ed66beed8d611f47a3036c9838fc4e3074dea", size = 7027577 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/58/13/645df3995075112cb3cce15e8797c205f0f88fb50acc11012b84b071bc22/pypdf-6.18.1-py3-none-any.whl", hash = "sha256:ee93a2665670ecf57ee81d197a4ca548f3dc15f9cefc56e59b8140866aaa3de5", size = 394327 },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes the loop deferred from the P0 image-tool-route change: a sent PDF is stored at `files/<sha>` and its path surfaced, but `read_file` returned `(binary file … not shown)` for it.

## Choice: text extraction, not page rendering

`pypdf>=6` (pure Python, `py3-none-any` wheel) is the one new dependency. It bundles on all three platforms through the existing `uv sync --all-extras --locked` with no compiler or binary wheel. Page rendering would need a rasteriser (`pymupdf`, binary wheels) and is out of scope; a PDF with no text layer now gets an honest note with its page count instead of a silent empty read.

## What changed

- `pyproject.toml` + `uv.lock`: `pypdf>=6` (lock diff is 11 lines). `uv sync --all-extras --locked` verified clean locally, the release CI's strict mode.
- `brain/tools/impls/read_file.py`
  - New PDF branch after the image branch and **before** the 256 KB text cap (a PDF is binary-large but text-small, the same cap-ordering lesson as images). Sniffed on `%PDF-`.
  - `_read_pdf`: size cap via new tunable `files.pdf_max_bytes` (default 20 MB, matches `/upload`); per-turn dedup cache; per-page `extract_text()`; pages joined with `--- page N ---` markers; owner-password-only PDFs opened with the empty user password; any `pypdf` failure returns a fail-soft error dict; audit rows as for text.
  - The text branch's ranged-read / 400-line head-cap policy is extracted into `_window_lines` and shared, so `max_lines`/`offset` behave identically on PDFs. Result adds `pages`.
- `brain/tools/schemas.py`: `read_file` description gains "a PDF returns its text, page-marked".

## Tests (written first, watched fail)
`tests/unit/brain/tools/test_read_file_pdf.py` builds minimal PDFs in-test (no binary fixture): page-marked content + `pages`; no-text-layer note; over-cap refusal; ranged read; corrupt file fails soft. The ranged test originally passed vacuously because an all-ASCII PDF decoded as text under the old code, so it now also asserts the raw `%PDF` bytes are absent.

## Issue criterion: "send a PDF → she can read its content"
Through-path check run locally: `file_store.save_file_bytes` on a generated PDF, then `read_file` on the resulting `files/<sha>` path returned the extracted sentence with `pages: 1`. A live send through the desktop app was not driven here because the token-spending harness pre-check refuses to run beside the running bridge.

## Verification
- `uv run ruff check .` clean. `pnpm test` 351 passed. `pnpm build` clean.
- Full `uv run pytest -q -p no:randomly`: see the final comment on this PR.

Closes #126

🤖 Generated with [Claude Code](https://claude.com/claude-code)
