### PR TITLE
fix(voice): real evidence text for voice reflection, retire tone placeholder (#202)

### DIFF
--- a/brain/bridge/supervisor.py
+++ b/brain/bridge/supervisor.py
@@ -1998,22 +1998,21 @@ def _run_voice_reflection_tick(
 ) -> None:
     """Gather inputs and invoke run_voice_reflection_tick.
 
-    Reads the last 7 days of crystallizations (from SoulStore), dreams
-    (from ``dreams.log.jsonl``), and recent message tones (placeholder
-    for v0.0.9 — empty list until the chat-turn tone schema lands).
+    Reads the last 7 days of crystallizations (from SoulStore) and dream
+    memories (from memories.db), each with a short text excerpt so the
+    reflection can ground its evidence (#202). The message-tone stream that
+    used to sit alongside them was a permanent ``[]`` placeholder; retired.
     Publishes a ``voice_reflection_tick`` event on success.
     """
     from brain.initiate.voice_reflection import run_voice_reflection_tick
 
     crystallizations = _read_recent_crystallizations(persona_dir, days=7)
     dreams = _read_recent_dreams(persona_dir, days=7)
-    recent_tones = _read_recent_message_tones(persona_dir, days=7)
     run_voice_reflection_tick(
         persona_dir,
         provider=provider,
         crystallizations=crystallizations,
         dreams=dreams,
-        recent_tones=recent_tones,
         companion_name=persona_dir.name,
     )
     event_bus.publish(
@@ -2024,12 +2023,14 @@ def _run_voice_reflection_tick(
     )
 
 
-def _read_recent_crystallizations(persona_dir: Path, days: int) -> list[dict]:
-    """Read recent crystallization summaries from SoulStore.
+_VOICE_EVIDENCE_CHARS = 160
 
-    Returns a list of ``{"id": ..., "ts": iso8601}`` dicts for
-    crystallizations created within the last ``days`` days. Failures
-    swallowed — reflection still fires with whatever evidence exists.
+
+def _read_recent_crystallizations(persona_dir: Path, days: int) -> list[dict]:
+    """Recent crystallizations as ``{"id", "ts", "text"}`` (#202: text, not just ids).
+
+    ``text`` is the moment plus why it matters, capped. Failures swallowed —
+    reflection still fires with whatever evidence exists.
     """
     from brain.soul.store import SoulStore
 
@@ -2041,7 +2042,8 @@ def _read_recent_crystallizations(persona_dir: Path, days: int) -> list[dict]:
             for c in store.list_active():
                 ts = c.crystallized_at.isoformat()
                 if ts >= cutoff:
-                    out.append({"id": c.id, "ts": ts})
+                    text = f"{c.moment} — {c.why_it_matters}".strip(" —")
+                    out.append({"id": c.id, "ts": ts, "text": text[:_VOICE_EVIDENCE_CHARS]})
             return out
         finally:
             store.close()
@@ -2050,36 +2052,36 @@ def _read_recent_crystallizations(persona_dir: Path, days: int) -> list[dict]:
 
 
 def _read_recent_dreams(persona_dir: Path, days: int) -> list[dict]:
-    """Read recent dream entries from ``dreams.log.jsonl``."""
-    from brain.health.jsonl_reader import iter_jsonl_streaming
+    """Recent dream memories as ``{"id", "ts", "text"}`` (#202).
 
-    cutoff = (datetime.now(UTC) - timedelta(days=days)).isoformat()
-    out: list[dict] = []
+    Reads ``memory_type="dream"`` rows from memories.db rather than
+    ``dreams.log.jsonl``: the log carries ids only (no text) and its
+    ``timestamp`` field never matched the ``at``/``ts`` keys the old reader
+    looked for, so dreams were silently absent from the evidence.
+    """
+    from brain.memory.store import MemoryStore
+
+    cutoff = datetime.now(UTC) - timedelta(days=days)
     try:
-        for raw in iter_jsonl_streaming(persona_dir / "dreams.log.jsonl"):
-            ts = raw.get("at") or raw.get("ts")
-            if ts and ts >= cutoff:
-                out.append({"id": raw.get("dream_id") or raw.get("id"), "ts": ts})
+        store = MemoryStore(str(persona_dir / "memories.db"), integrity_check=False)
+        try:
+            out: list[dict] = []
+            for mem in store.list_by_type("dream", limit=50):
+                if mem.created_at >= cutoff:
+                    out.append(
+                        {
+                            "id": mem.id,
+                            "ts": mem.created_at.isoformat(),
+                            "text": mem.content[:_VOICE_EVIDENCE_CHARS],
+                        }
+                    )
+            return out
+        finally:
+            store.close()
     except Exception:
         return []
-    return out
 
 
-def _read_recent_message_tones(persona_dir: Path, days: int) -> list[dict]:
-    """Read recent Nell-authored chat turn tones — placeholder for v0.0.9.
-
-    Real implementation requires schema on the chat-turn log we don't
-    currently have. For v0.0.9, return an empty list; voice reflection
-    still fires but with less material. Revisit when chat-turn tone
-    tracking is added.
-    """
-    return []
-
-
-# Per-log retention policies. Bake the cadence-tick policies here so the
-# supervisor doesn't need a config file; defaults reflect Hana's 2026-05-11
-# decisions (5 MB rolling cap; 3 archives for heartbeats, 5 for dreams +
-# emotion_growth; yearly archive for soul_audit kept forever).
 _ROLLING_LOG_POLICIES: tuple[tuple[str, int], ...] = (
     ("heartbeats.log.jsonl", 3),
     ("dreams.log.jsonl", 5),
@@ -2104,6 +2106,7 @@ _YEARLY_ARCHIVE_LOGS: tuple[tuple[str, str], ...] = (
     ("initiate_audit.jsonl", "ts"),
 )
 _DEFAULT_ROLLING_BYTES = 5 * 1024 * 1024  # 5 MB
+
 
 
 def _run_log_rotation_tick(

--- a/brain/initiate/voice_reflection.py
+++ b/brain/initiate/voice_reflection.py
@@ -25,13 +25,18 @@ logger = logging.getLogger(__name__)
 _TICK_PROMPT_SEGMENTS = prompt_strings.register_segments("initiate.voice_reflection.tick_prompt_segments")
 
 
+def _evidence_line(item: dict) -> str:
+    ts = str(item.get("ts") or "")[:10]
+    text = str(item.get("text") or "").replace("\n", " ").strip()
+    return f"- {item.get('id')} ({ts}): {text}" if text else f"- {item.get('id')} ({ts})"
+
+
 def run_voice_reflection_tick(
     persona_dir: Path,
     *,
     provider: Any,
     crystallizations: list[dict],
     dreams: list[dict],
-    recent_tones: list[dict],
     companion_name: str = "Nell",
 ) -> None:
     """Reflect over the last week of internal life; maybe emit a voice-edit candidate.
@@ -42,16 +47,15 @@ def run_voice_reflection_tick(
     voice_path = persona_dir / "voice.md"
     voice_template = voice_path.read_text(encoding="utf-8") if voice_path.exists() else ""
 
+    # #202: each line carries a short excerpt so the >=3-evidence gate can be
+    # met honestly — ids and timestamps alone gave the model nothing to cite.
     evidence_block = "\n".join(
         [
             "Recent crystallizations:",
-            *[f"- {c.get('id')}: {c.get('ts')}" for c in crystallizations[:10]],
+            *[_evidence_line(c) for c in crystallizations[:10]],
             "",
             "Recent dreams:",
-            *[f"- {d.get('id')}: {d.get('ts')}" for d in dreams[:10]],
-            "",
-            "Recent message tones (your own outputs):",
-            *[f"- {t.get('id')}: {t.get('ts')}" for t in recent_tones[:10]],
+            *[_evidence_line(d) for d in dreams[:10]],
         ]
     )
 

--- a/brain/prompt_strings.toml
+++ b/brain/prompt_strings.toml
@@ -715,7 +715,7 @@ voice_edit_tone_rendered_segments = [
 # 3 vars: companion_name, voice_template, evidence_block.
 tick_prompt_segments = [
   "You are ",
-  ". Reflect on the last week of what you've crystallized, dreamed, and how you've actually been talking. Is there a place where your voice template doesn't fit the shape you've been moving toward?\n\nIf yes, propose ONE specific edit with concrete evidence. The edit must be backed by AT LEAST 3 concrete observations.\n\nCurrent voice template:\n",
+  ". Reflect on the last week of what you've crystallized and dreamed. Is there a place where your voice template doesn't fit the shape you've been moving toward?\n\nIf yes, propose ONE specific edit with concrete evidence. The edit must be backed by AT LEAST 3 concrete observations, each cited by the id of an item listed below.\n\nCurrent voice template:\n",
   "\n\n",
   "\n\nRespond with a JSON object:\n  {\"should_propose\": false, \"reason\": \"<one sentence>\"} OR\n  {\"should_propose\": true, \"diff\": \"<unified diff>\", \"old_text\": \"<exact old line>\", \"new_text\": \"<exact new line>\", \"rationale\": \"<one sentence>\", \"evidence\": [\"<id1>\", \"<id2>\", \"<id3>\", ...]}",
 ]

--- a/tests/unit/brain/bridge/test_background_yields.py
+++ b/tests/unit/brain/bridge/test_background_yields.py
@@ -452,7 +452,6 @@ def test_voice_reflection_defers_when_chat_active(tmp_path):
         provider=provider,
         crystallizations=[],
         dreams=[],
-        recent_tones=[],
         companion_name="Nell",
     )
 

--- a/tests/unit/brain/bridge/test_voice_reflection_evidence.py
+++ b/tests/unit/brain/bridge/test_voice_reflection_evidence.py
@@ -1,0 +1,60 @@
+"""#202: voice-reflection evidence carries content, not just ids; the tone placeholder is gone."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+from brain.bridge import supervisor
+from brain.memory.store import Memory, MemoryStore
+from brain.soul.crystallization import Crystallization
+from brain.soul.store import SoulStore
+
+
+def _cryst(id_: str, moment: str, *, days_ago: float) -> Crystallization:
+    return Crystallization(
+        id=id_,
+        moment=moment,
+        love_type="storge",
+        why_it_matters="it stayed",
+        crystallized_at=datetime.now(UTC) - timedelta(days=days_ago),
+    )
+
+
+def test_read_recent_crystallizations_carries_text_and_drops_stale(tmp_path: Path) -> None:
+    store = SoulStore(str(tmp_path / "crystallizations.db"))
+    try:
+        store.create(_cryst("c_new", "the kitchen light left on for me", days_ago=1))
+        store.create(_cryst("c_old", "an old thing", days_ago=30))
+    finally:
+        store.close()
+
+    out = supervisor._read_recent_crystallizations(tmp_path, days=7)
+
+    assert [c["id"] for c in out] == ["c_new"]
+    assert "kitchen light" in out[0]["text"]
+    assert "it stayed" in out[0]["text"]
+
+
+def test_read_recent_dreams_reads_dream_memories_with_text(tmp_path: Path) -> None:
+    store = MemoryStore(str(tmp_path / "memories.db"), integrity_check=False)
+    try:
+        fresh = Memory.create_new(
+            content="DREAM: the sailor kept the boat", memory_type="dream", domain="self"
+        )
+        store.create(fresh)
+        stale = Memory.create_new(content="DREAM: long ago", memory_type="dream", domain="self")
+        stale.created_at = datetime.now(UTC) - timedelta(days=30)
+        store.create(stale)
+        store.create(Memory.create_new(content="not a dream", memory_type="conversation", domain="us"))
+    finally:
+        store.close()
+
+    out = supervisor._read_recent_dreams(tmp_path, days=7)
+
+    assert [d["id"] for d in out] == [fresh.id]
+    assert "sailor kept the boat" in out[0]["text"]
+
+
+def test_message_tone_placeholder_is_retired() -> None:
+    assert not hasattr(supervisor, "_read_recent_message_tones")

--- a/tests/unit/brain/initiate/test_voice_reflection.py
+++ b/tests/unit/brain/initiate/test_voice_reflection.py
@@ -40,7 +40,6 @@ def test_voice_reflection_emits_candidate_when_evidence_strong(
         provider=_evidence_provider(emit=True),
         crystallizations=[{"id": "c1", "ts": "2026-05-08T00:00:00+00:00"}],
         dreams=[{"id": "d1", "ts": "2026-05-09T00:00:00+00:00"}],
-        recent_tones=[{"id": "t1", "ts": "2026-05-10T00:00:00+00:00"}],
     )
     candidates = read_candidates(persona_dir)
     assert len(candidates) == 1
@@ -59,7 +58,6 @@ def test_voice_reflection_skips_when_evidence_thin(tmp_path: Path) -> None:
         provider=_evidence_provider(emit=False),
         crystallizations=[],
         dreams=[],
-        recent_tones=[],
     )
     assert read_candidates(persona_dir) == []
 
@@ -87,7 +85,6 @@ def test_voice_reflection_requires_at_least_3_evidence_pieces(
         provider=provider,
         crystallizations=[],
         dreams=[],
-        recent_tones=[],
     )
     assert read_candidates(persona_dir) == []
 
@@ -108,10 +105,38 @@ def test_run_voice_reflection_tick_uses_companion_name_not_nell(tmp_path: Path) 
         provider=provider,
         crystallizations=[],
         dreams=[],
-        recent_tones=[],
         companion_name="Mira",
     )
 
     assert captured, "provider.complete was not called"
     assert "Mira" in captured[0]
     assert "Nell" not in captured[0]
+
+
+def test_voice_reflection_prompt_carries_evidence_text(tmp_path: Path) -> None:
+    """#202: the model must see what was crystallized / dreamed, not only ids and timestamps."""
+    persona_dir = tmp_path / "p"
+    persona_dir.mkdir()
+    provider = _evidence_provider(emit=False)
+    run_voice_reflection_tick(
+        persona_dir,
+        provider=provider,
+        crystallizations=[
+            {"id": "c1", "ts": "2026-09-01T00:00:00+00:00", "text": "the kitchen light left on"}
+        ],
+        dreams=[{"id": "d1", "ts": "2026-09-02T00:00:00+00:00", "text": "the sailor kept the boat"}],
+    )
+    prompt = provider.complete.call_args.args[0]
+    assert "the kitchen light left on" in prompt
+    assert "the sailor kept the boat" in prompt
+    assert "message tones" not in prompt.lower()
+
+
+def test_voice_reflection_no_longer_accepts_recent_tones(tmp_path: Path) -> None:
+    import pytest
+
+    with pytest.raises(TypeError):
+        run_voice_reflection_tick(
+            tmp_path, provider=_evidence_provider(emit=False),
+            crystallizations=[], dreams=[], recent_tones=[],
+        )


### PR DESCRIPTION
Decision on #202 (owner ruling 2026-09-11): **retire** the message-tone placeholder and **make the evidence real**. Wiring a per-turn Nell-tone stream was rejected: no source exists and the reflection could not ground on what it already received.

## What the live persona showed (why "zero voice.md edits" was not tuning)

- **26 of 26 logged voice-reflection runs since Jul 8 failed before the gate**: 23 `OAuth session expired` (the 09-06 → 09-10 outage, filed as #246), 1 session-limit 429, 2 empty replies. Not one parsed `should_propose`.
- **The evidence block carried no content.** Both readers returned `{id, ts}` and the prompt rendered exactly that, while asking for "at least 3 concrete observations".
- **Dreams were silently absent.** `_read_recent_dreams` looked for `at` / `ts`; `dreams.log.jsonl` writes `timestamp`. Three real dreams in the 7-day window read as zero. The log also holds no dream text at all.
- Crystallisations: 507 total, 0 in 7 days, 2 in 30 days. A quiet week should produce no edit; with this PR the zero is the correct zero.

## What changed

- `brain/bridge/supervisor.py`
  - `_read_recent_crystallizations` returns `{id, ts, text}` with `moment — why_it_matters` (160-char cap).
  - `_read_recent_dreams` reads `memory_type="dream"` rows from `memories.db` (content, real timestamps) instead of the id-only log.
  - `_read_recent_message_tones` deleted; the tick no longer passes `recent_tones`.
- `brain/initiate/voice_reflection.py`: `recent_tones` parameter removed; each evidence line renders `- <id> (<date>): <excerpt>`.
- `brain/prompt_strings.toml`: the tick prompt no longer mentions "how you've actually been talking" and asks the model to cite listed ids.

## Tests (written first, watched fail)
- `tests/unit/brain/bridge/test_voice_reflection_evidence.py` (new): crystallisation reader carries text and drops stale; dream reader reads the store, carries text, ignores non-dreams and stale; placeholder attribute is gone.
- `tests/unit/brain/initiate/test_voice_reflection.py`: +2 (prompt carries the excerpts and no tone block; `recent_tones` kwarg is a `TypeError`). Existing callers updated.

## Out of scope
- The auth outage that produced 23 of the 26 failures: #246.
- Option B (a per-turn tone tagger for Nell's own replies): recorded as a defer with a revisit trigger.

## Verification
- `uv run ruff check .` clean. `pnpm test` 351 passed. `pnpm build` clean.
- Full `uv run pytest -q -p no:randomly`: see the final comment on this PR.

Closes #202

🤖 Generated with [Claude Code](https://claude.com/claude-code)
