### PR TITLE
test(heartbeat): drop the removed recent_tones kwarg (#251)

### DIFF
--- a/tests/unit/brain/engines/test_heartbeat_auth_deferred.py
+++ b/tests/unit/brain/engines/test_heartbeat_auth_deferred.py
@@ -193,7 +193,7 @@ def test_voice_reflection_deferral_is_quiet(tmp_path: Path, caplog) -> None:
     from brain.initiate.voice_reflection import run_voice_reflection_tick
 
     with caplog.at_level(logging.INFO, logger="brain.initiate.voice_reflection"):
-        run_voice_reflection_tick(tmp_path, provider=_DeferringProvider(), crystallizations=[], dreams=[], recent_tones=[])
+        run_voice_reflection_tick(tmp_path, provider=_DeferringProvider(), crystallizations=[], dreams=[])
     assert [r for r in caplog.records if r.levelno >= logging.WARNING] == []
 
 


### PR DESCRIPTION
## Summary

Main went red after #247 and #249 merged: #247 removed the `recent_tones` parameter from `run_voice_reflection_tick`, while #249 (based on an older main) added `test_voice_reflection_deferral_is_quiet`, which still passed `recent_tones=[]`. Each PR was green on its own base; combined they raised `TypeError`.

This drops the stale keyword from that one call. Test-only; the production caller in `supervisor.py` already uses the current signature, and `test_voice_reflection_no_longer_accepts_recent_tones` (which deliberately passes the arg to assert rejection) is untouched.

Diagnosis by @ThinkerOfThoughts in #251, verified by reproducing the failure on `main` before the change.

Closes #251

## Verification

- `test_voice_reflection_deferral_is_quiet`: RED on `main` (`TypeError`), GREEN after.
- Full `uv run pytest` summary in the PR comment below.
- `ruff check .` clean; `pnpm test` 354 passed; `pnpm build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
